### PR TITLE
fn: show the order of fn definitions doesn't matter.

### DIFF
--- a/examples/fn/fn.rs
+++ b/examples/fn/fn.rs
@@ -1,3 +1,8 @@
+// Unlike C/C++, no restriction on the order of definitions
+fn main() {
+    fizzbuzz_to(100);
+}
+
 // Function that returns a boolean value
 fn is_divisible_by(lhs: uint, rhs: uint) -> bool {
     // Corner case, early return
@@ -28,8 +33,4 @@ fn fizzbuzz_to(n: uint) {
     for n in range(1, n + 1) {
         fizzbuzz(n);
     }
-}
-
-fn main() {
-    fizzbuzz_to(100);
 }


### PR DESCRIPTION
This is a minor but important advantage of Rust over C/C++ from which many programmers may come.

``` c
int main() { return foo(); } // undefined function foo()!!
int foo(void) { return 0; }
```
