### PR TITLE
Fixes bounds/bounds.rs

### DIFF
--- a/examples/bounds/bounds.rs
+++ b/examples/bounds/bounds.rs
@@ -4,11 +4,10 @@ struct Vec2<T> {
     y: T,
 }
 
-impl<
-    // Bound: `T` must implement the `Add` trait
-    T: Add<T, T>
-> Add<Vec2<T>, Vec2<T>>
-for Vec2<T> {
+// Apply bound to `T` at first instance of `T`. `T`
+// must implement the `Add` trait.
+impl<T: Add<T, T>> Add<Vec2<T>, Vec2<T>>
+        for Vec2<T> {
     fn add(self, rhs: Vec2<T>) -> Vec2<T> {
         Vec2 {
             // `x` and `y` are of type `T`, and implement the `add` method
@@ -19,11 +18,9 @@ for Vec2<T> {
     }
 }
 
-impl<
-    // Bound: `T` must implement the `Sub` trait
-    T: Sub<T, T>
-> Sub<Vec2<T>, Vec2<T>>
-for Vec2<T> {
+// Bound: `T` must implement the `Sub` trait
+impl<T> Sub<Vec2<T>, Vec2<T>> for Vec2<T>
+        where T: Sub<T, T> {
     fn sub(self, rhs: Vec2<T>) -> Vec2<T> {
         Vec2 {
             x: self.x - rhs.x,
@@ -32,10 +29,9 @@ for Vec2<T> {
     }
 }
 
-impl<
-    // Bound: `T` must implement *both* the `Add` trait and the `Mul` trait
-    T: Add<T, T> + Mul<T, T>
-> Vec2<T> {
+// Bound: `T` must implement *both* the `Add` trait and the `Mul` trait
+impl<T> Vec2<T> 
+        where T: Add<T, T> + Mul<T, T> {
     fn dot(self, rhs: Vec2<T>) -> T {
         (self.x * rhs.x) + (self.y * rhs.y)
     }

--- a/examples/bounds/bounds.rs
+++ b/examples/bounds/bounds.rs
@@ -1,4 +1,4 @@
-#[deriving(Show)]
+#[deriving(Show, Copy)]
 struct Vec2<T> {
     x: T,
     y: T,
@@ -9,10 +9,10 @@ impl<
     T: Add<T, T>
 > Add<Vec2<T>, Vec2<T>>
 for Vec2<T> {
-    fn add(&self, rhs: &Vec2<T>) -> Vec2<T> {
+    fn add(self, rhs: Vec2<T>) -> Vec2<T> {
         Vec2 {
             // `x` and `y` are of type `T`, and implement the `add` method
-            x: self.x.add(&rhs.x),
+            x: self.x.add(rhs.x),
             // The sugary `+` operator can also be used
             y: self.y + rhs.y,
         }
@@ -24,7 +24,7 @@ impl<
     T: Sub<T, T>
 > Sub<Vec2<T>, Vec2<T>>
 for Vec2<T> {
-    fn sub(&self, rhs: &Vec2<T>) -> Vec2<T> {
+    fn sub(self, rhs: Vec2<T>) -> Vec2<T> {
         Vec2 {
             x: self.x - rhs.x,
             y: self.y - rhs.y,
@@ -35,9 +35,8 @@ for Vec2<T> {
 impl<
     // Bound: `T` must implement *both* the `Add` trait and the `Mul` trait
     T: Add<T, T> + Mul<T, T>
-> Mul<Vec2<T>, T>
-for Vec2<T> {
-    fn mul(&self, rhs: &Vec2<T>) -> T {
+> Vec2<T> {
+    fn dot(self, rhs: Vec2<T>) -> T {
         (self.x * rhs.x) + (self.y * rhs.y)
     }
 }
@@ -49,7 +48,7 @@ fn main() {
 
     println!("{} + {} = {}", v1, v2, v1 + v2);
     println!("{} - {} = {}", v1, v2, v1 - v2);
-    println!("{} . {} = {}", v1, v2, v1.dot(&v2));
+    println!("{} ⋅ {} = {}", v1, v2, v1.dot(v2));
 
     // Error! `char` doesn't implement the `Add` trait
     println!("{}", Vec2 { x: ' ', y: 'b' } + Vec2 { x: 'c', y: 'd' });

--- a/examples/bounds/input.md
+++ b/examples/bounds/input.md
@@ -7,4 +7,9 @@ When working with generics, the type parameters (e.g. `Ty`) may use traits
 * The generic can only be specialized for type parameters that conform to the
   bounds.
 
+Bounds are typically applied in one of two ways:
+
+* At the first instance of the type
+* In a `where` clause which directly precedes the `{` in the `impl`
+
 {bounds.play}

--- a/examples/ops/input.md
+++ b/examples/ops/input.md
@@ -1,11 +1,10 @@
 In Rust, many of the operators can be overloaded via traits. This is possible
 because operators are just sugar for method calls. For example, `a + b`
-desugars to `a.add(&b)`. This `add` method is part of the `Add` trait, hence
+desugars to `a.add(b)`. This `add` method is part of the `Add` trait, hence
 any implementor of the `Add` trait will be able to use the `+` operator.
 
 {operator.play}
 
-Here is a [list][ops] of
-the traits that overload operators.
+Here is a [list][ops] of the traits that overload operators.
 
 [ops]: http://doc.rust-lang.org/core/ops/

--- a/examples/ops/operator.rs
+++ b/examples/ops/operator.rs
@@ -13,7 +13,7 @@ struct BarFoo;
 // This block implements the operation: Foo + Bar = FooBar
 impl Add<Bar, FooBar> for Foo {
     fn add(self, _rhs: Bar) -> FooBar {
-        println!("> Foo.add(&Bar) was called");
+        println!("> Foo.add(Bar) was called");
 
         FooBar
     }
@@ -23,7 +23,7 @@ impl Add<Bar, FooBar> for Foo {
 // This block implements the operation: Bar + Foo = BarFoo
 impl Add<Foo, BarFoo> for Bar {
     fn add(self, _rhs: Foo) -> BarFoo {
-        println!("> Bar.add(&Foo) was called");
+        println!("> Bar.add(Foo) was called");
 
         BarFoo
     }


### PR DESCRIPTION
First of all, change Add and Sub to take by value, not reference. Second,
reverts part of PR #260, because that person made the dot product into a
multiplication operation, which shouldn't have ever happened.

Also fixes #347 