### PR TITLE
Activities 2b

### DIFF
--- a/examples/hello/input.md
+++ b/examples/hello/input.md
@@ -5,14 +5,6 @@ This is the source code of the traditional Hello World program.
 `println!` is a [*macro*][macros] that prints text to the
 console.
 
-**Activity**: Click 'Run' above to see the expected output. Next, add a new
-line with a second `println!` macro so that the output
-shows:
-```
-Hello World!
-I'm a Rustacian!
-```
-
 A binary can be generated using the Rust compiler: `rustc`.
 
 ```
@@ -24,6 +16,16 @@ $ rustc hello.rs
 ```
 $ ./hello
 Hello World!
+```
+
+### Activity
+
+Click 'Run' above to see the expected output. Next, add a new
+line with a second `println!` macro so that the output
+shows:
+```
+Hello World!
+I'm a Rustacian!
 ```
 
 [macros]: ./macros.html

--- a/examples/hello/input.md
+++ b/examples/hello/input.md
@@ -5,7 +5,7 @@ This is the source code of the traditional Hello World program.
 `println!` is a [*macro*][macros] that prints text to the
 console.
 
-Activity: Click 'Run' above to see the expected output. Next, add a new
+**Activity**: Click 'Run' above to see the expected output. Next, add a new
 line with a second `println!` macro so that the output
 shows:
 ```

--- a/examples/hello/print/input.md
+++ b/examples/hello/print/input.md
@@ -11,8 +11,8 @@ be checked at compile time.
 {print.play}
 
 **Activities**:
- * Fix the two isses in the above code (see FIXME) so that it runs
-without error.
+ * Fix the two isses in the above code (see FIXME) so that it runs without
+   error.
  * Add a `println!` macro that prints: `Pi is roughly 3.143`, using twenty-two
    divided by seven to generate the estimate for Pi. (Hint: you may need to
    check the [`std::fmt`][fmt] documentation for setting the number of

--- a/examples/hello/print/input.md
+++ b/examples/hello/print/input.md
@@ -29,7 +29,7 @@ for these types. To print text for custom types, more steps are required.
    check the [`std::fmt`][fmt] documentation for setting the number of
    decimals to display)
 
-### See also:
+### See also
 
 [`std::fmt`][fmt], [`macros`][macros], [`struct`][structs],
 and [`traits`][traits]

--- a/examples/hello/print/input.md
+++ b/examples/hello/print/input.md
@@ -10,6 +10,14 @@ be checked at compile time.
 
 {print.play}
 
+**Activities**:
+ * Fix the two isses in the above code (see FIXME) so that it runs
+without error.
+ * Add a `println!` macro that prints: `Pi is roughly 3.143`, using twenty-two
+   divided by seven to generate the estimate for Pi. (Hint: you may need to
+   check the [`std::fmt`][fmt] documentation for setting the number of
+   decimals to display)
+
 [`std::fmt`][fmt] contains many [`traits`][traits] which govern the display
 of text. The base form of two important ones are listed below:
 

--- a/examples/hello/print/input.md
+++ b/examples/hello/print/input.md
@@ -10,14 +10,6 @@ be checked at compile time.
 
 {print.play}
 
-**Activities**:
- * Fix the two isses in the above code (see FIXME) so that it runs without
-   error.
- * Add a `println!` macro that prints: `Pi is roughly 3.143`, using twenty-two
-   divided by seven to generate the estimate for Pi. (Hint: you may need to
-   check the [`std::fmt`][fmt] documentation for setting the number of
-   decimals to display)
-
 [`std::fmt`][fmt] contains many [`traits`][traits] which govern the display
 of text. The base form of two important ones are listed below:
 
@@ -27,6 +19,15 @@ friendly fashion.
 
 Here, `fmt::Display` was used because the std library provides implementations
 for these types. To print text for custom types, more steps are required.
+
+### Activities
+
+ * Fix the two isses in the above code (see FIXME) so that it runs without
+   error.
+ * Add a `println!` macro that prints: `Pi is roughly 3.143`, using twenty-two
+   divided by seven to generate the estimate for Pi. (Hint: you may need to
+   check the [`std::fmt`][fmt] documentation for setting the number of
+   decimals to display)
 
 ### See also:
 


### PR DESCRIPTION
One alternative mentioned by @mdinger . 

https://github.com/absoludity/rust-by-example/blob/activities-2b/examples/hello/print/input.md

Given that each page/example is short (is there nearly always just one example per page?), it seems to be fine having the activities at the bottom with a header. I don't mind either way.

Another one to come.