### PR TITLE
lifetimes/structs expand unclear abbreviation

### DIFF
--- a/examples/scope/lifetime/struct/struct.rs
+++ b/examples/scope/lifetime/struct/struct.rs
@@ -12,7 +12,7 @@ struct Pair<'a, 'b> {
 }
 
 fn main() {
-    // Let's say that `one` has lifetime `o`
+    // Let us say that `one` has lifetime `o`
     let mut one = 1;
 
     {


### PR DESCRIPTION
The `'s` in `Let's` gets rendered like a lifetime, which could be confusing for some, especially in this particular chapter. 