### PR TITLE
Fix `make serve` try 2

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,7 +19,10 @@ make book GITBOOK=`pwd`/node_modules/.bin/gitbook
 make test GITBOOK=`pwd`/node_modules/.bin/gitbook
 ```
 
-View the results with `make serve GITBOOK=`pwd`/node_modules/.bin/gitbook`.
+View the results with:
+```
+make serve GITBOOK=`pwd`/node_modules/.bin/gitbook
+```
 
 Note: on Ubuntu `node` may be called `nodejs`. I had to edit `.bin/gitbook` accordingly.
 


### PR DESCRIPTION
`make serve GITBOOK=`pwd`/node_modules/.bin/gitbook` on the readme now splits around _pwd_ in markdown and it shouldn't (as shown above).  Wrap it in code demarkation to fix it.
