### PR TITLE
Fix breakage from 97f24a85965. Make hof cleaner.

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2,13 +2,13 @@
 name = "update"
 version = "0.0.1"
 dependencies = [
- "regex 0.1.26 (registry+https://github.com/rust-lang/crates.io-index)",
+ "regex 0.1.27 (registry+https://github.com/rust-lang/crates.io-index)",
  "rustc-serialize 0.3.12 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
 name = "regex"
-version = "0.1.26"
+version = "0.1.27"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]

--- a/examples/hof/hof.rs
+++ b/examples/hof/hof.rs
@@ -1,18 +1,14 @@
-#![feature(step_by)]
 #![feature(core)]
-
-// The `AdditiveIterator` trait adds the `sum` method to iterators
-use std::iter::AdditiveIterator;
 
 fn main() {
     println!("Find the sum of all the squared odd numbers under 1000");
-    let upper = 1000u32;
+    let upper = 1000;
 
     // Imperative approach
     // Declare accumulator variable
     let mut acc = 0;
     // Iterate: 0, 1, 2, ... to infinity
-    for n in (0u32..).step_by(1) {
+    for n in 0.. {
         // Square the number
         let n_squared = n * n;
 
@@ -27,17 +23,11 @@ fn main() {
     println!("imperative style: {}", acc);
 
     // Functional approach
-    let sum_of_squared_odd_numbers =
-        // All natural numbers
-        (0u32..).step_by(1).
-        // Squared
-        map(|n| n * n).
-        // Below upper limit
-        take_while(|&n| n < upper).
-        // That are odd
-        filter(|n| is_odd(*n)).
-        // Sum them
-        sum();
+    let sum_of_squared_odd_numbers: u32 =
+        (0..).map(|n| n * n)             // All natural numbers squared
+             .take_while(|&n| n < upper) // Below upper limit
+             .filter(|n| is_odd(*n))     // That are odd
+             .sum();                     // Sum them
     println!("functional style: {}", sum_of_squared_odd_numbers);
 }
 

--- a/src/example.rs
+++ b/src/example.rs
@@ -1,6 +1,5 @@
 use markdown::Markdown;
 use rustc_serialize::{Decodable,json};
-use std::iter::AdditiveIterator;
 use std::iter::repeat;
 use std::sync::mpsc;
 use std::io::prelude::*;
@@ -36,7 +35,9 @@ impl Example {
     pub fn count(&self) -> usize {
         match self.children {
             None => 1,
-            Some(ref children) => 1 + children.iter().map(|c| c.count()).sum(),
+            Some(ref children) => 1 + children.iter()
+                                              .map(|c| c.count())
+                                              .sum::<usize>(),
         }
     }
 


### PR DESCRIPTION
* Fixes https://github.com/rust-lang/rust/commit/97f24a85965c3c51a2c18be029091ae52bbd7920 breakage. AdditiveIterator is now inherent to iterator.
* No reason for `step_by(1)`
* Cleaned up [hof](http://rustbyexample.com/hof.html) a little