### PR TITLE
Activities 3

### DIFF
--- a/examples/hello/print/fmt/input.md
+++ b/examples/hello/print/fmt/input.md
@@ -26,7 +26,7 @@ RGB (128, 255, 90) 0x80FF5A
 RGB (0, 3, 254) 0x0003FE
 RGB (0, 0, 0) 0x000000
 ```
-Two hints in case you get stuck:
+Two hints if you get stuck:
  * You [may need to list each color more than once][argument_types],
  * You can [pad with zeros to a width of 2][fmt_width] with `:02`.
 

--- a/examples/hello/print/fmt/input.md
+++ b/examples/hello/print/fmt/input.md
@@ -14,16 +14,27 @@ handles cases where the argument type is left unspecified: `{}` for instance.
 
 {show.play}
 
-Here's the full list of formatting traits and their respective argument types:
+You can view a [full list of formatting traits][fmt_traits] and their argument
+types in the [`std::fmt`][fmt] documentation.
 
-* *unspecified* -> `Display`
-* `?` -> `Debug`
-* `o` -> `Octal`
-* `x` -> `LowerHex`
-* `X` -> `UpperHex`
-* `p` -> `Pointer`
-* `b` -> `Binary`
-* `e` -> `LowerExp`
-* `E` -> `UpperExp`
+### Activity
+Add an implementation of the `fmt::Display` trait for the `Color` struct above
+so that the output displays as:
 
+```
+RGB (128, 255, 90) 0x80FF5A
+RGB (0, 3, 254) 0x0003FE
+RGB (0, 0, 0) 0x000000
+```
+Two hints in case you get stuck:
+ * You [may need to list each color more than once][argument_types],
+ * You can [pad with zeros to a width of 2][fmt_width] with `:02`.
+
+### See also
+[`std::fmt`][fmt]
+
+[argument_types]: http://doc.rust-lang.org/std/fmt/#argument-types
 [deadbeef]: https://en.wikipedia.org/wiki/Deadbeef#Magic_debug_values
+[fmt]: http://doc.rust-lang.org/std/fmt/
+[fmt_traits]: http://doc.rust-lang.org/std/fmt/#formatting-traits
+[fmt_width]: http://doc.rust-lang.org/std/fmt/#width

--- a/examples/hello/print/fmt/show.rs
+++ b/examples/hello/print/fmt/show.rs
@@ -21,6 +21,13 @@ impl Display for City {
     }
 }
 
+#[derive(Debug)]
+struct Color {
+    red: u8,
+    green: u8,
+    blue: u8,
+}
+
 fn main() {
     for city in [
         City { name: "Dublin", lat: 53.347778, lon: -6.259722 },
@@ -29,5 +36,13 @@ fn main() {
     ].iter() {
         println!("{}", *city);
     }
+    for color in [
+        Color { red: 128, green: 255, blue: 90 },
+        Color { red: 0, green: 3, blue: 254 },
+        Color { red: 0, green: 0, blue: 0 },
+    ].iter() {
+        // Switch this to use {} once you've added an implementation
+        // for fmt::Display
+        println!("{:?}", *color)
+    }
 }
-

--- a/examples/hello/print/print_debug/input.md
+++ b/examples/hello/print/print_debug/input.md
@@ -25,7 +25,7 @@ All std library types automatically are printable with `{:?}` too:
 So `fmt::Debug` definitely makes this printable but sacrifices some
 elegance. Manually implementing `fmt::Display` will fix that.
 
-### See also:
+### See also
 
 [attributes][attributes], [`derive`][derive], [`std::fmt`][fmt],
 and [`struct`][structs]

--- a/examples/hello/print/print_display/input.md
+++ b/examples/hello/print/print_display/input.md
@@ -48,7 +48,16 @@ therefore cannot be used. `std::fmt` has many such [`traits`][traits] and
 each requires it's own implementation. This is detailed further in
 [`std::fmt`][fmt].
 
-### See also:
+### Activity
+
+Using the `Point2` struct as an example, add a Complex struct to the example
+above. When printed in the same way, the output should be:
+```
+Display: 3.3 + 7.2i
+Debug: Complex { real: 3.3, imag: 7.2 }
+```
+
+### See also
 
 [`derive`][derive], [`std::fmt`][fmt], [macros], [`struct`][structs],
 [`trait`][traits], and [use][use]

--- a/examples/hello/print/print_display/input.md
+++ b/examples/hello/print/print_display/input.md
@@ -50,8 +50,9 @@ each requires it's own implementation. This is detailed further in
 
 ### Activity
 
-Using the `Point2` struct as an example, add a Complex struct to the example
-above. When printed in the same way, the output should be:
+After checking the output of the above example, use the `Point2` struct as
+guide to add a Complex struct to the example. When printed in the same
+way, the output should be:
 ```
 Display: 3.3 + 7.2i
 Debug: Complex { real: 3.3, imag: 7.2 }

