### PR TITLE
Fix shell scripts for MacOS X

### DIFF
--- a/check-line-length.sh
+++ b/check-line-length.sh
@@ -7,7 +7,7 @@ WHITELIST=(
 
 echo "Checking if any rust file has a line longer than 79 characters"
 
-suspects=$(find -name '*.rs' | xargs grep -Pl ".{80}")
+suspects=$(find . -name '*.rs' | xargs grep -El ".{80}")
 status=$?
 
 any_offender=false

--- a/fix-edit-button.sh
+++ b/fix-edit-button.sh
@@ -5,6 +5,6 @@ for example in $(find examples -type d -name "*"); do
   if [[ -f ${html} ]]; then
     echo ${html}
 
-    sed -i s:${example#examples/}.md:${example}/input.md: ${html}
+    sed -i -e s:${example#examples/}.md:${example}/input.md: ${html}
   fi
 done


### PR DESCRIPTION
Make test and book doesn't work on Yosemite without installing GNU versions of grep, sed and findutils.
Modify shell scripts to be compatible with BSD-based distributions:
- grep extended regex syntax since Perl syntax no longer supported
- find requires explicit path
- sed requires explicit option after empty extension
