### PR TITLE
Rename int/uint to isize/usize in type/input.md

### DIFF
--- a/examples/type/input.md
+++ b/examples/type/input.md
@@ -7,8 +7,8 @@ annotation burden.
 
 This is a summary of the primitive types in Rust:
 
-* signed integers: `i8`, `i16`, `i32`, `i64` and `int` (machine word size)
-* unsigned integers: `u8`, `u16`, `u32`, `u64` and `uint` (machine word size)
+* signed integers: `i8`, `i16`, `i32`, `i64` and `isize` (pointer size)
+* unsigned integers: `u8`, `u16`, `u32`, `u64` and `usize` (pointer size)
 * floating point: `f32`, `f64`
 * `char` Unicode scalar values like `'a'`, `'α'` and `'∞'` (4 bytes each)
 * `bool` either `true` or `false`


### PR DESCRIPTION
Also, isize and usize are technically the size of a pointer, not a machine
word