### PR TITLE
Results: Fixing text wrapping bug

### DIFF
--- a/node_modules/gitbook-plugin-rust-playpen/book/editor.css
+++ b/node_modules/gitbook-plugin-rust-playpen/book/editor.css
@@ -28,7 +28,7 @@
   display: none;
   border-radius: 4px;
   font-family: Menlo, Monaco, Consolas, "Courier New", monospace;
-  white-space: pre;
+  white-space: normal;
 }
 
 #reset-code {


### PR DESCRIPTION
Updated editor.css
Changed white-space on results to normal to stop text overflowing.