### PR TITLE
Add margin to bottom of interactive code blocks

### DIFF
--- a/node_modules/gitbook-plugin-rust-playpen/book/editor.css
+++ b/node_modules/gitbook-plugin-rust-playpen/book/editor.css
@@ -7,6 +7,7 @@
   border-radius: 4px;
   background-color: #FDFDFD;
   border: 1px solid #CCC;
+  margin-bottom: 16px;
 }
 
 #editor {


### PR DESCRIPTION
On pages like [this one](http://rustbyexample.com/type.html) where interactive code blocks are followed by more content, there is no spacing between the bottom of the code block and the top of the following paragraph. By adding a 16px margin to the bottom of `#active-code`, the margin below the code block matches the margin above.