### PR TITLE
Added a page for unsafe operations

### DIFF
--- a/src/unsafe/asm.rs
+++ b/src/unsafe/asm.rs
@@ -1,3 +1,5 @@
+#![feature(asm)]
+
 fn add(a: i32, b: i32) -> i32 {
     let sum: i32;
     unsafe {

--- a/src/unsafe/input.md
+++ b/src/unsafe/input.md
@@ -7,7 +7,7 @@ Unsafe blocks in Rust are used to bypass protections put in place by the compile
 * inline assembly
 
 ### Raw Pointers
-Raw pointers `*` and references `&T` function similarly, but references are always safe because they are guaranteed to point to valid data.  Dereferencing a raw pointer can only be done through an unsafe block.
+Raw pointers `*` and references `&T` function similarly, but references are always safe because they are guaranteed to point to valid data due to the borrow checker.  Dereferencing a raw pointer can only be done through an unsafe block.
 
 {pointer.rs}
 
@@ -18,5 +18,7 @@ Allows simple conversion from one type to another, however both types must have 
 
 ### Inline Assembly
 Inline assembly functions very similarly to the inline assembly of c, which makes sense considering its implementation is not handled by rust, rather by the LLVM.  It allows for direct access to assembly manipulation, which can massively increase speed, but it can also decrease portability and stability.  In most cases the compiler will optimize your rust code to better assembly than you could write, so in most instances it is not worth it.  The first parameter of asm!() is the format of the assembly, the parameter following the colon is the output variable, and the parameter(s) following that are the input variables.
+
+**Note**: `#![feature(asm)]` is currently required to use inline assembly.
 
 {asm.rs}

--- a/src/unsafe/pointer.rs
+++ b/src/unsafe/pointer.rs
@@ -1,5 +1,7 @@
-let raw_p: *u32 = &10;
+fn main() {
+    let raw_p: *u32 = &10;
 
-unsafe {
-    assert!(*raw_p == 10);
+    unsafe {
+        assert!(*raw_p == 10);
+    }
 }

--- a/src/unsafe/transmute.rs
+++ b/src/unsafe/transmute.rs
@@ -1,5 +1,7 @@
-let u: &[u8] = [49,50,51];
+fn main() {
+    let u: &[u8] = [49,50,51];
 
-unsafe {
-    assert!(u == std::cast::transmute("123"));
+    unsafe {
+        assert!(u == std::cast::transmute("123"));
+    }
 }


### PR DESCRIPTION
It is not the most in depth, but after looking at the other pages in the book it seems to match the coverage.  Plus, there is an official [rust tutorial](http://static.rust-lang.org/doc/0.10/guide-unsafe.html) for unsafe code which will suffice for a more in depth explanation, whereas this page serves as a quick reference and getting started point.
