### PR TITLE
The "crate_id" attribute is deprecated

### DIFF
--- a/examples/attribute/crate/lib.rs
+++ b/examples/attribute/crate/lib.rs
@@ -1,7 +1,7 @@
 // This crate is a library
 #![crate_type = "lib"]
-// The library is named "erty", and its version is 0.1
-#![crate_id = "erty#0.1"]
+// The library is named "erty"
+#![crate_name = "erty"]
 
 pub fn public_function() {
     println!("called erty's `public_function()`");


### PR DESCRIPTION
"crate_id" has been deprecated in favor of "crate_name".  Not sure if there is an attribute for specifying the version of the crate though.