--- a/examples/hello/print/print_display/testcase_list/input.md
+++ b/examples/hello/print/print_display/testcase_list/input.md
@@ -16,7 +16,7 @@ straightforward:
 
 {testcase_list.play}
 
-### See also:
+### See also
 
 [`for`][for], [`ref`][ref], [`Result`][result], [`struct`][struct],
 [`try!`][try], and [`vec!`][vec]

--- a/examples/primitives/tuples/input.md
+++ b/examples/primitives/tuples/input.md
@@ -19,8 +19,8 @@ use tuples to return multiple values, as tuples can hold any number of values.
     accepts a matrix as an argument, and returns a matrix in which two elements
     have been swapped. For example:
 ```
-print!("Matrix:\n{}", matrix)
-print!("Transpose:\n{}", transpose(matrix))
+println!("Matrix:\n{}", matrix)
+println!("Transpose:\n{}", transpose(matrix))
 ```
 results in the output:
 ```

--- a/examples/primitives/tuples/input.md
+++ b/examples/primitives/tuples/input.md
@@ -4,3 +4,32 @@ using parentheses `()`, and each tuple itself is a value with type signature
 use tuples to return multiple values, as tuples can hold any number of values.
 
 {tuples.play}
+
+### Activity
+
+ 1. *Recap*: Add the `fmt::Display` trait to the Matrix `struct` in the above example,
+    so that if you switch from printing the debug format `{:?}` to the display
+    format `{}`, you see the following output:
+```
+( 1.1 1.2 )
+( 2.1 2.2 )
+```
+    You may want to refer back to the example for [print display](print_display).
+ 2. Add a `transpose` function using the `reverse` function as a template, which
+    accepts a matrix as an argument, and returns a matrix in which two elements
+    have been swapped. For example:
+```
+print!("Matrix:\n{}", matrix)
+print!("Transpose:\n{}", transpose(matrix))
+```
+results in the output:
+```
+Matrix:
+( 1.1 1.2 )
+( 2.1 2.2 )
+Transpose:
+( 1.1 2.1 )
+( 1.2 2.2 )
+```
+
+[print_display]: /hello/print/print_display.html

--- a/examples/primitives/tuples/tuples.rs
+++ b/examples/primitives/tuples/tuples.rs
@@ -6,6 +6,10 @@ fn reverse(pair: (i32, bool)) -> (bool, i32) {
     (boolean, integer)
 }
 
+// The following struct is for the activity.
+#[derive(Debug)]
+struct Matrix(f32, f32, f32, f32);
+
 fn main() {
     // A tuple with a bunch of different types
     let long_tuple = (1u8, 2u16, 3u32, 4u64,
@@ -32,10 +36,14 @@ fn main() {
     // from a literal surrounded by parentheses
     println!("one element tuple: {:?}", (5u32,));
     println!("just an integer: {:?}", (5u32));
-    
+
     //tuples can be destructured to create bindings
     let tuple = (1, "hello", 4.5, true);
 
     let (a, b, c, d) = tuple;
     println!("{:?}, {:?}, {:?}, {:?}", a, b, c, d);
+
+    let matrix = Matrix(1.1, 1.2, 2.1, 2.2);
+    println!("{:?}", matrix)
+
 }


### PR DESCRIPTION
Adds activities for the print_display, format and tuples examples.

For the format page, I replaced the full list of formatting traits with a link. No problem to put it back if that's not wanted (it just seemed easy to open up if interested).