### PR TITLE
if-else: remark on a semicolon after a long if-else.

### DIFF
--- a/examples/if-else/if-else.rs
+++ b/examples/if-else/if-else.rs
@@ -21,7 +21,7 @@ fn main() {
             // This expression must return an `int` as well
             n / 2
             // TODO ^ Try suppressing this expression with a semicolon
-        };
+        }; // don't forget to put a semicolon here;  `let` requires it
 
     println!("{} -> {}", n, big_n);
 }


### PR DESCRIPTION
When I use `if-else` in the rhs of `let`, I tend to forget to terminate the sentence with `;`...  Only me?
