### PR TITLE
Track Rust master

### DIFF
--- a/examples/staging/arg/matching/match_args.rs
+++ b/examples/staging/arg/matching/match_args.rs
@@ -35,7 +35,7 @@ fn main() {
         // one command and one argument passed
         [_, ref cmd, ref num] => {
             // parse the number
-            let number: int = match from_str(num.as_slice()) {
+            let number: int = match num.parse() {
                 Some(n) => {
                     n
                 },

--- a/src/example.rs
+++ b/src/example.rs
@@ -2,6 +2,7 @@ use file;
 use markdown::Markdown;
 use serialize::{Decodable,json};
 use std::iter::AdditiveIterator;
+use std::iter::repeat;
 
 #[deriving(Decodable)]
 pub struct Example {
@@ -46,20 +47,22 @@ impl Example {
         let entry =
             match Markdown::process(number.as_slice(), id, title, prefix) {
                 Ok(_) => {
-                    let md = if prefix.as_slice().is_whitespace() {
+                    let md = if prefix.chars().all(|c| c.is_whitespace()) {
                         format!("{}.md", id)
                     } else {
                         format!("{}/{}.md", prefix, id)
                     };
 
                     format!("{}* [{}]({})",
-                            "  ".repeat(indent),
+                            repeat("  ").take(indent).collect::<String>(),
                             title,
                             md)
                 },
                 Err(why) => {
                     print!("{}: {}\n", id, why);
-                    format!("{}* {}", "  ".repeat(indent), title)
+                    format!("{}* {}",
+                            repeat("  ").take(indent).collect::<String>(),
+                            title)
                 },
             };
 
@@ -74,7 +77,7 @@ impl Example {
 
                 for (i, example) in children.iter().enumerate() {
                     let tx = tx.clone();
-                    let prefix = if prefix.as_slice().is_whitespace() {
+                    let prefix = if prefix.chars().all(|c| c.is_whitespace()) {
                         format!("{}", id)
                     } else {
                         format!("{}/{}", prefix, id)

--- a/src/markdown.rs
+++ b/src/markdown.rs
@@ -1,5 +1,6 @@
 use file;
 use playpen;
+use std::iter::repeat;
 
 pub struct Markdown<'a, 'b> {
     content: String,
@@ -30,8 +31,9 @@ impl<'a, 'b> Markdown<'a, 'b> {
             format!("{}", x)
         }).collect::<Vec<String>>().connect(".");
 
+        let len = number.len();
         let content = format!("{} {} {}\n\n{}",
-                              "#".repeat(number.len()),
+                              repeat("#").take(len).collect::<String>(),
                               version,
                               title,
                               body);


### PR DESCRIPTION
Fix usage of deprecated methods to compile with latest Rust nightly:
- parse instead of from_str
- std::iter::repeat instead of deprecated StrExt::repeat
- per char is_whitespace instead of deprecated StrExt::is_whitespace
