### PR TITLE
staging/hashmap: Fix outdated info

### DIFF
--- a/examples/staging/hash/alt-key-types/input.md
+++ b/examples/staging/hash/alt-key-types/input.md
@@ -3,33 +3,30 @@ This includes:
 
 * `bool` (though not very useful since there is only two possible keys)
 * `int`, `uint`, and all variations thereof 
-(see `SmallIntMap` for a more streamlined map implementation keyed by `uint`)
+(see [`VecMap`][vecmap] for a more streamlined map implementation keyed by `uint`)
+* `String` and `&str` (protip: you can have a `HashMap` keyed by `String` 
+and call `.get()` with an `&str`)
 
 Note that `f32` and `f64` do *not* implement `Hash`, 
-likely because floating-point precision errors 
-would make using them as hash map keys very frustrating.
+likely because [floating-point precision errors][floating]
+would make using them as hashmap keys horribly error-prone.
 
-All collection classes implement `Eq`, and implicitly implement `Hash` 
-if their contained type also implements `Hash`. 
-E.g. `Vec<T>` will implement `Hash` if `T` implements `Hash`.
+All collection classes implement `Eq` and `Hash` 
+if their contained type also respectively implements `Eq` and `Hash`. 
+For example, `Vec<T>` will implement `Hash` if `T` implements `Hash`.
 
 You can easily implement `Eq` and `Hash` for a custom type with just one line: 
-`#[deriving(Eq,Hash)]`
+`#[deriving(PartialEq, Eq, Hash)]`
 
 The compiler will do the rest. If you want more control over the details, 
-you can implement `Eq` and `Hash` yourself. 
+you can implement `Eq` and/or `Hash` yourself. 
 This guide will not cover the specifics of implementing `Hash`. 
-
-Note that two instances of a type that are equal 
-(such that `a == b` returns `true`) should hash to the same value, 
-but two instances with the same hash don't necessarily have to be equal. 
-Read up on [hashes][hash] and [hash collisions][collision] 
-for more information.
 
 To play around with using a `struct` in `HashMap`, 
 let's try making a very simple user logon system:
 
 {alt-key-types.play}
 
+[vecmap]: http://doc.rust-lang.org/std/collections/struct.VecMap.html
 [hash]: http://en.wikipedia.org/wiki/Hash_function
-[collision]: http://en.wikipedia.org/wiki/Hash_collision
+[floating]: http://en.wikipedia.org/wiki/Floating_point#Accuracy_problems

--- a/examples/staging/hash/hashset/input.md
+++ b/examples/staging/hash/hashset/input.md
@@ -1,12 +1,12 @@
-Consider a `HashSet` as a `HashMap` where the key and value are the same. 
-Or, to be more precise, a `HashMap` where we just care about the keys.
+Consider a `HashSet` as a `HashMap` where we just care about the keys (
+`HashSet<T>` is, in actuality, just a wrapper around `HashMap<T, ()>`).
 
 "What's the point of that?" you ask. "I could just store the keys in a `Vec`."
 
 A `HashSet`'s unique feature is that 
 it is guaranteed to not have duplicate elements. 
-That's the contract that any [`Set`][set] implementation fulfills. 
-`HashSet` is just one implementation. (see also: [`MutableSet`][mutableset])
+That's the contract that any set collection fulfills. 
+`HashSet` is just one implementation. (see also: [`TreeSet`][treeset])
 
 If you insert a value that is already present in the `HashSet`, 
 (i.e. the new value is equal to the existing and they both have the same hash), 
@@ -16,12 +16,10 @@ This is great for when you never want more than one of something,
 or when you want to know if you've already got something.
 
 But sets can do more than that. 
-If they weren't important, then why would there be a 
-[branch of mathematics][set-theory] dedicated to them? 
 
 Sets have 4 primary operations (all of the following calls return an iterator):
 
-* `union`: get all the elements in one set or the other.
+* `union`: get all the unique elements in both sets.
 
 * `difference`: get all the elements that are in the first set but not the second.
 
@@ -34,11 +32,7 @@ Try all of these in the following example.
 
 {hashset.play}
 
-Sets don't seem so pointless now, do they? 
-
 (Examples adapted from the [documentation.][hash-set])
 
-[set]: http://doc.rust-lang.org/std/collections/trait.Set.html
-[mutableset]: http://doc.rust-lang.org/std/collections/trait.MutableSet.html
-[set-theory]: http://en.wikipedia.org/wiki/Set_theory
+[treeset]: http://doc.rust-lang.org/std/collections/struct.TreeSet.html
 [hash-set]: http://doc.rust-lang.org/std/collections/hashmap/struct.HashSet.html#method.difference


### PR DESCRIPTION
Cut out a lot of BS in the markdown to push the examples and functionality. Also fixed a bunch of outdated information.

I thought about changing `alt-key-types.rs` to demonstrate that you can index a `HashMap<String, _>` with `&str` but I didn't want to get rid of the current example which, though contrived, does demonstrate how to have a `HashMap` keyed by a custom type.
