### PR TITLE
flow_control/match/destructuring/destructure_structures: Link to the related "the ref pattern"

### DIFF
--- a/examples/flow_control/match/destructuring/destructure_structures/input.md
+++ b/examples/flow_control/match/destructuring/destructure_structures/input.md
@@ -3,4 +3,4 @@ Similarly, a `struct` can be destructured as shown:
 {struct.play}
 
 ### See also:
-[Structs](/structs.html)
+[Structs](/structs.html), [The ref pattern](/borrow/ref.html)


### PR DESCRIPTION
When looking up syntax of the ref pattern in destructuring let, I searched for 'destructuring' in the TOC and landed on this page. Couldn't find the 'ref pattern' page without looking through all the TOC.