### PR TITLE
Suppress warnings on cast by default

### DIFF
--- a/examples/cast/cast.rs
+++ b/examples/cast/cast.rs
@@ -1,3 +1,6 @@
+// Suppress all warnings from casts which overflow.
+#![allow(overflowing_literals)]
+
 fn main() {
     let decimal = 65.4321_f32;
 


### PR DESCRIPTION
Fixes https://github.com/rust-lang/rust-by-example/issues/603