### PR TITLE
Replace the escapeHTML() by a more efficient one

### DIFF
--- a/node_modules/gitbook-plugin-rust-playpen/book/editor.css
+++ b/node_modules/gitbook-plugin-rust-playpen/book/editor.css
@@ -26,6 +26,7 @@
   display: none;
   border-radius: 4px;
   font-family: Menlo, Monaco, Consolas, "Courier New", monospace;
+  white-space: pre;
 }
 
 #reset-code {

--- a/node_modules/gitbook-plugin-rust-playpen/book/editor.js
+++ b/node_modules/gitbook-plugin-rust-playpen/book/editor.js
@@ -129,14 +129,26 @@ function updateEditorHeight() {
   editor.resize();
 };
 
+// 
+// escapeHTML() borrowed from mustache.js:
+// https://github.com/janl/mustache.js/blob/master/mustache.js#L43
+// 
+// via:
+// http://stackoverflow.com/questions/24816/escaping-html-strings-with-jquery/12034334#12034334
+// 
+var entityMap = {
+  "&": "&amp;",
+  "<": "&lt;",
+  ">": "&gt;",
+  '"': '&quot;',
+  "'": '&#39;',
+  "/": '&#x2F;'
+};
+
 function escapeHTML(unsafe) {
-  return unsafe
-    .replace(/&/g, "&amp;")
-    .replace(/</g, "&lt;")
-    .replace(/>/g, "&gt;")
-    .replace(/"/g, "&quot;")
-    .replace(/'/g, "&#039;")
-    .replace(newLineRegex, '<br />');
+  return String(unsafe).replace(/[&<>"'\/]/g, function(s) {
+    return entityMap[s];
+  });
 }
 
 // Dispatches a XMLHttpRequest to the Rust playpen, running the program, and


### PR DESCRIPTION
The `escapeHTML()` function in [editor.js](https://github.com/rust-lang/rust-by-example/blob/master/node_modules/gitbook-plugin-rust-playpen/book/editor.js#L134) is a little too optimistic about JavaScript laziness. Chaining `String.replace()` like this...

``` JavaScript
function escapeHTML(unsafe) {
  return unsafe
    .replace(/&/g, "&amp;")
    .replace(/</g, "&lt;")
    .replace(/>/g, "&gt;")
    .replace(/"/g, "&quot;")
    .replace(/'/g, "&#039;")
    .replace(newLineRegex, '<br />');
}
```

…sadly results in `unsafe` being parsed _six_ time, and crash Firefox when a playpen response is too large. Other browsers may optimize this as I haven't seen Safari or Chrome crash.

It can be tried on the [Loop page](http://rustbyexample.com/loop.html) by commenting out the `break` to create an infinite loop, and wait for the playpen timeout.
