### PR TITLE
generics/phantom/testcase_units: alleviate the syntactical heaviness of the types and bounds

### DIFF
--- a/examples/generics/phantom/testcase_units/input.md
+++ b/examples/generics/phantom/testcase_units/input.md
@@ -3,20 +3,22 @@ for a phantom type. The `Add` `trait` is examined below:
 
 ```rust
 // This construction would impose: `Self + RHS = Output`.
+// where RHS and Self are of the same type.
 pub trait Add<RHS = Self> {
     type Output;
 
     fn add(self, rhs: RHS) -> Self::Output;
 }
 
-// So, `Output` must be `T` and therefore, `T + T = T`.
-impl<T> Add<T, Output = T> for T {}
+// `Output` must be `T` so that `T + T = T`.
+impl Add for T {
+    type Output = T;
+    ...
+}
 
-// Similarly, this imposes: `S<T> + S<T> = S<T>` can be
-// added only when `T + T = T`.
-impl<S<T>> Add<S<T> for S<T> where
-    T: Add<T, Output = T> {
-    type Output = S<T>;
+// Similarly, this imposes: `T<U> + T<U> = T<U>`
+impl<U> Add for T<U> {
+    type Output = T<U>;
     ...
 }
 ```

--- a/examples/generics/phantom/testcase_units/input.md
+++ b/examples/generics/phantom/testcase_units/input.md
@@ -2,15 +2,15 @@ A useful method of unit conversions can be examined by implementing `Add`
 for a phantom type. The `Add` `trait` is examined below:
 
 ```rust
-// This construction would impose: `Self + RHS = Output`.
-// where RHS defaults to Self if not specified in the implementation
+// This construction would impose: `Self + RHS = Output`
+// where RHS defaults to Self if not specified in the implementation.
 pub trait Add<RHS = Self> {
     type Output;
 
     fn add(self, rhs: RHS) -> Self::Output;
 }
 
-// `Output` must be `T<U>` so that `T<U> + T<U> = T<U>`
+// `Output` must be `T<U>` so that `T<U> + T<U> = T<U>`.
 impl<U> Add for T<U> {
     type Output = T<U>;
     ...

--- a/examples/generics/phantom/testcase_units/input.md
+++ b/examples/generics/phantom/testcase_units/input.md
@@ -3,7 +3,7 @@ for a phantom type. The `Add` `trait` is examined below:
 
 ```rust
 // This construction would impose: `Self + RHS = Output`.
