### PR TITLE
Fix feature build errors

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,7 @@
 GITBOOK = node_modules/.bin/gitbook
 RUSTC = rustc
 STRICT = -D deprecated
-QUIET = -A unused-variables -A dead-code -A unused-assignments -A unstable
+QUIET = -A unused-variables -A dead-code -A unused-assignments
 RUSTC_NT = $(RUSTC) -Z no-trans --test $(QUIET) ${STRICT}
 WHITELIST = examples/attribute/cfg/custom/custom.rs \
 						examples/borrow/borrow.rs \

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,8 +1,12 @@
+#![feature(os)]
+#![feature(io)]
+#![feature(std_misc)]
+#![feature(path)]
+#![feature(core)]
+
 #![deny(warnings)]
 #![feature(int_uint)]
 #![feature(plugin)]
-
-#![allow(unstable)]
 
 extern crate regex;
 


### PR DESCRIPTION
rustup broke it again so this fixes it. The `unstable` lint does't work anymore. I couldn't find the commit that removed it but even renaming it to `unstable-features` doesn't remove the warnings. `make test` throws ***a lot*** of warnings now.

Probably related to http://discuss.rust-lang.org/t/psa-important-info-about-rustcs-new-feature-staging/82