### PR TITLE
Grammatical fixes for its/it's

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -15,7 +15,7 @@ not clear". The example id is the relative path in the URL without the html
 extension, e.g. URL: `http://rustbyexample.com/variables/scope.html` -> id:
 `variables/scope`
 
-If its something simple like a typo, you can send a PR directly.
+If it's something simple like a typo, you can send a PR directly.
 
 # Sending a PR for a small fix
 

--- a/examples/fn/closures/anonymity/input.md
+++ b/examples/fn/closures/anonymity/input.md
@@ -19,7 +19,7 @@ is stored until calling.
 Since this new type is of unknown type, any usage in a function will require
 generics. However, an unbounded type parameter (`<T>`) would still be ambiguous
 and not be allowed. Thus, bounding by one of the `traits`: `Fn`, `FnMut`, or
-`FnOnce` (which it implements) is sufficient to specify it's type.
+`FnOnce` (which it implements) is sufficient to specify its type.
 
 {anonymity.play}
 

--- a/examples/hello/print/print_display/input.md
+++ b/examples/hello/print/print_display/input.md
@@ -45,7 +45,7 @@ This is not a problem though because for any new *container* type which is
 
 So, `fmt::Display` has been implemented but `fmt::Binary` has not, and
 therefore cannot be used. `std::fmt` has many such [`traits`][traits] and
-each requires it's own implementation. This is detailed further in
+each requires its own implementation. This is detailed further in
 [`std::fmt`][fmt].
 
 ### Activity


### PR DESCRIPTION
Three very small fixes, each replacing its for it's, or vice versa. These were all of the examples I could find in the current master branch.