### PR TITLE
match.rs: Formatting: Each branch on separate line

### DIFF
--- a/src/match/match.rs
+++ b/src/match/match.rs
@@ -34,6 +34,7 @@ fn main() {
             let y = x * x;
             let z = x * x * x;
             x + y + z
-        } x => x,
+        },
+        x => x,
     };
 }


### PR DESCRIPTION
Putting each branch on a new line and terminating each branch with a
comma is consistent with the other examples in this source file, and
less confusing. The comma isn't strictly necessary when the previous
branch ends with a "}" but it's more consistent.

I experimented with a more comprehensive check for code formatting
throughout this tutorial by running `rustc --pretty` in the makefile,
but `rustc --pretty` is a bit too idiosyncratic: It forces a newline
before each comment, it sometimes puts spaces before commas, and it adds
unnecessary quoting like "ain\'t".
