### PR TITLE
lifetime/struct: Change int to i32

### DIFF
--- a/examples/lifetime/struct/struct.rs
+++ b/examples/lifetime/struct/struct.rs
@@ -1,7 +1,7 @@
 // First attempt: No explicit lifetimes
 // Error! Compiler needs explicit lifetime
 //struct Singleton {
-    //one: &mut int,
+    //one: &mut i32,
 //}
 // TODO ^ Try uncommenting this struct
 


### PR DESCRIPTION
If uncomment the struct Singleton.
Before this change, the error message is
```
error: use of undeclared type name `int`
```

After this change, the error message is
```
error: missing lifetime specifier [E0106]
```

And the second one it is exactly what we wanted.
