### PR TITLE
crates/lib, attributes/crate - generated name change

### DIFF
--- a/examples/attribute/crate/input.md
+++ b/examples/attribute/crate/input.md
@@ -10,5 +10,5 @@ When the `crate_type` attribute is used, we no longer need to pass the
 ```
 $ rustc lib.rs
 $ ls lib*
-liberty-a1e7dc98-0.1.rlib
+liberty.rlib
 ```

--- a/examples/crates/lib/input.md
+++ b/examples/crates/lib/input.md
@@ -5,9 +5,7 @@ Let's create a library, and then see how to link it to another crate.
 ```
 $ rustc --crate-type=lib erty.rs
 $ ls lib*
-liberty-e6eaab2e-0.0.rlib
+liberty.rlib
 ```
 
-Libraries get prefixed with "lib", and contain a hash and their version in
-their name. The version and name of the library can be changed using
-[attributes](/attribute/crate.html).
+Libraries get prefixed with "lib".


### PR DESCRIPTION
rustc no longer generates a hash and a version for a library
