### PR TITLE
JSON: Encoder::str_encode replaced by json::encode

### DIFF
--- a/examples/staging/json/encodable/encodable.rs
+++ b/examples/staging/json/encodable/encodable.rs
@@ -17,7 +17,7 @@ fn main() {
         City { name: "Lima",      lat: -12.043333, lon: -77.028333 },
         City { name: "Santiago",  lat: -33.45,     lon: -70.666667 },
     ].iter() {
-        // `str_encode` encodes an `Encodable` implementor into a `String`
-        println!("{}", json::Encoder::str_encode(city));
+        // `encode` encodes an `Encodable` implementor into a `String`
+        println!("{}", json::encode(city));
     }
 }

--- a/examples/staging/json/encodable/input.md
+++ b/examples/staging/json/encodable/input.md
@@ -1,8 +1,7 @@
 `serialize::Encodable` is a trait implemented for types to make them encodable
 by the `serialize` module.
 
-`Encodable` types can be serialized into JSON using
-`json::Encoder::str_encode`.
+`Encodable` types can be serialized into JSON using `json::encode`.
 
 Just like `Decodable`, `Encodable` can be automatically derived for a struct
 using `#[deriving(Encodable)]`.


### PR DESCRIPTION
`Encoder::str_encode` is deprecated in favor of `encode`.
