### PR TITLE
lifetime/borrow: Change lifetime names to reflect comments

### DIFF
--- a/examples/lifetime/borrow/borrow.rs
+++ b/examples/lifetime/borrow/borrow.rs
@@ -1,15 +1,15 @@
-// FIXME To see the "real" compiler error, change both `&'b` and `&'e` into `&`
+// FIXME To see the "real" compiler error, change both `&'c` and `&'d` into `&`
 
 fn main() { // `'main` starts ────────────────────────────────────────────┐
     let stack_integer: i32 = 5; // `'a` starts ─────────────────────────┐ │
     let boxed_integer = Box::new(4); // `'b` starts ──────────────────┐ │ │
     //                                                                │ │ │
     // This is a valid operation                                      │ │ │
-    let ref_to_box: &'b i32 = &*boxed_integer; // `'c` starts ──────┐ │ │ │
+    let ref_to_box: &'c i32 = &*boxed_integer; // `'c` starts ──────┐ │ │ │
     //                                                              │ │ │ │
     // The compiler forbids this operation, because                 │ │ │ │
     // `ref_to_another_box` would become a dangling pointer         │ │ │ │
-    let ref_to_another_box: &'e i32 = { // `'let` `'d` start ───┬─┐ │ │ │ │
+    let ref_to_another_box: &'d i32 = { // `'let` `'d` start ───┬─┐ │ │ │ │
         let another_boxed_integer = Box::new(3); // ──────────┐ │ │ │ │ │ │
         // ^ `e` starts                                       │ │ │ │ │ │ │
         &*another_boxed_integer //                            │ │ │ │ │ │ │


### PR DESCRIPTION
Changed the lifetime names to `'c` and `'d` to reflect what is written in the article portion of the page as well as the comments.