### PR TITLE
Fixed rustc-serialize issue

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3,7 +3,7 @@ name = "update"
 version = "0.0.1"
 dependencies = [
  "regex 0.1.19 (registry+https://github.com/rust-lang/crates.io-index)",
- "rustc-serialize 0.3.3 (registry+https://github.com/rust-lang/crates.io-index)",
+ "rustc-serialize 0.3.6 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -13,6 +13,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
 name = "rustc-serialize"
-version = "0.3.3"
+version = "0.3.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 


### PR DESCRIPTION
+Compiling Error(make all) coming due to rust-serializer has been locked to 0.3.3 which does not have std::os::prelude::unix support, so it giving missing errors. 
error: unresolved import `std::os::unix::OsStringExt`. There is no `OsStringExt` in `std::os::unix`
error: unresolved import `std::os::unix::OsStrExt`. There is no `OsStrExt` in `std::os::unix`. 
Latest version of rust-serializer(0.3.6) has fixed this issue, so update Cargo.lock to fetch 0.3.6 version. 