### PR TITLE
raii: add link to wikipedia for raii

### DIFF
--- a/examples/raii/input.md
+++ b/examples/raii/input.md
@@ -1,6 +1,6 @@
 Variables in Rust do more than just hold data in the stack, they can also *own*
 resources, e.g. `Box<T>` owns memory in the heap. Because Rust enforces the
-RAII discipline, whenever an object goes out of scope, its destructor is called
+[RAII](http://en.wikipedia.org/wiki/Resource_Acquisition_Is_Initialization) discipline, whenever an object goes out of scope, its destructor is called
 and the resources *owned* by it are freed. This behavior shields against
 *resource leak* bugs.
 


### PR DESCRIPTION
I had to lookup what RAII was, so I thought maybe a wikipedia link might be helpful for people who had no idea what it stood for.
