### PR TITLE
Check the size of the response before appending it to the DOM. Close #177

### DIFF
--- a/node_modules/gitbook-plugin-rust-playpen/book/editor.js
+++ b/node_modules/gitbook-plugin-rust-playpen/book/editor.js
@@ -40,6 +40,9 @@ var Range;
 // Original source code
 var originalCode;
 
+// Maximum length of a response before it has to be truncated
+var MAX_RESPONSE_LENGTH = 50000;
+
 function initEditor() {
   // Fetching DOM items
   editorDiv = document.getElementById("editor");
@@ -181,6 +184,15 @@ function runProgram(program, callback) {
 
 // The callback to runProgram
 function handleResult(statusCode, message) {
+  
+  // Check the size of the message, shorten it if 
+  // it's too big to be appended to the DOM.
+  if ( message.length > MAX_RESPONSE_LENGTH ) {
+    message = message.slice(0, MAX_RESPONSE_LENGTH / 2)
+            + '\n\n--- THIS RESULT HAS BEEN SHORTENED ---\n\n'
+            + message.slice(-MAX_RESPONSE_LENGTH / 2);
+  }
+  
   // Dispatch depending on result type
   if (result == null) {
     resultDiv.style.backgroundColor = errorColor;


### PR DESCRIPTION
The problem occurs when the response is [appended to the DOM](https://github.com/rust-lang/rust-by-example/blob/master/node_modules/gitbook-plugin-rust-playpen/book/editor.js#L200). The rest of the code can handle a pretty large volume of data, I tested it with responses up to ~150MB before Firefox threw an `allocation size overflow`. Thanks to that, we're able to check the length of the response, and truncate it if necessary, before touching the DOM, avoiding a crash / hang.

I've set the `MAX_RESPONSE_LENGTH` to 50,000 characters. Above that the response is truncated (25,000 from the head, 25,000 from the tail.)
