### PR TITLE
match: Add clarifying print statement

### DIFF
--- a/examples/match/match.rs
+++ b/examples/match/match.rs
@@ -37,4 +37,6 @@ fn main() {
         },
         x => x,
     };
+
+    println!("{}", big_number)
 }


### PR DESCRIPTION
Opening in playpen gives an unused variable error and this may be confusing as an introduction to matching in Rust.
