### PR TITLE
Fixes site generation (Links now work)

### DIFF
--- a/examples/channels/channels.rs
+++ b/examples/channels/channels.rs
@@ -1,4 +1,5 @@
 use std::comm;
+use std::thread::Thread;
 
 static NTASKS: uint = 3;
 
@@ -13,7 +14,9 @@ fn main() {
         let task_tx = tx.clone();
 
         // Each task will send its id via the channel
-        spawn(move || {
+        // We need to explicity ignore the return value of Thread::spawn
+        // Read more at http://doc.rust-lang.org/std/thread/index.html
+        let _ = Thread::spawn(move || {
             // The task takes ownership over `task_tx`
             // Each task queues a message in the channel
             task_tx.send(id);

--- a/examples/tasks/tasks.rs
+++ b/examples/tasks/tasks.rs
@@ -1,10 +1,11 @@
+use std::thread::Thread;
 static NTASKS: int = 10;
 
 // This is the `main` task
 fn main() {
     for i in range(0, NTASKS) {
         // Spin up another task
-        spawn(move || {
+        let _ = Thread::spawn(move || {
             println!("this is task number {}", i)
         });
     }

--- a/src/markdown.rs
+++ b/src/markdown.rs
@@ -53,7 +53,7 @@ impl<'a, 'b> Markdown<'a, 'b> {
             match re.captures(line) {
                 None => {},
                 Some(captures) => {
-                    let src = captures.at(1);
+                    let src = captures.at(1).unwrap();
                     let input = format!("{{{}}}", src);
                     let p = format!("examples/{}/{}/{}", prefix, id, src);
                     let output = match file::read(&Path::new(p.as_slice())) {
@@ -93,9 +93,9 @@ impl<'a, 'b> Markdown<'a, 'b> {
             match r.captures(line) {
                 None => {},
                 Some(captures) => {
-                    let src = captures.at(1);
+                    let src = captures.at(1).unwrap();
                     let input = format!("{{{}.out}}", src);
-                    let s = try!(file::run(prefix, id, src.unwrap()));
+                    let s = try!(file::run(prefix, id, src));
                     let s = format!("```\n$ rustc {0}.rs && ./{0}\n{1}```",
                                     src, s);
 
@@ -129,8 +129,9 @@ impl<'a, 'b> Markdown<'a, 'b> {
                         once_ = true;
                     }
 
-                    let input = format!("{{{}.play}}", captures.at(1));
-                    let src = format!("{}.rs", captures.at(1));
+                    let c = captures.at(1).unwrap();
+                    let input = format!("{{{}.play}}", c);
+                    let src = format!("{}.rs", c);
                     let p = format!("examples/{}/{}/{}", prefix, id, src);
                     let output = match file::read(&Path::new(p.as_slice())) {
                         Err(_) => {

--- a/src/update.rs
+++ b/src/update.rs
@@ -7,6 +7,7 @@ extern crate regex_macros;
 extern crate serialize;
 
 use example::Example;
+use std::thread::Thread;
 
 mod example;
 mod file;
@@ -22,7 +23,7 @@ fn main() {
         let tx = tx.clone();
         let count = example.count();
 
-        spawn(move || {
+        let _ = Thread::spawn(move || {
             example.process(vec!(i + 1), tx, 0, String::new());
         });
 


### PR DESCRIPTION
captures.at() now returns an option, so we unwrap that

Also, change from spawn() to Thread::spawn()

This also fixes #343 
