### PR TITLE
Format so it's better to see that this is an assignment

### DIFF
--- a/src/if-else/if-else-expr.rs
+++ b/src/if-else/if-else-expr.rs
@@ -1,15 +1,16 @@
 fn main() {
     let n = 5;
 
-    let big_n = if n < 10 {
-        println!("small number, increase ten-fold");
+    let big_n =
+        if n < 10 {
+            println!("small number, increase ten-fold");
 
-        10 * n
-    } else {
-        println!("big number, reduce by two");
+            10 * n
+        } else {
+            println!("big number, reduce by two");
 
-        n / 2
-    };
+            n / 2
+        };
 
     println!("{} -> {}", n, big_n);
 }


### PR DESCRIPTION
I don't know whether you are crazy about this, but if we format it like this i think it's easier to see that this is not just a normal if/else block but an assignment of the if/else-expression:

```
    let big_n =
        if n < 10 {
            println!("small number, increase ten-fold");

            10 * n
        } else {
            println!("big number, reduce by two");

            n / 2
        };
```

compared to

```
    let big_n = if n < 10 {
        println!("small number, increase ten-fold");

        10 * n
    } else {
        println!("big number, reduce by two");

        n / 2
    };
```
