### PR TITLE
Be more clear about enum variants name

### DIFF
--- a/examples/flow_control/match/destructuring/destructure_enum/enum.rs
+++ b/examples/flow_control/match/destructuring/destructure_enum/enum.rs
@@ -8,8 +8,12 @@ enum Color {
     Red,
     Blue,
     Green,
-    // This requires 3 `i32`s.
-    RGB(i32, i32, i32),
+    // These likewise tie `u32` tuples to different names: color models.
+    RGB(u32, u32, u32),
+    HSV(u32, u32, u32),
+    HSL(u32, u32, u32),
+    CMY(u32, u32, u32),
+    CMYK(u32, u32, u32, u32),
 }
 
 fn main() {
@@ -22,9 +26,17 @@ fn main() {
         Color::Red   => println!("The color is Red!"),
         Color::Blue  => println!("The color is Blue!"),
         Color::Green => println!("The color is Green!"),
-        Color::RGB(r, g, b) => {
-            println!("Red: {:?}, green: {:?}, and blue: {:?}!", r, g, b);
-        },
+        Color::RGB(r, g, b) =>
+            println!("Red: {}, green: {}, and blue: {}!", r, g, b),
+        Color::HSV(h, s, v) =>
+            println!("Hue: {}, saturation: {}, value: {}!", h, s, v),
+        Color::HSL(h, s, l) =>
+            println!("Hue: {}, saturation: {}, lightness: {}!", h, s, l),
+        Color::CMY(c, m, y) =>
+            println!("Cyan: {}, magenta: {}, yellow: {}!", c, m, y),
+        Color::CMYK(c, m, y, k) =>
+            println!("Cyan: {}, magenta: {}, yellow: {}, key (black): {}!",
+                c, m, y, k),
         // Don't need another arm because all variants have been examined
     }
 }

--- a/examples/flow_control/match/destructuring/destructure_enum/input.md
+++ b/examples/flow_control/match/destructuring/destructure_enum/input.md
@@ -4,8 +4,10 @@ An `enum` is destructured similarly:
 
 ### See also:
 
-[`#[allow(...)]`][allow], [`enum`][enum], and [`#[derive(...)]`][derive]
+[`#[allow(...)]`][allow], [color models][color_models], [`enum`][enum],
+and [`#[derive(...)]`][derive]
 
-[enum]: /custom_types/enum.html
-[derive]: /trait/derive.html
 [allow]: /fn/unused.html
+[color_models]: http://en.wikipedia.org/wiki/Color_model
+[derive]: /trait/derive.html
+[enum]: /custom_types/enum.html


### PR DESCRIPTION
This is another take on https://github.com/rust-lang/rust-by-example/pull/565.

@jyrkiput This should be more proper than the previous change but is it actually clearer to you?

@steveklabnik Don't merge immediately. I'm hoping he replies and I'm curious if he will think it's clearer. I didn't actually need to list all the color spaces but I figured I might as well use the main ones I found on wikipedia.