### PR TITLE
Regenerate CNAME on deploy.

### DIFF
--- a/deploy.sh
+++ b/deploy.sh
@@ -10,6 +10,8 @@ git config user.email "steve@steveklabnik.com"
 git remote add upstream "https://$GH_TOKEN@github.com/rust-lang/rust-by-example.git"
 git fetch upstream && git reset upstream/gh-pages
 
+echo "rustbyexample.com" > CNAME
+
 touch .
 
 git add -A .


### PR DESCRIPTION
Previously, we had just relied on having a CNAME existing on the branch. Now that the deploy script regenerates things, it didn't make a new CNAME, which caused Bad Things.
