### PR TITLE
Fix a typo and update some code samples

### DIFF
--- a/examples/generics/input.md
+++ b/examples/generics/input.md
@@ -6,7 +6,7 @@ over. This will require a rather involving syntax, though it seems
 straightforward at first.
 
 A type is specified as generic by `<A, B, ...>`. There are 2 basic rules
-regarding this which are applied *at* the types first use:
+regarding this which are applied *at* the type's first use:
 
 * Any type previously and locally specified to be generic is generic.
 * Everything else is concrete (non-generic).

--- a/examples/std_misc/file/create/input.md
+++ b/examples/std_misc/file/create/input.md
@@ -2,10 +2,9 @@ The `create` static method opens a file in write-only mode. If the file
 already existed, the old content is destroyed. Otherwise, a new file is
 created.
 
-{create.play}
+{create.rs}
 
-As in the previous example, the playpen won't allow file I/O, so you'll hit one
-of the failure paths. Here's the expected successful output:
+Here's the expected successful output:
 
 ```
 $ mkdir out
@@ -21,7 +20,7 @@ proident, sunt in culpa qui officia deserunt mollit anim id est laborum.
 ```
 
 (As in the previous example, you are encouraged to test this example under
-failure conditions)
+failure conditions.)
 
 There is also a more generic `open_mode` method that can open files in other
 modes like: read+write, append, etc.

--- a/examples/std_misc/file/open/input.md
+++ b/examples/std_misc/file/open/input.md
@@ -3,9 +3,8 @@ The `open` static method can be used to open a file in read-only mode.
 A `File` owns a resource, the file descriptor and takes care of closing the
 file when it is `drop`ed.
 
-{open.play}
+{open.rs}
 
-The playpen doesn't allow file I/O, so you'll hit one of the failure paths.
 Here's the expected successful output:
 
 ```

--- a/examples/std_misc/fs/input.md
+++ b/examples/std_misc/fs/input.md
@@ -1,10 +1,9 @@
 The `std::io::fs` module contains several functions that deal with the
 filesystem.
 
-{fs.play}
+{fs.rs}
 
-You won't be able to run the previous code, because the playpen doesn't allow
-file operations. Here's the expected successful output:
+Here's the expected successful output:
 
 ```
 $ rustc fs.rs && ./fs
@@ -45,4 +44,3 @@ a
 [`cfg!`][cfg]
 
 [cfg]: /attribute/cfg.html
-


### PR DESCRIPTION
- Typo: add an apostrophe to a possessive that was missing it.
- Code samples: switch from playpen to built-in sample type in all the file I/O examples, since their being editable is at best irrelevant and at worst confusing. Update the verbiage around them accordingly, no longer referencing the inability to run the samples in the playpen.

I took this route on these code samples to bring it in line with the FFI examples, which likewise do not use the playpen.