### PR TITLE
Obsolete use syntax is fixed

### DIFF
--- a/examples/mod/use/use.rs
+++ b/examples/mod/use/use.rs
@@ -1,5 +1,5 @@
 // Bind the `deeply::nested::function` path to `other_function`
-use other_function = deeply::nested::function;
+use deeply::nested::function as other_function;
 
 fn function() {
     println!("called `function()`");


### PR DESCRIPTION
"error: obsolete syntax: `use foo = bar` syntax" is fixed
