### PR TITLE
The fizzbuzz_to function is corrected now to use Rust's new a..b range syntax

### DIFF
--- a/examples/fn/fn.rs
+++ b/examples/fn/fn.rs
@@ -31,7 +31,7 @@ fn fizzbuzz(n: u32) -> () {
 // When a function returns `()`, the return type can be omitted from the
 // signature
 fn fizzbuzz_to(n: u32) {
-    for n in range(1, n + 1) {
+    for n in 1..(n + 1) {
         fizzbuzz(n);
     }
 }

--- a/examples/fn/fn.rs
+++ b/examples/fn/fn.rs
@@ -31,7 +31,7 @@ fn fizzbuzz(n: u32) -> () {
 // When a function returns `()`, the return type can be omitted from the
 // signature
 fn fizzbuzz_to(n: u32) {
-    for n in 1..(n + 1) {
+    for n in 1..n + 1 {
         fizzbuzz(n);
     }
 }


### PR DESCRIPTION
It seems like there was a small typo in the fn.rs example.  It was using the old range(a, b) instead of the a..b syntax for range.