### PR TITLE
Removed unnecessary "if" in is_odd() definition.

### DIFF
--- a/examples/hof/hof.rs
+++ b/examples/hof/hof.rs
@@ -42,9 +42,5 @@ fn main() {
 }
 
 fn is_odd(n: uint) -> bool {
-    if n % 2 == 1 {
-        true
-    } else {
-        false
-    }
+    n % 2 == 1
 }


### PR DESCRIPTION
Removed unnecessary "if" in is_odd() definition in Higher Order Functions example.
