### PR TITLE
Elide lifetimes in `generics/implementation`

### DIFF
--- a/examples/generics/impl/impl.rs
+++ b/examples/generics/impl/impl.rs
@@ -3,8 +3,7 @@ struct GenTup<T>(T,);
 
 // impl of Tup
 impl Tup {
-    // Borrowing a ref (val) requires lifelines
-    fn value<'a>(&'a self) -> &'a f64 {
+    fn value(&self) -> &f64 {
         let &Tup ( ref val ) = self;
 
         val
@@ -13,7 +12,7 @@ impl Tup {
 
 // impl of GenTup for a generic type `T`
 impl <T> GenTup<T> {
-    fn value<'a>(&'a self) -> &'a T {
+    fn value(&self) -> &T {
         let &GenTup (ref val) = self;
         
         val


### PR DESCRIPTION
Remove lifetime annotation since they are no longer needed