-// where RHS and Self are of the same type.
+// where RHS defaults to Self if not specified in the implementation
 pub trait Add<RHS = Self> {
     type Output;
 

--- a/examples/generics/phantom/testcase_units/input.md
+++ b/examples/generics/phantom/testcase_units/input.md
@@ -10,13 +10,7 @@ pub trait Add<RHS = Self> {
     fn add(self, rhs: RHS) -> Self::Output;
 }
 
-// `Output` must be `T` so that `T + T = T`.
-impl Add for T {
-    type Output = T;
-    ...
-}
-
-// Similarly, this imposes: `T<U> + T<U> = T<U>`
+// `Output` must be `T<U>` so that `T<U> + T<U> = T<U>`
 impl<U> Add for T<U> {
     type Output = T<U>;
     ...

--- a/examples/generics/phantom/testcase_units/units.rs
+++ b/examples/generics/phantom/testcase_units/units.rs
@@ -8,26 +8,30 @@ struct Inch;
 struct Mm;
 
 /// Length is phantom type with hidden parameter `Unit`
+/// f64 already implements the Clone and Copy traits
 #[derive(Debug, Clone, Copy)]
-struct Length<Unit, T>(T,PhantomData<Unit>);
+struct Length<Unit>(f64,PhantomData<Unit>);
 
-// This is similar to the header except `T` must also
-// implement `Clone` and `Copy.
-impl<Unit, T> Add<Length<Unit, T>> for Length<Unit, T> where
-    T: Add<T, Output=T> + Clone + Copy {
-    type Output = Length<Unit, T>;
+/// The Add trait defines the behavior of the `+` operator
+impl<Unit> Add for Length<Unit> {
+     type Output = Length<Unit>;
 
-    fn add(self, r: Length<Unit, T>) -> Length<Unit, T> {
-        Length(self.0 + r.0, PhantomData)
+	// add() returns a new Length struct containing the sum
+    fn add(self, rhs: Length<Unit>) -> Length<Unit> {
+		// `+` calls the Add implementation for f64
+        Length(self.0 + rhs.0, PhantomData)
     }
 }
 
 fn main() {
     // Specialize one_foot to have hidden parameter `Inch`
-    let one_foot:  Length<Inch, f32> = Length(12.0, PhantomData);
+    let one_foot:  Length<Inch> = Length(12.0, PhantomData);
     // one_meter has hidden parameter `Mm`
-    let one_meter: Length<Mm, f32>   = Length(1000.0, PhantomData);
+    let one_meter: Length<Mm>   = Length(1000.0, PhantomData);
 
+	// `+` calls the add() method we implemented for Length<Unit>
+	// Since Length implements Clone + Copy, add() does not consume
+	// one_foot and one_meter but makes a copy of them in `self` and `rhs`
     let two_feet = one_foot + one_foot;
     let two_meters = one_meter + one_meter;
 

--- a/examples/generics/phantom/testcase_units/units.rs
+++ b/examples/generics/phantom/testcase_units/units.rs
@@ -1,15 +1,15 @@
 use std::ops::Add;
 use std::marker::PhantomData;
 
-/// Null enumerations to define unit types
+/// Null enumerations define unit types.
 #[derive(Debug, Clone, Copy)]
 struct Inch;
 #[derive(Debug, Clone, Copy)]
 struct Mm;
 
-/// `Length` is phantom type with hidden parameter `Unit`
+/// `Length` is phantom type with hidden parameter `Unit`.
 ///
-/// `f64` already implements the `Clone` and `Copy` traits
+/// `f64` already implements the `Clone` and `Copy` traits.
 #[derive(Debug, Clone, Copy)]
 struct Length<Unit>(f64,PhantomData<Unit>);
 
@@ -19,30 +19,30 @@ impl<Unit> Add for Length<Unit> {
 
     // add() returns a new `Length` struct containing the sum.
     fn add(self, rhs: Length<Unit>) -> Length<Unit> {
-        // `+` calls the `Add` implementation for `f64`
+        // `+` calls the `Add` implementation for `f64`.
         Length(self.0 + rhs.0, PhantomData)
     }
 }
 
 fn main() {
-    // Specialize `one_foot` to have hidden parameter `Inch`
+    // Specializes `one_foot` to have hidden parameter `Inch`.
     let one_foot:  Length<Inch> = Length(12.0, PhantomData);
-    // `one_meter` has hidden parameter `Mm`
+    // `one_meter` has hidden parameter `Mm`.
     let one_meter: Length<Mm>   = Length(1000.0, PhantomData);
 
-    // `+` calls the `add()` method we implemented for `Length<Unit>`
+    // `+` calls the `add()` method we implemented for `Length<Unit>`.
     //
     // Since `Length` implements `Clone` + `Copy`, `add()` does not consume
-    // `one_foot` and `one_meter` but makes a copy of them in `self` and `rhs`
+    // `one_foot` and `one_meter` but makes a copy of them in `self` and `rhs`.
     let two_feet = one_foot + one_foot;
     let two_meters = one_meter + one_meter;
 
-    // Addition works
+    // Addition works.
     println!("one foot + one_foot = {:?}", two_feet);
     println!("one meter + one_meter = {:?}", two_meters);
 
-    // Nonsensical operations fail as they should
-    // Error: type mismatch
+    // Nonsensical operations fail as they should:
+    // Error: type mismatch.
     //let one_feter = one_foot + one_meter;
 }
 

--- a/examples/generics/phantom/testcase_units/units.rs
+++ b/examples/generics/phantom/testcase_units/units.rs
@@ -7,31 +7,33 @@ struct Inch;
 #[derive(Debug, Clone, Copy)]
 struct Mm;
 
-/// Length is phantom type with hidden parameter `Unit`
-/// f64 already implements the Clone and Copy traits
+/// `Length` is phantom type with hidden parameter `Unit`
+///
+/// `f64` already implements the `Clone` and `Copy` traits
 #[derive(Debug, Clone, Copy)]
 struct Length<Unit>(f64,PhantomData<Unit>);
 
-/// The Add trait defines the behavior of the `+` operator
+/// The `Add` trait defines the behavior of the `+` operator.
 impl<Unit> Add for Length<Unit> {
      type Output = Length<Unit>;
 
-	// add() returns a new Length struct containing the sum
+    // add() returns a new `Length` struct containing the sum.
     fn add(self, rhs: Length<Unit>) -> Length<Unit> {
-		// `+` calls the Add implementation for f64
+        // `+` calls the `Add` implementation for `f64`
         Length(self.0 + rhs.0, PhantomData)
     }
 }
 
 fn main() {
-    // Specialize one_foot to have hidden parameter `Inch`
+    // Specialize `one_foot` to have hidden parameter `Inch`
     let one_foot:  Length<Inch> = Length(12.0, PhantomData);
-    // one_meter has hidden parameter `Mm`
+    // `one_meter` has hidden parameter `Mm`
     let one_meter: Length<Mm>   = Length(1000.0, PhantomData);
 
-	// `+` calls the add() method we implemented for Length<Unit>
-	// Since Length implements Clone + Copy, add() does not consume
-	// one_foot and one_meter but makes a copy of them in `self` and `rhs`
+    // `+` calls the `add()` method we implemented for `Length<Unit>`
+    //
+    // Since `Length` implements `Clone` + `Copy`, `add()` does not consume
+    // `one_foot` and `one_meter` but makes a copy of them in `self` and `rhs`
     let two_feet = one_foot + one_foot;
     let two_meters = one_meter + one_meter;
 


### PR DESCRIPTION
I tried to retain the information on the bounds in a few comments because it does matter.
Close #582