### PR TITLE
Allow '$' in rust files

### DIFF
--- a/src/playpen.rs
+++ b/src/playpen.rs
@@ -12,6 +12,7 @@ fn escape(source: &str) -> String {
 
     for chr in source.trim().chars() {
         match chr {
+            '$' => s.push_str("&#36;"),
             '*' => s.push_str("&#42;"),
             '<' => s.push_str("&lt;"),
             '>' => s.push_str("&gt;"),


### PR DESCRIPTION
Actually fixes #334, without workarounds.