### PR TITLE
RGB(i32, i32, i32) does not require name

### DIFF
--- a/examples/flow_control/match/destructuring/destructure_enum/enum.rs
+++ b/examples/flow_control/match/destructuring/destructure_enum/enum.rs
@@ -8,7 +8,7 @@ enum Color {
     Red,
     Blue,
     Green,
-    // This requires 3 `i32`s and a name.
+    // This requires 3 `i32`s.
     RGB(i32, i32, i32),
 }
 


### PR DESCRIPTION
The RGB(i32, i32, i32) does not require name, so fix the comment.

At least this is how I understood what the code does.