### PR TITLE
Activities 2c

### DIFF
--- a/examples/hello/input.md
+++ b/examples/hello/input.md
@@ -5,13 +5,13 @@ This is the source code of the traditional Hello World program.
 `println!` is a [*macro*][macros] that prints text to the
 console.
 
-**Activity**: Click 'Run' above to see the expected output. Next, add a new
-line with a second `println!` macro so that the output
-shows:
-```
-Hello World!
-I'm a Rustacian!
-```
+> **Activity**: Click 'Run' above to see the expected output. Next, add a new
+> line with a second `println!` macro so that the output
+> shows:
+> ```
+> Hello World!
+> I'm a Rustacian!
+> ```
 
 A binary can be generated using the Rust compiler: `rustc`.
 

--- a/examples/hello/input.md
+++ b/examples/hello/input.md
@@ -5,7 +5,7 @@ This is the source code of the traditional Hello World program.
 `println!` is a [*macro*][macros] that prints text to the
 console.
 
-Activity: Click 'Run' above to see the expected output. Next, add a new
+**Activity**: Click 'Run' above to see the expected output. Next, add a new
 line with a second `println!` macro so that the output
 shows:
 ```

--- a/examples/hello/print/input.md
+++ b/examples/hello/print/input.md
@@ -11,8 +11,8 @@ be checked at compile time.
 {print.play}
 
 **Activities**:
- * Fix the two isses in the above code (see FIXME) so that it runs
-without error.
+ * Fix the two isses in the above code (see FIXME) so that it runs without
+   error.
  * Add a `println!` macro that prints: `Pi is roughly 3.143`, using twenty-two
    divided by seven to generate the estimate for Pi. (Hint: you may need to
    check the [`std::fmt`][fmt] documentation for setting the number of

--- a/examples/hello/print/input.md
+++ b/examples/hello/print/input.md
@@ -10,6 +10,14 @@ be checked at compile time.
 
 {print.play}
 
+**Activities**:
+ * Fix the two isses in the above code (see FIXME) so that it runs
+without error.
+ * Add a `println!` macro that prints: `Pi is roughly 3.143`, using twenty-two
+   divided by seven to generate the estimate for Pi. (Hint: you may need to
+   check the [`std::fmt`][fmt] documentation for setting the number of
+   decimals to display)
+
 [`std::fmt`][fmt] contains many [`traits`][traits] which govern the display
 of text. The base form of two important ones are listed below:
 

--- a/examples/hello/print/input.md
+++ b/examples/hello/print/input.md
@@ -10,13 +10,13 @@ be checked at compile time.
 
 {print.play}
 
-**Activities**:
- * Fix the two isses in the above code (see FIXME) so that it runs without
-   error.
- * Add a `println!` macro that prints: `Pi is roughly 3.143`, using twenty-two
-   divided by seven to generate the estimate for Pi. (Hint: you may need to
-   check the [`std::fmt`][fmt] documentation for setting the number of
-   decimals to display)
+> **Activities**:
+>  * Fix the two isses in the above code (see FIXME) so that it runs without
+>    error.
+>  * Add a `println!` macro that prints: `Pi is roughly 3.143`, using twenty-two
+>    divided by seven to generate the estimate for Pi. (Hint: you may need to
+>    check the [`std::fmt`][fmt] documentation for setting the number of
+>    decimals to display)
 
 [`std::fmt`][fmt] contains many [`traits`][traits] which govern the display
 of text. The base form of two important ones are listed below:


### PR DESCRIPTION
Third option for @mdinger  - using quote formatting.

https://github.com/absoludity/rust-by-example/blob/activities-2c/examples/hello/print/input.md

Certainly delineates the activity from the main text in a more obvious way. And allows the same formatting within the quote.

Let me know what you prefer and I'll go with that :)