### PR TITLE
Make travis-ci not spit out so much from rustup

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,7 +2,7 @@ language: node_js
 
 install:
   - npm install gitbook -g
-  - curl -s https://static.rust-lang.org/rustup.sh | sudo sh
+  - curl -s https://static.rust-lang.org/rustup.sh | sudo sh > /dev/null
 
 script:
   - rustc --version


### PR DESCRIPTION
This is correct this time.

On another note, does anyone know of a better way of squashing the commits? I usually switch to a new branch, but that seems counter productive...
