### PR TITLE
Fix typo in comment on Iterator::find

### DIFF
--- a/examples/fn/closures/closure_analysis/iter_find/input.md
+++ b/examples/fn/closures/closure_analysis/iter_find/input.md
@@ -7,7 +7,7 @@ pub trait Iterator {
     // The type being iterated over.
     type Item;
 
-    // `any` takes `&mut self` meaning the caller may be borrowed
+    // `find` takes `&mut self` meaning the caller may be borrowed
     // and modified, but not consumed.
     fn find<P>(&mut self, predicate: P) -> Option<Self::Item> where
         // `FnMut` meaning any captured variable may at most be


### PR DESCRIPTION
The comment appears to have been copy-and-pasted from the `Iterator::any` example on the previous page, and the comment still had `and` instead of `find` in its description of the method.