### PR TITLE
Activities 2

### DIFF
--- a/examples/hello/input.md
+++ b/examples/hello/input.md
@@ -5,7 +5,7 @@ This is the source code of the traditional Hello World program.
 `println!` is a [*macro*][macros] that prints text to the
 console.
 
-Activity: Click 'Run' above to see the expected output. Next, add a new
+**Activity**: Click 'Run' above to see the expected output. Next, add a new
 line with a second `println!` macro so that the output
 shows:
 ```

--- a/examples/hello/print/input.md
+++ b/examples/hello/print/input.md
@@ -10,6 +10,14 @@ be checked at compile time.
 
 {print.play}
 
+**Activities**:
+ * Fix the two isses in the above code (see FIXME) so that it runs
+without error.
+ * Add a `println!` macro that prints: `Pi is roughly 3.143`, using twenty-two
+   divided by seven to generate the estimate for Pi. (Hint: you may need to
+   check the [`std::fmt`][fmt] documentation for setting the number of
+   decimals to display)
+
 [`std::fmt`][fmt] contains many [`traits`][traits] which govern the display
 of text. The base form of two important ones are listed below:
 


### PR DESCRIPTION
Updates the first activity to use bold so it's easy to identify and skip if wanted.

Added a second example activities section for the print example.

The bold seems to work well - it's simple, and as long as we only ever have one paragraph for an activities section (ie. one sentence or a bullet list of activities like the print example), it's easy to identify the whole block.

I'll do larger branches from here on in - assuming the format is OK.