### PR TITLE
Update rust

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3,7 +3,7 @@ name = "update"
 version = "0.0.1"
 dependencies = [
  "regex 0.1.29 (registry+https://github.com/rust-lang/crates.io-index)",
- "rustc-serialize 0.3.12 (registry+https://github.com/rust-lang/crates.io-index)",
+ "rustc-serialize 0.3.13 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -13,6 +13,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
 name = "rustc-serialize"
-version = "0.3.12"
+version = "0.3.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 

--- a/examples/str/str.rs
+++ b/examples/str/str.rs
@@ -1,5 +1,4 @@
 #![feature(collections)]
-#![feature(str_words)]
 
 fn main() {
     // (all the type annotations are superfluous)
@@ -9,7 +8,7 @@ fn main() {
 
     // Iterate over words in reverse, no new string is allocated
     println!("Words in reverse");
-    for word in pangram.words().rev() {
+    for word in pangram.split_whitespace().rev() {
         println!("> {}", word);
     }
 


### PR DESCRIPTION
There's another warning but I can't fix it yet because the fix which is to use `std::os::windows` doesn't seem to exist yet.