### PR TITLE
hof: remove extern

### DIFF
--- a/examples/hof/hof.rs
+++ b/examples/hof/hof.rs
@@ -1,5 +1,3 @@
-extern crate num;
-
 // The `AdditiveIterator` trait adds the `sum` method to iterators
 use std::iter::AdditiveIterator;
 use std::iter;


### PR DESCRIPTION
Crate ‘num’ is not required to compile but breaks ‘Run’ on
website
