### PR TITLE
Fix method name: read_to_str -> read_to_string

### DIFF
--- a/examples/file/open/open.rs
+++ b/examples/file/open/open.rs
@@ -13,7 +13,7 @@ fn main() {
     };
 
     // Read the file contents into a string, returns `IoResult<String>`
-    match file.read_to_str() {
+    match file.read_to_string() {
         Err(why) => fail!("couldn't read {}: {}", display, why.desc),
         Ok(string) => print!("{} contains:\n{}", display, string),
     }

--- a/examples/fs/fs.rs
+++ b/examples/fs/fs.rs
@@ -3,7 +3,7 @@ use std::io::{File,IoResult,UserRWX};
 
 // A simple implementation of `$ cat path`
 fn cat(path: &Path) -> IoResult<String> {
-    File::open(path).and_then(|mut f| f.read_to_str())
+    File::open(path).and_then(|mut f| f.read_to_string())
 }
 
 // A simple implementation of `$ echo s > path`

--- a/examples/process/pipe/pipe.rs
+++ b/examples/process/pipe/pipe.rs
@@ -30,7 +30,7 @@ fn main() {
     // The `stdout` field also has type `Option<PipeStream>`
     // the `get_mut_ref` method will return a mutable reference to the value
     // wrapped in a `Some` variant
-    match process.stdout.get_mut_ref().read_to_str() {
+    match process.stdout.get_mut_ref().read_to_string() {
         Err(why) => fail!("couldn't read wc stdout: {}", why.desc),
         Ok(string) => print!("wc responded with:\n{}", string),
     }

--- a/examples/sockets/server.rs
+++ b/examples/sockets/server.rs
@@ -23,6 +23,6 @@ fn main() {
 
     // Iterate over clients, blocks if no client available
     for mut client in stream.listen().incoming() {
-        println!("Client said: {}", client.read_to_str().unwrap());
+        println!("Client said: {}", client.read_to_string().unwrap());
     }
 }


### PR DESCRIPTION
In one of the recent nightlies, `read_to_str` was renamed to
`read_to_string`. The PR fixes the spots where I noticed the old
usage.
