### PR TITLE
fix for lifetime/borrow: ambiguous type error

### DIFF
--- a/examples/lifetime/borrow/borrow.rs
+++ b/examples/lifetime/borrow/borrow.rs
@@ -1,7 +1,7 @@
 // FIXME To see the "real" compiler error, change both `&'b` and `&'e` into `&`
 
 fn main() { // `'main` starts ────────────────────────────────────────────┐
-    let stack_integer = 5; // `'a` starts ──────────────────────────────┐ │
+    let stack_integer: int = 5; // `'a` starts ─────────────────────────┐ │
     let boxed_integer = box 4; // `'b` starts ────────────────────────┐ │ │
     //                                                                │ │ │
     // This is a valid operation                                      │ │ │


### PR DESCRIPTION
Close #148
- Added the explicit type declaration for `stack_integer`
- re-aligned lifetime lines for readability
- Tested successfully on the live site to verify that it works
