### PR TITLE
Manually grab `ace` to use latest gitbook

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -45,4 +45,4 @@ serve: node_modules/gitbook
 	$(GITBOOK) serve stage
 
 node_modules/gitbook:
-	npm install gitbook@0.7.1
+	npm install gitbook

--- a/node_modules/gitbook-plugin-rust-playpen/index.js
+++ b/node_modules/gitbook-plugin-rust-playpen/index.js
@@ -5,6 +5,7 @@ module.exports = {
             "editor.css"
         ],
         js: [
+            "ace/ace.js",
             "editor.js",
             "mode-rust.js"
         ]

--- a/setup-stage.sh
+++ b/setup-stage.sh
@@ -1,4 +1,11 @@
+#!/bin/dash
+
+ace_repository='https://github.com/ajaxorg/ace-builds/trunk/src-min-noconflict'
+ace_local_folder='node_modules/gitbook-plugin-rust-playpen/book/ace'
+
 mkdir -p bin
 mkdir -p stage/node_modules
+svn checkout ${ace_repository} ${ace_local_folder}
+
 ln -sf ../book.json stage
 ln -sf ../examples/README.md stage


### PR DESCRIPTION
This makes gitbook 1.5.0 (what NPM installed) work for me. I had an syntax highlighting issues with 1.4.2 which is what is installed by Ubuntu but I think it's related to `gitbook serve` not working properly. Otherwise, it seems to work fine.

I wasn't sure if you'd want *ace* in tree so I downloaded it in the script.