### PR TITLE
Replace "compulsory"

### DIFF
--- a/src/if-else/input.md
+++ b/src/if-else/input.md
@@ -1,4 +1,4 @@
 Branching with if-else is similar to C. But unlike C, the boolean condition
-doesn't need to be surrounded by parentheses and the braces are compulsory.
+doesn't need to be surrounded by parentheses and braces must be used.
 
 {if-else.rs}


### PR DESCRIPTION
I don't know about other non-native speakers, but I sometimes have
trouble remembering what "compulsory" means. "mandatory" is better, but
it can also be written in simpler words.
