### PR TITLE
Fix `make book` on Mac

### DIFF
--- a/fix-edit-button.sh
+++ b/fix-edit-button.sh
@@ -5,6 +5,10 @@ for example in $(find examples -type d -name "*"); do
   if [[ -f ${html} ]]; then
     echo ${html}
 
-    sed -i s:${example#examples/}.md:${example}/input.md: ${html}
+    if [[ `uname` == "Darwin" ]]; then
+      sed -i '' s:${example#examples/}.md:${example}/input.md: ${html}
+    else
+      sed -i s:${example#examples/}.md:${example}/input.md: ${html}
+    fi
   fi
 done


### PR DESCRIPTION
The BSD version of sed included on Mac OSX has very primitive argument parsing. When running `make book`, `fix-edit-button.sh`'s sed call fails because the `-i` flag tries to associate with the sed script. My fix checks if `--version` succeeds to decide if it should use the BSD or GNU syntax.
