### PR TITLE
Fix typo in expressions example

### DIFF
--- a/src/expression/input.md
+++ b/src/expression/input.md
@@ -2,7 +2,7 @@ Several statements (like if-else) in Rust are actually expressions, i.e. they
 return a value. Since Rust is strongly typed, this means each branch of an
 expression must return the same type.
 
-Sometimes is desirable to ignore the output of an expression, this can be done
+Sometimes it's desirable to ignore the output of an expression, this can be done
 by terminating the expression with a semicolon `;`. Expressions terminated with
 a semicolon will return the unit type `()`. Empty if-else branches will also
 return this type.


### PR DESCRIPTION
Very small typo fix, literally a two character change.
