### PR TITLE
Many things, mostly updating to lastest rustc

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -38,7 +38,7 @@ clean:
 	rm -rf bin stage
 
 test:
-	$(foreach src,$(srcs),$(RUSTC_NT) $(src) || exit;)
+	@$(foreach src,$(srcs),$(RUSTC_NT) $(src) || exit;)
 	./check-line-length.sh
 
 serve: node_modules/gitbook

--- a/examples/mod/super/super.rs
+++ b/examples/mod/super/super.rs
@@ -23,7 +23,7 @@ mod my {
             // `self` refers to the current module scope, in this case: `my`
             use self::cool::function as my_cool_function;
 
-            print!("> ")
+            print!("> ");
             my_cool_function();
         }
 

--- a/examples/staging/macros/designators.rs
+++ b/examples/staging/macros/designators.rs
@@ -13,8 +13,8 @@ macro_rules! create_function {
     }
 }
 
-create_function!(foo)
-create_function!(bar)
+create_function!(foo);
+create_function!(bar);
 
 macro_rules! print_result {
     // the `expr` designator is used for expressions

--- a/examples/staging/macros/dry.rs
+++ b/examples/staging/macros/dry.rs
@@ -25,9 +25,9 @@ macro_rules! op {
 }
 
 // implement add_assign, mul_assign, and sub_assign functions
-op!(add_assign, Add, +=, add)
-op!(mul_assign, Mul, *=, mul)
-op!(sub_assign, Sub, -=, sub)
+op!(add_assign, Add, +=, add);
+op!(mul_assign, Mul, *=, mul);
+op!(sub_assign, Sub, -=, sub);
 
 fn main() {
     let mut xs = Vec::from_elem(5, 0f64);
@@ -56,7 +56,7 @@ mod test {
     }
 
     // test add_assign, mul_assign and sub_assign
-    test!(add_assign, 1u, 2u, 3u)
-    test!(mul_assign, 2u, 3u, 6u)
-    test!(sub_assign, 3u, 2u, 1u)
+    test!(add_assign, 1u, 2u, 3u);
+    test!(mul_assign, 2u, 3u, 6u);
+    test!(sub_assign, 3u, 2u, 1u);
 }

--- a/examples/staging/simd/simd_add.rs
+++ b/examples/staging/simd/simd_add.rs
@@ -71,6 +71,6 @@ mod bench {
         }
     }
 
-    bench!(vanilla, add_assign)
-    bench!(simd, simd_add_assign)
+    bench!(vanilla, add_assign);
+    bench!(simd, simd_add_assign);
 }

--- a/src/markdown.rs
+++ b/src/markdown.rs
@@ -95,7 +95,7 @@ impl<'a, 'b> Markdown<'a, 'b> {
                 Some(captures) => {
                     let src = captures.at(1);
                     let input = format!("{{{}.out}}", src);
-                    let s = try!(file::run(prefix, id, src));
+                    let s = try!(file::run(prefix, id, src.unwrap()));
                     let s = format!("```\n$ rustc {0}.rs && ./{0}\n{1}```",
                                     src, s);
 


### PR DESCRIPTION
Makefile: No more writing out the entirety of the command when you `make test`

super/super.rs: Minor compile fix (forgot a semicolon)

Macros: Added a semicolon where it is needed now

src/markdown.rs: src is now an Option<&str>, so we'll unwrap it
