### PR TITLE
Remove unused use

### DIFF
--- a/examples/iter/iter.rs
+++ b/examples/iter/iter.rs
@@ -1,5 +1,3 @@
-use std::mem;
-
 struct Fibonacci {
     curr: u32,
     next: u32,


### PR DESCRIPTION
[Iter](http://rustbyexample.com/iter.html) is throwing an `unused import` warning for `std::mem` because https://github.com/rust-lang/rust-by-example/pull/409 removed `mem::replace()` usage. This fixes that warning.