### PR TITLE
Add an exlicit activity.

### DIFF
--- a/examples/hello/input.md
+++ b/examples/hello/input.md
@@ -5,6 +5,14 @@ This is the source code of the traditional Hello World program.
 `println!` is a [*macro*][macros] that prints text to the
 console.
 
+Activity: Click 'Run' above to see the expected output. Next, add a new
+line with a second `println!` macro so that the output
+shows:
+```
+Hello World!
+I'm a Rustacian!
+```
+
 A binary can be generated using the Rust compiler: `rustc`.
 
 ```


### PR DESCRIPTION
After working through rust-by-example, one thing I missed from previous experience with the go-lang tour is explicit activities.

If it's wanted, I'd like to go through and add explicit bite-sized activities where appropriate, so that each step has a sense of accomplishment, and involves people in *doing* the learning, not just reading and running the examples.

No problem if it's not wanted, or if there's a different format the activities should take. If it is wanted, I'll keep working my way through again adding them.

Thanks for all the work!