### PR TITLE
Changing `mkdir` to `mkdir -p` in setup-stage.sh

### DIFF
--- a/setup-stage.sh
+++ b/setup-stage.sh
@@ -1,5 +1,4 @@
-mkdir bin
-mkdir stage
-mkdir stage/node_modules
+mkdir -p bin
+mkdir -p stage/node_modules
 ln -sf ../book.json stage
 ln -sf ../examples/README.md stage


### PR DESCRIPTION
This will take away the warning about the folders already existing, and also
make the directories in one less line
