### PR TITLE
attribute: fixing Markdown link

### DIFF
--- a/examples/attribute/input.md
+++ b/examples/attribute/input.md
@@ -3,7 +3,7 @@ can be used to/for:
 
 <!-- TODO: Link these to their respective examples -->
 * [conditional compilation of code][cfg]
-* [set crate name, version and type (binary or library)][config]
+* [set crate name, version and type (binary or library)][crate]
 * disable [lints][lint] (warnings)
 * enable compiler features (macros, glob imports, etc.)
 * link to a foreign library


### PR DESCRIPTION
The Markdown link is named `[crate]` but the link referred to it as `[config]`, causing a formatting error. This fixes the link reference. This is essentially a typo fix so I'm just doing a PR directly.