### PR TITLE
Add example of initializing an array without literal

### DIFF
--- a/examples/array/array.rs
+++ b/examples/array/array.rs
@@ -9,6 +9,9 @@ fn analyze_slice(slice: &[int]) {
 fn main() {
     // Fixed-size array (type signature is superfluous)
     let xs: [int, ..5] = [1, 2, 3, 4, 5];
+    
+    // All elements can be initialized to the same value
+    let ys: [int, ..500] = [0, ..500];
 
     // Indexing starts at 0
     println!("first element of the array: {}", xs[0]);
@@ -26,7 +29,7 @@ fn main() {
 
     // Slices can point to a section of an array
     println!("borrow a section of the array as a slice");
-    analyze_slice(xs.slice(1, 4));
+    analyze_slice(ys.slice(1, 4));
 
     // Out of bound indexing yields a task failure
     println!("{}", xs[5]);


### PR DESCRIPTION
There was no example on how to initialize an array except for using a literal. For large arrays, initialization using a literal is not really an option.

I found the array syntax on the site, but this was the piece of information that I missed. I think it might be useful for other people as well.
