### PR TITLE
Travis :arrows_clockwise:

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,10 +1,15 @@
-language: node_js
+language: rust
 sudo: false
 
+rust:
+  - stable
+  - beta
+  - nightly
+
 install:
-  - curl -L https://static.rust-lang.org/rustup.sh | sh -s -- --yes --prefix=$PWD --disable-sudo --disable-ldconfig
-  - export PATH=$PATH:$PWD/bin
-  - export LD_LIBRARY_PATH=$LD_LIBRARY_PATH:$PWD/lib
+  - curl https://nodejs.org/dist/v0.12.7/node-v0.12.7-sunos-x64.tar.gz > node.tar.gz
+  - tar xf node.tar.gz
+  - export PATH=$PATH:$pwd/node-v0.12.7-linux-x64/bin
 
 script:
   - rustc --version


### PR DESCRIPTION
We currently have a node Travis environment, and we install Rust into it.

But that's not great. See, it'd be nice to be able to test against all three
channels of Rust. So instead, let's make this a Rust env, and install Node into it.