### PR TITLE
Fix first example of flow_control/while_let

### DIFF
--- a/examples/flow_control/while_let/input.md
+++ b/examples/flow_control/while_let/input.md
@@ -2,26 +2,28 @@ Similar to `if let`, `while let` can make awkward `match` sequences
 more tolerable. Consider, for example the following sequence:
 
 ```rust
-// Make `optional` of type `Option<i32>`
-let mut optional = Some(0);
+fn main() {
+    // Make `optional` of type `Option<i32>`
+    let mut optional = Some(0);
 
-// Repeatedly try this test.
-loop {
-    match optional {
-        // If `optional` destructures, evaluate the block.
-        Some(i) => {
-            if i > 9 {
-                println!("Greater than 9, quit!");
-                optional = None;
-            } else {
-                println!("`i` is `{:?}`. Try again.", i);
-                optional = Some(i + 1);
-            }
-            // ^ Requires 3 indentations!
-        },
-        // Quit when the destructure fails, meaning `break`.
-        _ => { break; }
-        // ^ Why should this be required? Seems superfluous.
+    // Repeatedly try this test.
+    loop {
+        match optional {
+            // If `optional` destructures, evaluate the block.
+            Some(i) => {
+                if i > 9 {
+                    println!("Greater than 9, quit!");
+                    optional = None;
+                } else {
+                    println!("`i` is `{:?}`. Try again.", i);
+                    optional = Some(i + 1);
+                }
+                // ^ Requires 3 indentations!
+            },
+            // Quit when the destructure fails, meaning `break`.
+            _ => { break; }
+            // ^ Why should this be required? Seems superfluous.
+        }
     }
 }
 ```


### PR DESCRIPTION
The original example doesn't compile.

Just wrapped it in the mandatory `fn main()` to avoid confusion.