### PR TITLE
std_misc/arg/matching: fix match_args.rs to match input.md

### DIFF
--- a/examples/std_misc/arg/matching/match_args.rs
+++ b/examples/std_misc/arg/matching/match_args.rs
@@ -26,10 +26,9 @@ fn main() {
         },
         // one argument passed
         2 => {
-            if &42 == &args[1].parse().unwrap() {
-                println!("This is the answer!");
-            } else {
-                println!("This is not the answer.");
+            match args[1].parse() {
+                Ok(42) => println!("This is the answer!"),
+                _ => println!("This is not the answer."),
             }
         },
         // one command and one argument passed


### PR DESCRIPTION
This patch fixes:

    $ ./match_args Rust
    thread '<main>' panicked at 'called `Result::unwrap()` on an `Err` value: ParseIntError { kind: InvalidDigit }', ../src/libcore/result.rs:732

to:

    $ ./match_args Rust
    This is not the answer.

which corresponds to the output expected by `input.md`.