### PR TITLE
fix method name: read_to_str should be read_to_string

### DIFF
--- a/src/file.rs
+++ b/src/file.rs
@@ -14,7 +14,7 @@ pub fn mkdir(path: &Path)  {
 pub fn read(path: &Path) -> Result<String, String> {
     match File::open(path) {
         Err(_) => Err(format!("couldn't open {}", path.display())),
-        Ok(mut file) => match file.read_to_str() {
+        Ok(mut file) => match file.read_to_string() {
             Err(_) => Err(format!("couldn't read {}", path.display())),
             Ok(string) => Ok(string),
         }


### PR DESCRIPTION
issue #165 fixes some of these, but missed one in `src/file.rs`.
