### PR TITLE
Fix example for vectors.

### DIFF
--- a/examples/vec/vec.rs
+++ b/examples/vec/vec.rs
@@ -19,12 +19,12 @@ fn main() {
     // The `len` method yields the current size of the vector
     println!("Vector size: {}", xs.len());
 
-    // Indexing is done using the `get` method (indexing starts at 0)
-    println!("Second element: {}", xs.get(1));
+    // Indexing is done using the square brackets (indexing starts at 0)
+    println!("Second element: {}", xs[1]);
 
     // `pop` removes the last element from the vector and returns it
     println!("Pop last element: {}", xs.pop());
 
     // Out of bounds indexing yields a task failure
-    println!("Fourth element: {}", xs.get(3));
+    println!("Fourth element: {}", xs[3]);
 }


### PR DESCRIPTION
No more Vec::get() method in rust.
