### PR TITLE
Remove old_io example

### DIFF
--- a/examples/mod/mod.rs
+++ b/examples/mod/mod.rs
@@ -22,12 +22,6 @@ mod my {
 fn main() {
     function();
 
-    // Items inside a module can be called using their full path
-    // The `println` function lives in the `stdio` module
-    // The `stdio` module lives in the `io` module
-    // And the `io` module lives in the `std` crate
-    std::old_io::stdio::println("Hello World!");
-
     // Error! `my::function` is private
     my::function();
     // TODO ^ Comment out this line


### PR DESCRIPTION
I don't know of a good replacement for this. Most simple functions are defined as methods which can be written with UFCS but I don't see the point in making the distinction here. Best I could think of is `from()` but I'm not thrilled with it. I don't see much harm in just dropping it.