### PR TITLE
Update print.rs

### DIFF
--- a/examples/print/print.rs
+++ b/examples/print/print.rs
@@ -3,7 +3,7 @@ fn main() {
     print!("January has ");
 
     // `{}` are placeholders for arguments that will be stringified
-    println!("{} days", 31is);
+    println!("{} days", 31);
     // The `i` suffix indicates the compiler that this literal has type: signed
     // pointer size integer, see next chapter for more details
 

--- a/examples/print/print.rs
+++ b/examples/print/print.rs
@@ -3,7 +3,7 @@ fn main() {
     print!("January has ");
 
     // `{}` are placeholders for arguments that will be stringified
-    println!("{} days", 31i);
+    println!("{} days", 31is);
     // The `i` suffix indicates the compiler that this literal has type: signed
     // pointer size integer, see next chapter for more details
 


### PR DESCRIPTION
Fixed the warning "`i` suffix on integers is deprecated; use `is` or one of the fixed-sized suffixes" by using `is` suffix.