### PR TITLE
Fixed redundancies in struct patterns

### DIFF
--- a/examples/generics/generics.rs
+++ b/examples/generics/generics.rs
@@ -6,7 +6,7 @@ struct Pair<T> {
 
 // A generic function
 fn swap<T>(pair: Pair<T>) -> Pair<T> {
-    let Pair { first: first, second: second } = pair;
+    let Pair { first, second } = pair;
 
     Pair { first: second, second: first }
 }

--- a/src/file.rs
+++ b/src/file.rs
@@ -42,7 +42,7 @@ pub fn run(prefix: &str, id: &str, src: &str) -> Result<String, String> {
 
     match Command::new(&executable).output() {
         Err(_) => Err(format!("couldn't find {}", executable.display())),
-        Ok(ProcessOutput { error: error, output: output, status: status }) => {
+        Ok(ProcessOutput { error, output, status }) => {
             let mut s = String::from_utf8(output).unwrap();
             if !status.success() {
                 s.push_str(String::from_utf8(error).unwrap().as_slice());


### PR DESCRIPTION
If merged with other pull request, this will fix `make` and `make test`. Sorry for not putting them into one, I can do that if necessary.
