### PR TITLE
Playpen frontend: Will now properly display newlines in successful output

### DIFF
--- a/node_modules/gitbook-plugin-rust-playpen/book/editor.js
+++ b/node_modules/gitbook-plugin-rust-playpen/book/editor.js
@@ -219,7 +219,11 @@ function handleResult(statusCode, message) {
 // Called on successful program run
 function handleSuccess(message) {
   resultDiv.style.backgroundColor = successColor;
-  resultDiv.innerHTML = escapeHTML(message);
+  var lines = message.split(newLineRegex);
+  message = lines.map(function(line) {
+    return escapeHTML(line);
+  }).join('<br />');
+  resultDiv.innerHTML = message;
 }
 
 // Called when program run results in warning(s)


### PR DESCRIPTION
This should fix #494. The `handleProblem` function already does this properly when outputting errors. One thing to note is that lines wrap because of the fix for #488, which may cause some confusion. It may be worth it to have the result box scroll horizontally.