### PR TITLE
Update threading example

### DIFF
--- a/examples/threads/threads.rs
+++ b/examples/threads/threads.rs
@@ -1,10 +1,10 @@
 use std::thread::Thread;
 
-static NTHREADS: int = 10;
+static NTHREADS: i32 = 10;
 
 // This is the `main` thread
 fn main() {
-    for i in range(0, NTHREADS) {
+    for i in (0..NTHREADS) {
         // Spin up another thread
         let _ = Thread::scoped(move || {
             println!("this is thread number {}", i)


### PR DESCRIPTION
Now the example uses range notation (`..`) and `i32` instead of `int`