### PR TITLE
Remove stray apostrophe in tasks/input.md

### DIFF
--- a/src/tasks/input.md
+++ b/src/tasks/input.md
@@ -20,6 +20,6 @@ this is task number 9
 this is task number 7
 ```
 
-(By default, Rust uses it's *native* runtime, which maps each rust task to a
+(By default, Rust uses its *native* runtime, which maps each Rust task to a
 native thread. Rust also provides a *green* runtime that provides green threads
-and maps M Rust tasks to N native threads)
+and maps M Rust tasks to N native threads.)


### PR DESCRIPTION
This is a possessive "its", not an "it is", so taking out the apostrophe. Also capitalize "Rust".
