### PR TITLE
Fix dead_code warnings

### DIFF
--- a/examples/enum/c-like/c-like.rs
+++ b/examples/enum/c-like/c-like.rs
@@ -1,4 +1,5 @@
 // enum with implicit discriminator (starts at 0)
+#[allow(dead_code)]
 enum Day {
     Monday,
     Tuesday,
@@ -20,6 +21,7 @@ impl Day {
 }
 
 // enum with explicit discriminator
+#[allow(dead_code)]
 enum Color {
     Red = 0xff0000,
     Green = 0x00ff00,


### PR DESCRIPTION
Simple fix to remove the dead_code warning when running the enum c-like example:
http://rustbyexample.com/enum/c-like.html
