### PR TITLE
print: append type suffix to integer literals

### DIFF
--- a/examples/print/print.rs
+++ b/examples/print/print.rs
@@ -3,7 +3,7 @@ fn main() {
     print!("January has ");
 
     // `{}` are placeholders for arguments that will be stringified
-    println!("{} days", 31);
+    println!("{} days", 31i);
 
     // The positional arguments can be reused along the template
     println!("{0}, this is {1}. {1}, this is {0}", "Alice", "Bob");
@@ -15,7 +15,7 @@ fn main() {
              verb="jumps");
 
     // Special formatting can be specified in the placeholder after a `:`
-    println!("{} of {:t} people know binary, the other half don't", 1, 2);
+    println!("{} of {:t} people know binary, the other half don't", 1i, 2i);
 
     // Error! You are missing an argument
     println!("My name is {0}, {1} {0}", "Bond");


### PR DESCRIPTION
format_args! is unable to determine the type of the integer literal without a suffix to specify the type explicitly. This fixes issue #138.
