### PR TITLE
Minor grammatical fixes in README.md

### DIFF
--- a/examples/README.md
+++ b/examples/README.md
@@ -7,13 +7,12 @@ This book is a collection of bitesize examples that illustrate various rustic
 concepts and the Rust distribution libraries. The source code is hosted
 [here][home].
 
-Be sure to have rust [installed][install] and the
-[docs][std] at hand, let's
-start!
+Be sure to have Rust [installed][install] and the [docs][std] at hand,
+and let's start!
 
 *Note*: This book will follow the nightly version of Rust until we reach
-version 1.0, it's highly possible that some examples won't work with snapshot
-versions like 0.10, be sure to use a nightly version!
+version 1.0; it's highly possible that some examples won't work with snapshot
+versions like 0.10, so be sure to use a nightly version!
 
 [rust]: http://www.rust-lang.org/
 [install]: http://www.rust-lang.org/install.html


### PR DESCRIPTION
I could only find [one instance](https://github.com/rust-lang/rust/blob/master/src/doc/intro.md#learning-more) of 'Rustic' in Rust's documentation, but it feels like a proper noun.