### PR TITLE
print_display/testcase_list: fix issue with zero-length vector

### DIFF
--- a/examples/hello/print/print_display/testcase_list/testcase_list.rs
+++ b/examples/hello/print/print_display/testcase_list/testcase_list.rs
@@ -8,18 +8,20 @@ impl fmt::Display for List {
         // Dereference `self` and create a reference to `vec`
         // via destructuring.
         let List(ref vec) = *self;
-        let len = vec.len(); // Save the vector length in `len`.
+
+        try!(write!(f, "["));
 
         // Iterate over `vec` in `v` while enumerating the iteration
         // count in `count`.
         for (count, v) in vec.iter().enumerate() {
-            // For every element except the last, format `write!`
-            // with a comma. Use `try!` to return on errors.
-            if count < len - 1 { try!(write!(f, "{}, ", v)) }
+            // For every element except the first, add a comma
+            // before calling `write!`. Use `try!` to return on errors.
+            if count != 0 { try!(write!(f, ", ")); }
+            try!(write!(f, "{}", v));
         }
 
-        // `write!` the last value without special formatting.
-        write!(f, "{}", vec[len-1])
+        // Close the opened bracket and return a fmt::Result value
+        write!(f, "]")
     }
 }
 


### PR DESCRIPTION
The implementation given to implement fmt::Display with a Vec
works fine, as long as the vector is not empty. If it is,
vec[len-1] is accessed, leading to a run-time panic.

The issue is that a fmt::Result value must be returned in the end,
and as the example did not used any brackets to surround the printed
values, empty vector would have meant nothing to print. A "Ok(())"
could be returned, but this isn't elegant or best for an example of
pretty Rust code.

'[' and ']' are therefore added around the printed values, and the
code is reworked to print a comma before every element that is not
the first one.