### PR TITLE
iter: Remove trailing whitespace after link

### DIFF
--- a/src/iter/input.md
+++ b/src/iter/input.md
@@ -5,5 +5,5 @@ arrays) and lazy value generators.
 
 {iter.out}
 
-The `Iterator` trait gives access to [several methods
-](http://static.rust-lang.org/doc/master/std/iter/trait.Iterator.html).
+The `Iterator` trait gives access to
+[several methods](http://static.rust-lang.org/doc/master/std/iter/trait.Iterator.html).


### PR DESCRIPTION
There was a space after the link because the link text included a
newline before.
