### PR TITLE
Correct explanation of where clauses

### DIFF
--- a/examples/generics/where/input.md
+++ b/examples/generics/where/input.md
@@ -13,7 +13,7 @@ impl <A, D> MyTrait<A, D> for YourType where
 ```
 
 * `where` clauses are more expressive than the normal syntax. They can
-apply bounds to arbitrary expressions rather than just types. The
+apply bounds to arbitrary types rather than just type parameters. The
 following example cannot be directly expressed without a `where` clause:
 
 {where.play}


### PR DESCRIPTION
Where clauses don't apply bounds to arbitrary expressions, they apply bounds to arbitrary types (`Option<T>`). The other form is limited in that it can only apply bounds to a type parameter (`T`).