### PR TITLE
Update use of std::env::args in arg chapter

### DIFF
--- a/examples/arg/args.rs
+++ b/examples/arg/args.rs
@@ -3,12 +3,13 @@
 use std::env;
 
 fn main() {
-    let args: Vec<String> = env::args().map(|x| x.to_string())
-                                       .collect();
+    let args: Vec<String> = env::args().collect();
+
     // The first argument is the path that was used to call the program.
     println!("My path is {}.", args[0]);
+
     // The rest of the arguments are the passed command line parameters.
     // Call the program like this:
-    // $ ./args arg1 arg2
+    //   $ ./args arg1 arg2
     println!("I got {:?} arguments: {:?}.", args.len() - 1, args.tail());
 }

--- a/examples/arg/getopts/echo.rs
+++ b/examples/arg/getopts/echo.rs
@@ -11,8 +11,7 @@ use std::old_io::stdio;
 static VERSION: &'static str = "1.0.0";
 
 fn main() {
-    let args: Vec<String> = env::args().map(|x| x.to_string())
-                                       .collect();
+    let args: Vec<String> = env::args().collect();
     let ref program = args[0];
 
     // Set possible flags.

--- a/examples/arg/getopts/input.md
+++ b/examples/arg/getopts/input.md
@@ -25,7 +25,7 @@ $ ./echo Hello, World!
 Hello, World!
 ```
 
-This is a simplified version of the `echo` implementation by
+This is a simplified version of the implementation in
 [uutils](https://github.com/uutils/coreutils).
 
 

--- a/examples/arg/getopts/testopt.rs
+++ b/examples/arg/getopts/testopt.rs
@@ -7,8 +7,7 @@ extern crate getopts;
 use std::env;
 
 fn main() {
-    let args: Vec<String> = env::args().map(|x| x.to_string())
-                                       .collect();
+    let args: Vec<String> = env::args().collect();
 
     let opts = [
         getopts::optflag("a", "long_a", ""),

--- a/examples/arg/input.md
+++ b/examples/arg/input.md
@@ -1,10 +1,10 @@
-The command line arguments can be accessed using `std::os::args`, which returns
-a [vector](http://static.rust-lang.org/doc/master/std/vec/index.html) of strings:
+The command line arguments can be accessed using `std::env::args`, which
+returns an iterator that yields a String for each argument:
 
 {args.play}
 
 ```
 $ ./args 1 2 3
 My path is ./args.
-I got 3 arguments: [1, 2, 3].
+I got 3 arguments: ["1", "2", "3"].
 ```

--- a/examples/arg/matching/input.md
+++ b/examples/arg/matching/input.md
@@ -25,6 +25,6 @@ $ ./match_args increase 42
 43
 ```
 
-<!-- TODO link to the getopts example, after moving this out of the staging area -->
-For implementing more complicated, unix-like command line interfaces see the `getopts` example.
+The next example demonstrates `getopts` as a way to build more advanced,
+unix-like command line interfaces.
 

--- a/examples/arg/matching/match_args.rs
+++ b/examples/arg/matching/match_args.rs
@@ -1,3 +1,5 @@
+#![feature(collections)]
+
 use std::env;
 
 fn increase(number: i32) {
@@ -17,8 +19,7 @@ match_args {{increase|decrease}} <integer>
 }
 
 fn main() {
-    let args: Vec<String> = env::args().map(|x| x.to_string())
-                                       .collect();
+    let args: Vec<String> = env::args().collect();
 
     match &args[..] {
         // no arguments passed


### PR DESCRIPTION
`std::os::args` is [deprecated](http://doc.rust-lang.org/std/os/fn.args.html).

`make tests` passed successfully.