### PR TITLE
Add same scope binding shadowing

### DIFF
--- a/examples/variable_bindings/scope/scope.rs
+++ b/examples/variable_bindings/scope/scope.rs
@@ -21,4 +21,9 @@ fn main() {
     // FIXME ^ Comment out this line
 
     println!("outer long: {}", long_lived_binding);
+    
+    // This binding also *shadows* the previous binding
+    let long_lived_binding = 'a';
+    
+    println!("outer long: {}", long_lived_binding);
 }


### PR DESCRIPTION
Add an example of shadowing a variable binding in the same scope.