### PR TITLE
add info to constants

### DIFF
--- a/examples/constants/constants.rs
+++ b/examples/constants/constants.rs
@@ -1,5 +1,6 @@
+// Globals are declared outside all other scopes.
 static LANGUAGE: &'static str = "Rust";
-static THRESHOLD: i32 = 10;
+const  THRESHOLD: i32 = 10;
 
 fn is_big(n: i32) -> bool {
     // Access constant in some function
@@ -14,15 +15,7 @@ fn main() {
     println!("The threshold is {}", THRESHOLD);
     println!("{} is {}", n, if is_big(n) { "big" } else { "small" });
 
-    // Error! Cannot modify a static item
+    // Error! Cannot modify a `const`.
     THRESHOLD = 5;
     // FIXME ^ Comment out this line
-
-    {
-        // String literals are references to read-only memory
-        let _static_string: &'static str = "In read-only memory";
-
-        // When `_static_string` goes out of scope, we can no longer refer to
-        // the underlying data, but the string remains in the read-only memory
-    }
 }

--- a/examples/constants/input.md
+++ b/examples/constants/input.md
@@ -1,12 +1,22 @@
-Constants can be declared in the global scope using the `static` keyword, the
-type annotation is obligatory in this case. These constants are placed in a
-read-only section of the memory and can be accessed in any other part of the
-program.
+Rust has two different types of constants which can be declared in any scope
+including global. Both require explicit type annotation:
 
-String literals like `"string"` can also be assigned to static variables. These
-variables have type signature `&'static str`, and are references to strings
-allocated in read-only memory. `'static` is a special lifetime that outlives
-all the other lifetimes, and indicates that the referenced data is available in
-all the scopes.
+* `const`: An unchangable value (the common case).
+* `static`: A possibly `mut`able variable with [`'static`][static] lifetime.
+
+One special case is the `"string"` literal. It can be assigned directly to a
+`static` variable without modification because it's type signature:
+`&'static str` has the required lifetime of `'static`. All other reference
+types must be specifically annotated so that they fulfill the `'static`
+lifetime. This may seem minor though because the required explicit annotation
+hides the distinction.
 
 {constants.play}
+
+### See also:
+
+[The `const`/`static` RFC](
+https://github.com/rust-lang/rfcs/blob/master/text/0246-const-vs-static.md),
+[`'static` lifetime][static]
+
+[static]: ./lifetime/static_lifetime.html

--- a/examples/lifetime/static_lifetime/input.md
+++ b/examples/lifetime/static_lifetime/input.md
@@ -1,0 +1,13 @@
+A `'static` lifetime is one which lasts for the lifetime of the running
+program. There are two ways to make a variable with `'static` lifetime:
+
+* Make a `"string"` literal which has type: `&'static str`.
+* Make a constant with the `static` declaration.
+
+{static_lifetime.play}
+
+### See also:
+
+[`'static` constants][static_const]
+
+[static_const]: ./constants.html

--- a/examples/lifetime/static_lifetime/static_lifetime.rs
+++ b/examples/lifetime/static_lifetime/static_lifetime.rs
@@ -1,0 +1,15 @@
+static NUM: i32 = 18;
+
+fn main() {
+    {
+        // String literals are references to read-only memory
+        let static_string = "In read-only memory";
+
+        // When `_static_string` goes out of scope, we can no longer refer to
+        // the underlying data, but the string remains in the read-only memory
+        println!("static_string holds: {}", static_string);
+    }
+    
+    println!("but now it's gone.");
+    println!("NUM: {} is still around though!", NUM);
+}

--- a/examples/structure.json
+++ b/examples/structure.json
@@ -80,9 +80,10 @@
   { "id": "lifetime", "title": "Lifetimes", "children": [
       { "id": "borrow", "title": "The borrow checker", "children": null },
       { "id": "fn", "title": "Functions", "children": null },
-      { "id": "struct", "title": "Structs", "children": null }
+      { "id": "struct", "title": "Structs", "children": null },
+      { "id": "static_lifetime", "title": "static", "children": null }
   ] },
-  { "id": "constants", "title": "Global constants", "children": null },
+  { "id": "constants", "title": "constants", "children": null },
   { "id": "methods", "title": "Methods", "children": null },
   { "id": "enum", "title": "Enums", "children": [
       { "id": "c_like", "title": "C-like", "children": null }


### PR DESCRIPTION
I've updated the bottom and I think it's better now than in my original change.

---

~~Here's a WIP for detailing the differences between `const` and `static`. I noticed it from [this](http://stackoverflow.com/questions/29225108/returning-slices-to-a-constant-array) stackoverflow question. I've still got to rewrite the `'static` lifetime section I added.~~

There are a bunch of other minor things that could be noted about constants on the RFC but probably shouldn't here.

Note: as written I'm not sure I like what I've written. There are differences between the two constants and what I've written seems accurate enough but I'm not sure it's worth pointing out here or not. Or that I've noted it in a good enough way.

Contants seem really simple. It doesn't seem right that they should need two pages...