### PR TITLE
Max line length is 99 not 79

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -64,7 +64,7 @@ See the [README][readme] for details about how the static site is generated.
 
 ## Markdown (.md)
 
-* Lines should contain a maximum of 79 characters.
+* Lines should contain a maximum of 99 characters.
 * Use reference style hyperlinks, for example:
 
 Instead of:
@@ -80,7 +80,7 @@ Use:
 
 ## Rust code (.rs)
 
-* Lines should contain a maximum of 79 characters.
+* Lines should contain a maximum of 99 characters.
 * In comments, types, methods, macros and variables should be wrapped in
   backticks, e.g. ``` `println!` ```
 


### PR DESCRIPTION
Forgot to update this in https://github.com/rust-lang/rust-by-example/pull/561. Specifically in 13f494b1046eeb8ecfe84b82c9899cb02171b400.