### PR TITLE
Add the cfg! macro to cfg

### DIFF
--- a/examples/attribute/cfg/cfg.rs
+++ b/examples/attribute/cfg/cfg.rs
@@ -12,4 +12,11 @@ fn are_you_on_linux() {
 
 fn main() {
     are_you_on_linux();
+    
+    println!("Are you sure?");
+    if cfg!(target_os = "linux") {
+        println!("Yes. It's definitely linux!");
+    } else {
+        println!("Yes. It's definitely *not* linux!");
+    }
 }

--- a/examples/attribute/cfg/input.md
+++ b/examples/attribute/cfg/input.md
@@ -1,7 +1,16 @@
-The `cfg` attribute can be use to achieve conditional compilation.
+Conditional compilation is possible through two different operators:
+
+* the `cfg` attribute: `#[cfg(...)]` in attribute position
+* the `cfg!` macro: `cfg!(...)` in boolean expressions
+
+Both utilize identical syntax.
 
 {cfg.play}
 
-See [the
-Reference](http://doc.rust-lang.org/reference.html#conditional-compilation) for
-more details.
+### See also:
+
+[the reference][ref], [`cfg!`][cfg], and [macros][macros].
+
+[cfg]: http://doc.rust-lang.org/std/macro.cfg!.html
+[macros]: /macros.html
+[ref]: http://doc.rust-lang.org/reference.html#conditional-compilation


### PR DESCRIPTION
It seems like it'd be better if macros and attributes each had their own section but there aren't two sections yet and this seems useful. Can be reorganized better later if that ever happens.

Fixes https://github.com/rust-lang/rust-by-example/issues/516

cc @mikedilger