### PR TITLE
hello: usage go into the text from the comments.

### DIFF
--- a/examples/hello/hello.rs
+++ b/examples/hello/hello.rs
@@ -1,14 +1,13 @@
 // This is a comment, and will be ignored by the compiler
-// You can test this code by clicking the "Run" button over there ->
-// or if prefer to use your keyboard, you can use the "Ctrl + Enter" shortcut
 
-// This code is editable, feel free to hack it!
-// You can always return to the original code by clicking the "Reset" button ->
+/*
+ There are also block style comments
+ /* which can be nested */
+*/
 
-// This is the main function
+/// This is the main function (three slashes are for `rustdoc`)
 fn main() {
     // The statements here will be executed when the compiled binary is called
 
-    // Print text to the console
-    println!("Hello World!");
+    println!("Hello World!"); // Print text to the console
 }

--- a/examples/hello/input.md
+++ b/examples/hello/input.md
@@ -1,5 +1,13 @@
 This is the source code of the traditional Hello World program.
 
+You can test this code by clicking the "Run" button on the top right corner.
+
+Or if prefer to use your keyboard, you can use the "Ctrl + Enter" shortcut.
+
+The code is also editable.  Feel free to hack it!
+
+You can always return to the original code by clicking the "Reset" button.
+
 {hello.play}
 
 `println!` is a *macro* (we'll cover them later) that prints text to the


### PR DESCRIPTION
This may be a matter of preference, but I think the usage of the playground codes should be in the main text because it's too important to overlook.

Also attempts to resolve the issue #107