### PR TITLE
Fix rustup

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2,13 +2,13 @@
 name = "update"
 version = "0.0.1"
 dependencies = [
- "regex 0.1.27 (registry+https://github.com/rust-lang/crates.io-index)",
+ "regex 0.1.28 (registry+https://github.com/rust-lang/crates.io-index)",
  "rustc-serialize 0.3.12 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
 name = "regex"
-version = "0.1.27"
+version = "0.1.28"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]

--- a/examples/threads/threads.rs
+++ b/examples/threads/threads.rs
@@ -1,3 +1,5 @@
+#![feature(scoped)]
+
 use std::thread;
 
 static NTHREADS: i32 = 10;

--- a/examples/timers/timers.rs
+++ b/examples/timers/timers.rs
@@ -1,45 +1,15 @@
-#![feature(old_io)]
-#![feature(std_misc)]
-#![feature(step_by)]
-
-use std::old_io::{timer, Timer};
-use std::time::duration::Duration;
-use std::sync::mpsc;
+use std::thread;
 
 fn main() {
-    let interval = Duration::milliseconds(1000);
-    // Create a timer object
-    let mut timer = Timer::new().unwrap();
+    let interval = 1000;
 
-    // Create a one-shot notification
-    // (superfluous type annotation)
-    let oneshot: mpsc::Receiver<()> = timer.oneshot(interval);
-
-    println!("Wait {} ms...", interval.num_milliseconds());
-
-    // Block the thread until notification arrives
-    let _ = oneshot.recv();
+    println!("Block for {} ms...", interval);
+    thread::park_timeout_ms(interval);
 
     println!("Done");
 
-    println!("Sleep for {} ms...", interval.num_milliseconds());
-
-    // This is equivalent to `timer.oneshot(interval).recv()`
-    timer::sleep(interval);
+    println!("Sleep for {} ms...", interval);
+    thread::sleep_ms(interval);
 
     println!("Done");
-
-    // The same timer can be used to generate periodic notifications
-    // (superfluous type annotation)
-    let metronome: mpsc::Receiver<()> = timer.periodic(interval);
-
-    println!("Countdown");
-    for i in (5i32..0).step_by(-1) {
-        // This loop will run once every second
-        let _ = metronome.recv();
-
-        println!("{}", i);
-    }
-    let _ = metronome.recv();
-    println!("Ignition!");
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,4 +1,5 @@
 #![feature(core)]
+#![feature(scoped)]
 
 #![deny(warnings)]
 #![feature(plugin)]


### PR DESCRIPTION
I don't have a lot of time but this makes rbe build. Timer could just as easily be deleted because it isn't in std currently. I replaced timer with thread functions where I could and just left it at that. Kinda sparse though. I'm not really that familiar with timer though.