### PR TITLE
'destroyed' is not a method of Pair

### DIFF
--- a/examples/methods/methods.rs
+++ b/examples/methods/methods.rs
@@ -102,6 +102,6 @@ fn main() {
     pair.destroy();
 
     // Error! Previous `destroy` call "consumed" `pair`
-    //pair.destroyed();
+    //pair.destroy();
     // TODO ^ Try uncommenting this line
 }


### PR DESCRIPTION
Fix a small typo
