### PR TITLE
std/str: Fix warning: deprecated item

### DIFF
--- a/examples/std/str/str.rs
+++ b/examples/std/str/str.rs
@@ -1,5 +1,3 @@
-#![feature(collections)]
-
 fn main() {
     // (all the type annotations are superfluous)
     // A reference to a string allocated in read only memory
@@ -33,7 +31,7 @@ fn main() {
     println!("Used characters: {}", trimmed_str);
 
     // Heap allocate a string
-    let alice = String::from_str("I like dogs");
+    let alice = String::from("I like dogs");
     // Allocate new memory and store the modified string there
     let bob: String = alice.replace("dog", "cat");
 


### PR DESCRIPTION
This sample throws a warning in line 36 currently, which does not appear to be intended: 

```
warning: use of deprecated item: use `String::from` instead, #[warn(deprecated)] on by default
```
As making the suggested change produces this warning instead: 
```
warning: unused or unknown feature, #[warn(unused_features)] on by default
``` 
...the reference to `#![feature(collections)]` is removed as well.