### PR TITLE
Reword to emphasize borrow isn't permanent

### DIFF
--- a/examples/borrow/alias/alias.rs
+++ b/examples/borrow/alias/alias.rs
@@ -11,8 +11,8 @@ fn main() {
         println!("Point has coordinates: ({}, {}, {})",
                  borrowed_point.x, another_borrow.y, point.z);
 
-        // Error! Can't borrow point as mutable because it's also borrowed as
-        // immutable
+        // Error! Can't borrow point as mutable because it's currently
+        // borrowed as immutable
         //let mutable_borrow = &mut point;
         // TODO ^ Try uncommenting this line
 
@@ -25,8 +25,8 @@ fn main() {
         // Change data via mutable reference
         mutable_borrow.x = 5;
 
-        // Error! Can't borrow `point` as immutable because it's also borrowed
-        // as mutable
+        // Error! Can't borrow `point` as immutable because it's currently
+        // borrowed as mutable
         //let y = &point.y;
         // TODO ^ Try uncommenting this line
 

--- a/examples/borrow/alias/input.md
+++ b/examples/borrow/alias/input.md
@@ -1,6 +1,6 @@
-Data can be immutably borrowed any number of times, but once immutably
-borrowed, the original data can't be mutably borrowed. On the other side, data
-can be mutably borrowed *once*, and until the mutable reference goes out of
-scope, the original data can't be borrowed again.
+Data can be immutably borrowed any number of times, but while immutably
+borrowed, the original data can't be mutably borrowed. On the other side,
+only *one* mutable borrow is allowed at a time. The original data can be
+borrowed again after the mutable reference goes out of scope.
 
 {alias.play}


### PR DESCRIPTION
I thought it's wording suggested that after a single mutable borrow, an immutable borrow will never be allowed again.  I tried to reword it to emphasize that the borrow is only disallowed _while_ the borrow is still active.

The end sentence was inverted (can be vs. can't be) to emphasize that another borrow _will_ be allowed but will require a condition.
