### PR TITLE
Fix doubled request to the playpen on pages with an editor when accessed directly

### DIFF
--- a/node_modules/gitbook-plugin-rust-playpen/book/editor.js
+++ b/node_modules/gitbook-plugin-rust-playpen/book/editor.js
@@ -112,8 +112,6 @@ function initEditor() {
   });
 }
 
-initEditor();
-
 require(["gitbook"], function(gitbook) {
   gitbook.events.bind("page.change", function() {
     initEditor();


### PR DESCRIPTION
There is a global call to `initEditor()` in [node_modules/gitbook-plugin-rust-playpen/book/editor.js:115](https://github.com/rust-lang/rust-by-example/blob/master/node_modules/gitbook-plugin-rust-playpen/book/editor.js#L115) that is triggered when a page is loaded. The problem is that `initEditor()` is also called by gitbook on [`page.change` events](https://github.com/rust-lang/rust-by-example/blob/master/node_modules/gitbook-plugin-rust-playpen/book/editor.js#L119).

As `initEditor()` is responsible for binding the buttons with their handlers, those bindings are done twice when accessing a page directly: by the global call when the page is loaded, and by the `page.change` event that is also fired on page load. So when clicking the “Run” button, its handler is called twice, causing two requests to be made to the playpen.

I’ve put a `console.log()` stuffed version of `editor.js` [here](https://gist.github.com/dbbrian/ae28987e7ec5779a3f74), so it will be easier for everyone to test.
