### PR TITLE
Deploy to GH pages

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -13,5 +13,9 @@ script:
   - make
   - make test
 
+after_success: bash deploy.sh
+
 branches:
   only: master
+
+secure: "oFD/tic8JAwpMXuMDBZXV4ot6w1NLWvHQTrDKmUHSMQJC1cbbrR1p5q8XayfjtmdqQdFQmIfM6YHEKeHw//ypgObWjYS8q00OaaMDXPTdmgr1Ee4nhgkkDihT+kVij0rn96W/QvyAVoaV5hJoyUr3Nhk+mnHEYm3M+Q3LAQglRg="

--- a/deploy.sh
+++ b/deploy.sh
@@ -1,0 +1,21 @@
+#!/bin/bash
+
+repo="https://$GH_TOKEN@github.com/japaric/rust-by-example.git"
+
+git config user.name "Steve Klabnik"
+git config user.email "steve@steveklabnik.com"
+
+rev=$(git rev-parse --short HEAD)
+
+cd stage/_book
+
+git init -q
+git remote add up ../../.git
+git fetch -q up && git reset -q --hard up/gh-pages
+
+touch .
+
+git add .
+
+git commit -m "rebuild pages at ${rev}"
+git push -q o HEAD:gh-pages


### PR DESCRIPTION
This is a deploy script to automatically deploy to github pages after a successful build.

The secret is using an oauth token of mine, which should work just fine, but we can use someone else's if you'd like, @brson. It'd just involve changing the `secure:` line.

There's some `git` stuff here that might not be familliar to newer `git` users, I can explain in detail if needed.
