### PR TITLE
Fix thread::scoped warning

### DIFF
--- a/examples/std_misc/threads/threads.rs
+++ b/examples/std_misc/threads/threads.rs
@@ -1,15 +1,21 @@
-#![feature(scoped)]
-
 use std::thread;
 
 static NTHREADS: i32 = 10;
 
 // This is the `main` thread
 fn main() {
+    // Make a vector to hold the children which are spawned.
+    let mut children = vec![];
+
     for i in 0..NTHREADS {
         // Spin up another thread
-        let _ = thread::scoped(move || {
+        children.push(thread::spawn(move || {
             println!("this is thread number {}", i)
-        });
+        }));
+    }
+
+    for child in children {
+        // Wait for the thread to finish. Returns a result.
+        let _ = child.join();
     }
 }


### PR DESCRIPTION
This fixes the last warning.