### PR TITLE
Replace static.rust-lang.org with doc.rust-lang.org

### DIFF
--- a/examples/README.md
+++ b/examples/README.md
@@ -7,7 +7,7 @@ This book is a collection of bitesize examples that illustrate various rustic
 concepts and the Rust distribution libraries.
 
 Be sure to have rust [installed](http://www.rust-lang.org/install.html) and the
-[docs](http://static.rust-lang.org/doc/master/std/index.html) at hand, let's
+[docs](http://doc.rust-lang.org/std/) at hand, let's
 start!
 
 *Note*: This book will follow the nightly version of Rust until we reach

--- a/examples/file/create/input.md
+++ b/examples/file/create/input.md
@@ -23,5 +23,5 @@ proident, sunt in culpa qui officia deserunt mollit anim id est laborum.
 failure conditions)
 
 There is also a more generic
-[`open_mode`](http://static.rust-lang.org/doc/master/std/io/fs/struct.File.html#method.open_mode)
+[`open_mode`](http://doc.rust-lang.org/std/io/fs/struct.File.html#method.open_mode)
 method that can open files in other modes like: read+write, append, etc.

--- a/examples/fs/input.md
+++ b/examples/fs/input.md
@@ -1,4 +1,4 @@
-The [`std::io::fs`](http://static.rust-lang.org/doc/master/std/io/fs/index.html)
+The [`std::io::fs`](http://doc.rust-lang.org/std/io/fs/)
 module contains several functions that deal with the filesystem.
 
 {fs.play}

--- a/examples/hof/input.md
+++ b/examples/hof/input.md
@@ -4,7 +4,7 @@ give Rust its functional flavor.
 
 {hof.play}
 
-[Option](http://static.rust-lang.org/doc/master/core/option/type.Option.html)
+[Option](http://doc.rust-lang.org/core/option/type.Option.html)
 and
-[Iterator](http://static.rust-lang.org/doc/master/core/iter/trait.Iterator.html)
+[Iterator](http://doc.rust-lang.org/core/iter/trait.Iterator.html)
 implement their fair share of HOFs.

--- a/examples/iter/input.md
+++ b/examples/iter/input.md
@@ -4,4 +4,4 @@ arrays) and lazy value generators.
 {iter.play}
 
 The `Iterator` trait gives access to
-[several methods](http://static.rust-lang.org/doc/master/core/iter/trait.Iterator.html).
+[several methods](http://doc.rust-lang.org/core/iter/trait.Iterator.html).

--- a/examples/ops/input.md
+++ b/examples/ops/input.md
@@ -5,5 +5,5 @@ any implementor of the `Add` trait will be able to use the `+` operator.
 
 {operator.play}
 
-Here is a [list](http://static.rust-lang.org/doc/master/core/ops/index.html) of
+Here is a [list](http://doc.rust-lang.org/core/ops/) of
 the traits that overload operators.

--- a/examples/path/input.md
+++ b/examples/path/input.md
@@ -14,8 +14,8 @@ instead is stored as a vector of bytes (`Vec<u8>`). Therefore, converting a
 {path.play}
 
 Be sure to check at other `Path` methods
-([`posix::Path`](http://static.rust-lang.org/doc/master/std/path/posix/struct.Path.html)
-or [`windows::Path`](http://static.rust-lang.org/doc/master/std/path/windows/struct.Path.html))
+([`posix::Path`](http://doc.rust-lang.org/std/path/posix/struct.Path.html)
+or [`windows::Path`](http://doc.rust-lang.org/std/path/windows/struct.Path.html))
 and the
-[`FileStat`](http://static.rust-lang.org/doc/master/std/io/struct.FileStat.html)
+[`FileStat`](http://doc.rust-lang.org/std/io/struct.FileStat.html)
 struct.

--- a/examples/print/input.md
+++ b/examples/print/input.md
@@ -5,4 +5,4 @@ be checked at compile time.
 {print.play}
 
 For more information about formatting, take a look at
-[std::fmt](http://static.rust-lang.org/doc/master/std/fmt/index.html).
+[std::fmt](http://doc.rust-lang.org/std/fmt/).

--- a/examples/result/try/input.md
+++ b/examples/result/try/input.md
@@ -5,5 +5,5 @@ the `Ok(ok)` branch expands to an `ok` expression.
 
 {try.play}
 
-Be sure to check the [documentation](http://static.rust-lang.org/doc/master/std/result/type.Result.html),
+Be sure to check the [documentation](http://doc.rust-lang.org/std/result/type.Result.html),
 as there are many methods to map/compose `Result`.

--- a/examples/staging/unsafe/input.md
+++ b/examples/staging/unsafe/input.md
@@ -1,5 +1,5 @@
 As an introduction to this section, to borrow from [the official docs](
-http://static.rust-lang.org/doc/0.10/guide-unsafe.html), "one should try to
+http://doc.rust-lang.org/0.10/guide-unsafe.html), "one should try to
 minimize the amount of unsafe code in a code base."  With that in mind, let's
 get started!
 Unsafe blocks in Rust are used to bypass protections put in place by the

--- a/examples/str/input.md
+++ b/examples/str/input.md
@@ -10,6 +10,6 @@ can be used to view into a `String`, just like `&[T]` is a view into `Vec<T>`.
 {str.play}
 
 More `str`/`String` methods can be found under the
-[std::str](http://static.rust-lang.org/doc/master/std/str/index.html) and
-[std::string](http://static.rust-lang.org/doc/master/std/string/index.html)
+[std::str](http://doc.rust-lang.org/std/str/) and
+[std::string](http://doc.rust-lang.org/std/string/)
 modules

--- a/examples/trait/deriving/input.md
+++ b/examples/trait/deriving/input.md
@@ -6,24 +6,24 @@ manually implemented if a more complex behavior is required.
 
 This is a list of the "derivable" traits:
 * Comparison traits:
-  [`Eq`](http://static.rust-lang.org/doc/master/std/cmp/trait.Eq.html),
-  [`PartialEq`](http://static.rust-lang.org/doc/master/std/cmp/trait.PartialEq.html),
-  [`Ord`](http://static.rust-lang.org/doc/master/std/cmp/trait.Ord.html),
-  [`PartialOrd`](http://static.rust-lang.org/doc/master/std/cmp/trait.PartialOrd.html)
+  [`Eq`](http://doc.rust-lang.org/std/cmp/trait.Eq.html),
+  [`PartialEq`](http://doc.rust-lang.org/std/cmp/trait.PartialEq.html),
+  [`Ord`](http://doc.rust-lang.org/std/cmp/trait.Ord.html),
+  [`PartialOrd`](http://doc.rust-lang.org/std/cmp/trait.PartialOrd.html)
 * Serialization:
-  [`Encodable`](http://static.rust-lang.org/doc/master/serialize/trait.Encodable.html),
-  [`Decodable`](http://static.rust-lang.org/doc/master/serialize/trait.Decodable.html)
-* [`Clone`](http://static.rust-lang.org/doc/master/std/clone/trait.Clone.html),
+  [`Encodable`](http://doc.rust-lang.org/serialize/trait.Encodable.html),
+  [`Decodable`](http://doc.rust-lang.org/serialize/trait.Decodable.html)
+* [`Clone`](http://doc.rust-lang.org/std/clone/trait.Clone.html),
   to create `T` from `&T` via a copy.
-* [`Hash`](http://static.rust-lang.org/doc/master/std/hash/trait.Hash.html), to
+* [`Hash`](http://doc.rust-lang.org/std/hash/trait.Hash.html), to
   compute a hash from `&T`.
-* [`Rand`](http://static.rust-lang.org/doc/master/rand/trait.Rand.html), to
+* [`Rand`](http://doc.rust-lang.org/rand/trait.Rand.html), to
   create a random instance of a data type.
-* [`Default`](http://static.rust-lang.org/doc/master/std/default/trait.Default.html),
+* [`Default`](http://doc.rust-lang.org/std/default/trait.Default.html),
   to create an empty instance of a data type.
-* [`Zero`](http://static.rust-lang.org/doc/master/std/num/trait.Zero.html), to
+* [`Zero`](http://doc.rust-lang.org/std/num/trait.Zero.html), to
   create a zero instance of a numeric data type.
-* [`FromPrimitive`](http://static.rust-lang.org/doc/master/std/num/trait.FromPrimitive.html),
+* [`FromPrimitive`](http://doc.rust-lang.org/std/num/trait.FromPrimitive.html),
   to create an instance from a numeric primitive.
-* [`Show`](http://static.rust-lang.org/doc/master/std/fmt/trait.Show.html), to
+* [`Show`](http://doc.rust-lang.org/std/fmt/trait.Show.html), to
   format a value using the `{}` formatter.

--- a/examples/type/alias/input.md
+++ b/examples/type/alias/input.md
@@ -5,5 +5,5 @@ exception to this rule are the primitive types: `uint`, `f32`, etc.
 {alias.play}
 
 The main use of aliases is to reduce typing, for example the
-[`IoResult<T>`](http://static.rust-lang.org/doc/master/std/io/type.IoResult.html)
+[`IoResult<T>`](http://doc.rust-lang.org/std/io/type.IoResult.html)
 type is an alias for the `Result<T, IoError>` type.

--- a/examples/vec/input.md
+++ b/examples/vec/input.md
@@ -8,4 +8,4 @@ be surpassed, the vector gets reallocated with a bigger capacity.
 {vec.play}
 
 More `Vec` methods can be found under the
-[std::vec](http://static.rust-lang.org/doc/master/std/vec/index.html) module
+[std::vec](http://doc.rust-lang.org/std/vec/) module


### PR DESCRIPTION
Rust is apparently trying to phase out `static.rust-lang.org` and replace it with `doc.rust-lang.org`.  This fixes all the links to `static.rust-lang.org` except for the `.travis.yml` file.

See https://github.com/rust-lang/rust/issues/14851 for more info.
