### PR TITLE
Closures: Fix obsolete syntax: `&:`.

### DIFF
--- a/examples/closures/closures.rs
+++ b/examples/closures/closures.rs
@@ -1,7 +1,7 @@
 fn main() {
     let captured_value = 7u32;
 
-    let closure = |&:argument| {
+    let closure = |argument| {
         println!("I captured this: {}", captured_value);
         println!("Argument passed was: {}", argument);
 


### PR DESCRIPTION
Updated closures.rs.
Fixed the obsolete syntax so the example would run.