### PR TITLE
Rust update

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2,17 +2,17 @@
 name = "update"
 version = "0.0.1"
 dependencies = [
- "regex 0.1.10 (registry+https://github.com/rust-lang/crates.io-index)",
- "rustc-serialize 0.2.9 (registry+https://github.com/rust-lang/crates.io-index)",
+ "regex 0.1.11 (registry+https://github.com/rust-lang/crates.io-index)",
+ "rustc-serialize 0.2.10 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
 name = "regex"
-version = "0.1.10"
+version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
 name = "rustc-serialize"
-version = "0.2.9"
+version = "0.2.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 

--- a/examples/file/create/create.rs
+++ b/examples/file/create/create.rs
@@ -1,4 +1,4 @@
-use std::io::File;
+use std::old_io::File;
 
 static LOREM_IPSUM: &'static str =
 "Lorem ipsum dolor sit amet, consectetur adipisicing elit, sed do eiusmod

--- a/examples/file/open/open.rs
+++ b/examples/file/open/open.rs
@@ -1,4 +1,4 @@
-use std::io::File;
+use std::old_io::File;
 
 fn main() {
     // Create a path to the desired file

--- a/examples/fs/fs.rs
+++ b/examples/fs/fs.rs
@@ -1,6 +1,6 @@
-use std::io::fs;
-use std::io::fs::PathExtensions;
-use std::io::{File, IoResult, USER_RWX};
+use std::old_io::fs;
+use std::old_io::fs::PathExtensions;
+use std::old_io::{File, IoResult, USER_RWX};
 
 // A simple implementation of `% cat path`
 fn cat(path: &Path) -> IoResult<String> {

--- a/examples/path/path.rs
+++ b/examples/path/path.rs
@@ -1,4 +1,4 @@
-use std::io::fs::PathExtensions;
+use std::old_io::fs::PathExtensions;
 
 fn main() {
     // Create a `Path` from an `&'static str`

--- a/examples/process/pipe/pipe.rs
+++ b/examples/process/pipe/pipe.rs
@@ -1,4 +1,4 @@
-use std::io::process::Command;
+use std::old_io::process::Command;
 
 static PANGRAM: &'static str =
 "the quick brown fox jumped over the lazy dog\n";

--- a/examples/process/process.rs
+++ b/examples/process/process.rs
@@ -1,4 +1,4 @@
-use std::io::process::{Command,ProcessOutput};
+use std::old_io::process::{Command,ProcessOutput};
 
 fn main() {
     // Initial command `rustc`

--- a/examples/process/wait/wait.rs
+++ b/examples/process/wait/wait.rs
@@ -1,4 +1,4 @@
-use std::io::process::Command;
+use std::old_io::process::Command;
 
 fn main() {
     let _process = Command::new("sleep").arg("5").spawn();

--- a/examples/sockets/client.rs
+++ b/examples/sockets/client.rs
@@ -1,5 +1,5 @@
 use common::SOCKET_PATH;
-use std::io::net::pipe::UnixStream;
+use std::old_io::net::pipe::UnixStream;
 use std::os;
 
 mod common;

--- a/examples/sockets/server.rs
+++ b/examples/sockets/server.rs
@@ -1,8 +1,8 @@
 use common::SOCKET_PATH;
-use std::io::fs;
-use std::io::fs::PathExtensions;
-use std::io::net::pipe::UnixListener;
-use std::io::{Acceptor,Listener};
+use std::old_io::fs;
+use std::old_io::fs::PathExtensions;
+use std::old_io::net::pipe::UnixListener;
+use std::old_io::{Acceptor,Listener};
 
 mod common;
 

--- a/examples/staging/arg/getopts/echo.rs
+++ b/examples/staging/arg/getopts/echo.rs
@@ -1,8 +1,8 @@
 extern crate getopts;
 
 use std::os;
-use std::io::{print, println};
-use std::io::stdio;
+use std::old_io::{print, println};
+use std::old_io::stdio;
 
 static VERSION: &'static str = "1.0.0";
 

--- a/examples/timers/timers.rs
+++ b/examples/timers/timers.rs
@@ -1,5 +1,5 @@
-use std::io::Timer;
-use std::io::timer;
+use std::old_io::Timer;
+use std::old_io::timer;
 use std::time::duration::Duration;
 use std::iter;
 use std::sync::mpsc;

--- a/node_modules/gitbook-plugin-rust-playpen/book/editor.js
+++ b/node_modules/gitbook-plugin-rust-playpen/book/editor.js
@@ -165,7 +165,7 @@ function runProgram(program, callback) {
   });
 
   // console.log("Sending", data);
-  req.open('POST', "http://play.rust-lang.org/evaluate.json", true);
+  req.open('POST', "https://play.rust-lang.org/evaluate.json", true);
   req.onload = function(e) {
     if (req.readyState === 4 && req.status === 200) {
       var result = JSON.parse(req.response).result;

--- a/src/file.rs
+++ b/src/file.rs
@@ -1,7 +1,7 @@
-use std::io::USER_RWX;
-use std::io::fs;
-use std::io::process::{Command,ProcessOutput};
-use std::io::{File,Truncate,Write};
+use std::old_io::USER_RWX;
+use std::old_io::fs;
+use std::old_io::process::{Command,ProcessOutput};
+use std::old_io::{File,Truncate,Write};
 use std::os;
 
 pub fn mkdir(path: &Path) {


### PR DESCRIPTION
- Playpen moved to https: https://github.com/rust-lang/rust-playpen/commit/c58d43f768f33273b3edaf7fa69340a3647867b3
- `io` was renamed `old_io`: https://github.com/rust-lang/rust/commit/f72b1645103e12b581f7022b893c37b5fe41aef7
- cargo needed an update

Fixes https://github.com/rust-lang/rust-by-example/issues/434