### PR TITLE
Struct field visibility: Fix the variable name in the commented out line.

### DIFF
--- a/examples/structs/visibility/struct.rs
+++ b/examples/structs/visibility/struct.rs
@@ -38,6 +38,6 @@ fn main() {
 
     // The private fields of a struct can't be accessed
     // Error! The `contents` field is private
-    //println!("The black box contains: {}", black_box.contents);
+    //println!("The black box contains: {}", _black_box.contents);
     // TODO ^ Try uncommenting this line
 }


### PR DESCRIPTION
It's just a minor typo (but that's so easy to send a pull request).
