### PR TITLE
meta/doc link to rustdoc leads to old location

### DIFF
--- a/examples/meta/doc/input.md
+++ b/examples/meta/doc/input.md
@@ -4,5 +4,5 @@ documentation. They are denoted by a `///`, and support [Markdown][2].
 
 {doc.play}
 
-[1]: https://github.com/rust-lang/rust/blob/master/src/doc/rustdoc.md
+[1]: http://doc.rust-lang.org/book/documentation.html
 [2]: https://en.wikipedia.org/wiki/Markdown


### PR DESCRIPTION
http://rustbyexample.com/meta/doc.html has a link to rustdoc which points to https://github.com/rust-lang/rust/blob/master/src/doc/rustdoc.md which has moved to book. 
This PR directly links to the rustdoc documentation.