### PR TITLE
Don't explicitly prefer Courier New

### DIFF
--- a/node_modules/gitbook-plugin-rust-playpen/book/editor.css
+++ b/node_modules/gitbook-plugin-rust-playpen/book/editor.css
@@ -16,7 +16,7 @@
   width: 100%;
   min-height: 72px;
   font-size: 13px;
-  font-family: Menlo, Monaco, Consolas, "Courier New", monospace;
+  font-family: Menlo, Monaco, Consolas, monospace;
   white-space: pre-wrap;
 }
 
@@ -27,7 +27,7 @@
   padding: 10px;
   display: none;
   border-radius: 4px;
-  font-family: Menlo, Monaco, Consolas, "Courier New", monospace;
+  font-family: Menlo, Monaco, Consolas, monospace;
   white-space: normal;
 }
 


### PR DESCRIPTION
It looks worse than the default font on FreeType systems with low DPI.

See http://askubuntu.com/q/28419/19466 and http://ubuntuforums.org/showthread.php?t=1752937

I can provide screenshots if necessary.