### PR TITLE
Fix build failure by adding prefix

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,7 +3,7 @@ language: node_js
 sudo: true
 
 install:
-  - curl -L https://static.rust-lang.org/rustup.sh | sudo sh -s -- --channel=nightly
+  - curl -L https://static.rust-lang.org/rustup.sh | sudo sh -s -- --prefix=/usr --channel=nightly
 
 script:
   - rustc --version


### PR DESCRIPTION
A fix for the [travis build failure](https://travis-ci.org/rust-lang/rust-by-example#L91) was suggested by @brson at https://github.com/rust-lang/rustup/issues/3 . It worked with a multi-line rustup on [travis](https://travis-ci.org/mdinger/rust-by-example/builds/58376675).

I think I got the single line right but I gotta see if this succeeds. Should be safe to merge if travis succeeds.