### PR TITLE
Add new error handling section

### DIFF
--- a/examples/error/error.rs
+++ b/examples/error/error.rs
@@ -1,0 +1,12 @@
+fn give_princess(gift: &str) {
+    // Princesses hate snakes so definitely stop the computation while
+    // she shouts her dislike.
+    if gift == "snake" { panic!("AAAaaaaa!!!!"); }
+
+    println!("I love {}s!!!!!", gift);
+}
+
+fn main() {
+    give_princess("teddy bear");
+    give_princess("snake");
+}

--- a/examples/error/error_vs_absence/input.md
+++ b/examples/error/error_vs_absence/input.md
@@ -1,0 +1,23 @@
+Previously, we have used the type `Option` to annotate that absense is a possibility. This
+absense sometimes appears as an error, for example when `None` is unwrapped. In the more
+general case where there may be multiple failure points for a multitude of different reasons,
+an `Option` can be replaced by the more general `Result` type. A `Result<T, E>` has these
+variants:
+
+* `Ok<T>`: An element `T` was found
+* `Err<E>`: An error was found with element `E`
+
+Similar to `Option`, `Result` also contains the `unwrap()` method which yields the element
+`T` or calls `panic!()`. So far, this should seem similar to `Option`:
+
+{result.play}
+
+Clearly, panicking on an `Err` leaves an unhelpful error message. Do we even know anything
+about libcore that the error is telling us all about? There must be a better way.
+
+
+### See also:
+
+[`Result`][result]
+
+[result]: http://doc.rust-lang.org/std/result/enum.Result.html

--- a/examples/error/error_vs_absence/result.rs
+++ b/examples/error/error_vs_absence/result.rs
@@ -1,0 +1,14 @@
+fn double_number(number_str: &str) -> i32 {
+    // It might not always be possible to parse a string into the other type
+    // so `parse()` returns a `Result` indicating possible failure. Let's
+    // just try `unwrap()` to get the number out. Will it bite us?
+    2 * number_str.parse::<i32>().unwrap()
+}
+
+fn main() {
+    let twenty = double_number("10");
+    println!("double is {}", twenty);
+
+    let tt = double_number("t");
+    println!("double is {}", tt);
+}

--- a/examples/error/input.md
+++ b/examples/error/input.md
@@ -1,0 +1,16 @@
+Error handling is the process of handling the possibility of failure. For example, failing to
+read a file and then continuing to use that *bad* input regardless clearly would be problematic.
+Error handling allows us to notice and handle those errors in some explicit fashion, saving the
+rest of the program from pollution.
+
+The simplest error handling mechanism we will see is the `panic`; it prints an error message,
+starts unwinding the task, and usually exits the program. Consider the following example:
+
+{error.play}
+
+This easily shows that we can induce program failure at will but it has a problem: what happens
+if the princess is *not* given a gift? Technically, we *could* explicitly test this with a check
+against the null string (`""`) the same way as with the snake however this is not reliable. The
+problem is that programmers do not habitually make these checks unless required by the compiler.
+In order for this to always be reliable, we require the compiler to point out the cases where there
+may not be a gift. `str` does not do that for us; we require something else called `Option`.

--- a/examples/error/limits_of_strings/input.md
+++ b/examples/error/limits_of_strings/input.md
@@ -1,0 +1,27 @@
+We have been using `Strings` as errors for a while. In fact, this is somewhat limiting as
+an error type. Below are the criteria for a good error type. `String` nicely fulfills the first
+two but not the second two:
+
+* Represents different errors with the same type
+* Presents nice error messages to the user
+* Is easily type comparable. Consider comparing these two types:
+    - `Err("Please use a vector with at least one element".to_owned())`
+    - `Err(EmptyVec)`
+* Can hold information about the error. Compare:
+    - `Err("+ cannot be used here".to_owned())`
+    - `Err(BadChar(c, position))`
+
+This makes `String` errors both difficult to react to and verbose to create. In fact, a nice
+looking error message has nothing to do with how the type is structured. It is simply a
+consequence of `Display` being implemented for the type. It should not be necessary to
+pollute logic heavy code with `String` formatting simply for nice error messages.
+
+{rethink.play}
+
+### See also:
+
+[`Result`][result] and [`io::Result`][io_result]
+
+[result]: http://doc.rust-lang.org/std/result/enum.Result.html
+[io_result]: http://doc.rust-lang.org/std/io/type.Result.html
+[inplace]: /error/option_with_result/result_string_errors.html

--- a/examples/error/limits_of_strings/rethink.rs
+++ b/examples/error/limits_of_strings/rethink.rs
@@ -18,16 +18,19 @@ enum DoubleError {
 // How the type is displayed is completely separate from where the errors are generated.
 // We do not need to be concerned that the display style will clutter the complex logic
 // our utility requires. They are separate matters which are handled separately.
+//
+// We don't store extra info about the errors. If we had desired, for example, to state
+// which string failed to parse then we can't without modifying our types to carry that
+// information accordingly.
 impl fmt::Display for DoubleError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "Error: {}", match *self {
-            DoubleError::EmptyVec => 
-                "please use a vector with at least one element".to_owned(),
-            // We didn't store extra info about the error. If we had desired, for
-            // example, to state which string failed to parse then we can't without
-            // modifying our type to carry that information.
-            DoubleError::Parse(ref e) => e.to_string(),
-        })
+        match *self {
+            DoubleError::EmptyVec =>
+                write!(f, "please use a vector with at least one element"),
+            // This is a wrapper so defer to the underlying types' own implementation
+            // of `fmt`.
+            DoubleError::Parse(ref e) => e.fmt(f),
+        }
     }
 }
 
@@ -44,7 +47,7 @@ fn double_first(vec: Vec<&str>) -> Result<i32> {
 fn print(result: Result<i32>) {
     match result {
         Ok(n)  => println!("The first doubled is {}", n),
-        Err(e) => println!("{}", e),
+        Err(e) => println!("Error: {}", e),
     }
 }
 

--- a/examples/error/limits_of_strings/rethink.rs
+++ b/examples/error/limits_of_strings/rethink.rs
@@ -1,0 +1,59 @@
+use std::num::ParseIntError;
+use std::fmt;
+
+type Result<T> = std::result::Result<T, DoubleError>;
+
+#[derive(Debug)]
+// Define our error types. These may be customized however is useful for our error
+// handling cases. Now we will be able to defer to the underlying tools error
+// implementation, write our own errors, or something in between.
+enum DoubleError {
+    // We don't require any extra info to detail this error.
+    EmptyVec,
+    // We will defer to the parse error implementation for their error. Supplying extra
+    // info would require adding more data to the type.
+    Parse(ParseIntError),
+}
+
+// How the type is displayed is completely separate from where the errors are generated.
+// We do not need to be concerned that the display style will clutter the complex logic
+// our utility requires. They are separate matters which are handled separately.
+impl fmt::Display for DoubleError {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        write!(f, "Error: {}", match *self {
+            DoubleError::EmptyVec => 
+                "please use a vector with at least one element".to_owned(),
+            // We didn't store extra info about the error. If we had desired, for
+            // example, to state which string failed to parse then we can't without
+            // modifying our type to carry that information.
+            DoubleError::Parse(ref e) => e.to_string(),
+        })
+    }
+}
+
+fn double_first(vec: Vec<&str>) -> Result<i32> {
+    vec.first()
+       // Change the error to our new type.
+       .ok_or(DoubleError::EmptyVec)
+       .and_then(|s| s.parse::<i32>()
+            // Update to the new error type here also.
+            .map_err(DoubleError::Parse)
+            .map(|i| 2 * i))
+}
+
+fn print(result: Result<i32>) {
+    match result {
+        Ok(n)  => println!("The first doubled is {}", n),
+        Err(e) => println!("{}", e),
+    }
+}
+
+fn main() {
+    let numbers = vec!["93", "18"];
+    let empty = vec![];
+    let strings = vec!["tofu", "93", "18"];
+
+    print(double_first(numbers));
+    print(double_first(empty));
+    print(double_first(strings));
+}

--- a/examples/error/map/input.md
+++ b/examples/error/map/input.md
@@ -1,0 +1,22 @@
+Like before, `match` is a valid method for handling an `Option` however you may find that this
+gets tedious with heavy usage of `Options`. Luckily, there is an easier way.
+
+Consider the example below and in particular `peel()` and `chop()`; since each of these
+operations is only valid when the input exists, it seems sensible that bad input simply means
+the result is bad. This results in the simplistic mapping `Some -> Some` and `None -> None`.
+This is actually so common that there is a built in method for it called `map()` which is
+already implemented on `Option`.
+
+The result of this is that `chop()` is simpler to write than any of the previous methods.
+Furthermore, the ability to chain these together makes it even more flexible; `process()`
+easily can replace all the previous functions and still be compact.
+
+{map.play}
+
+[option]: http://doc.rust-lang.org/std/option/enum.Option.html
+
+### See also:
+
+[`struct`s][structs]
+
+[structs]: /custom_types/structs.html

--- a/examples/error/map/map.rs
+++ b/examples/error/map/map.rs
@@ -1,0 +1,60 @@
+#![allow(dead_code)]
+
+#[derive(Debug)] enum Food { Apple, Carrot, Potato }
+
+#[derive(Debug)] struct Peeled(Food);
+#[derive(Debug)] struct Chopped(Food);
+#[derive(Debug)] struct Cooked(Food);
+
+// Peeling food. If there isn't any, then just return `None`.
+// Otherwise, return the peeled food.
+fn peel(food: Option<Food>) -> Option<Peeled> {
+    match food {
+        Some(food) => Some(Peeled(food)),
+        None       => None,
+    }
+}
+
+// Similarly, we still need to keep track of whether there is a problem. If there
+// is, we just pass it on.
+fn chop(peeled: Option<Peeled>) -> Option<Chopped> {
+    match peeled {
+        Some(Peeled(food)) => Some(Chopped(food)),
+        None               => None,
+    }
+}
+
+// Same as before, when `Some`, pass `food` to `Cooked`, otherwise return `None`.
+fn cook(chopped: Option<Chopped>) -> Option<Cooked> {
+    chopped.map(|Chopped(food)| Cooked(food))
+}
+
+// You could even simplify the process further
+fn process(food: Option<Food>) -> Option<Cooked> {
+    food.map(|f| Peeled(f))
+        .map(|Peeled(f)| Chopped(f))
+        .map(|Chopped(f)| Cooked(f))
+}
+
+// Can we eat it now?
+fn eat(food: Option<Cooked>) {
+    match food {
+        Some(food) => println!("Mmm. I love {:?}", food),
+        None       => println!("Oh no! It wasn't edible."),
+    }
+}
+
+fn main() {
+    let apple = Some(Food::Apple);
+    let carrot = Some(Food::Carrot);
+    let potato = None;
+
+    let cooked_apple = cook(chop(peel(apple)));
+    let cooked_carrot = cook(chop(peel(carrot)));
+    // Let's try the simpler looking `process()` now.
+    let cooked_potato = process(potato);
+
+    eat(cooked_apple);
+    eat(cooked_carrot);
+    eat(cooked_potato);
+}

--- a/examples/error/more_combinators/combinators.rs
+++ b/examples/error/more_combinators/combinators.rs
@@ -1,0 +1,53 @@
+#![allow(dead_code)]
+
+#[derive(Debug)] enum Food { CordonBleu, Steak, Sushi }
+#[derive(Debug)] enum Day { Monday, Tuesday, Wednesday }
+
+// We don't have the ingredients to make Sushi.
+fn have_ingredients(food: Food) -> Option<Food> {
+    match food {
+        Food::Sushi => None,
+        _           => Some(food),
+    }
+}
+
+// We know how to make everything except Cordon Bleu.
+fn can_cook(food: Food) -> Option<Food> {
+    match food {
+        Food::CordonBleu => None,
+        _                => Some(food),
+    }
+}
+
+// To make a meal, we require both the ingredients and the ability to make that
+// meal, which is only possible when both are true; thus successes chain.
+// Conveniently, this can be rewritten more compactly with `and_then()`.
+fn cookable_v1(food: Food) -> Option<Food> {
+    match have_ingredients(food) {
+        None       => None,
+        Some(food) => match can_cook(food) {
+            None       => None,
+            Some(food) => Some(food),
+        },
+    }
+}
+
+// Same as `v1` above but uses `and_then()` instead.
+fn cookable_v2(food: Food) -> Option<Food> {
+    have_ingredients(food).and_then(can_cook)
+}
+
+fn eat(food: Food, day: Day) {
+    match cookable_v2(food) {
+        Some(food) => println!("Yay! On {:?} we get to eat {:?}.", day, food),
+        None       => println!("Oh no. We don't get to eat on {:?}?", day),
+    }
+}
+
+fn main() {
+    let (cordon_bleu, steak, sushi) = (Food::CordonBleu, Food::Steak, Food::Sushi);
+
+    eat(cordon_bleu, Day::Monday);
+    eat(steak, Day::Tuesday);
+    eat(sushi, Day::Wednesday);
+}

--- a/examples/error/more_combinators/input.md
+++ b/examples/error/more_combinators/input.md
@@ -1,0 +1,30 @@
+`map()` was previously described as a way to simplify a `match` which also allows chaining.
+However, `map()` does not work for all cases because the constituents often occur in many
+different combinations. Consider the following example:
+
+{combinators.play}
+
+The reason this worked is because `and_then()` happened to require the exact function type as an
+input that was needed here. `map()` did not. Comparing the signatures of their input types, you
+will see that when the function returned an `Option`, `and_then()` became the one and *only*
+valid choice.
+
+```rust
+map():      FnOnce(T) -> U
+and_then(): FnOnce(T) -> Option<U>
+```
+
+These are just two of many different combinators that are implemented on
+[`Option`][option] by the std library for many different use cases. It is advantageous
+to become familiar with them because they can simplify many error handling procedures and
+avoid the ugly and suicidal `panic!()` alternative. The other common error handling type,
+`Result`, also uses most of these same constructs so the skills are transferable.
+
+
+### See also:
+
+[`Option`][option], [`Option::map()`][map], and [`Option::and_then()`][and_then]
+
+[option]: http://doc.rust-lang.org/std/option/enum.Option.html
+[map]: http://doc.rust-lang.org/std/option/enum.Option.html#method.map
+[and_then]: http://doc.rust-lang.org/std/option/enum.Option.html#method.and_then 

--- a/examples/error/option_with_result/combinator_combinations/input.md
+++ b/examples/error/option_with_result/combinator_combinations/input.md
@@ -1,0 +1,15 @@
+What if multiple `Results` needed to interact together? Is it still reasonably convenient?
+It turns out, not really.
+
+{result_try.play}
+
+What is happening is this approach tries to work with the data without ever removing the `Ok`
+wrapper on it. Sometimes it is a good approach but in this case it is really awkward. What if
+we could `unwrap` it without possibly inducing `panic`? That is where we are headed next.
+
+### See also:
+
+[`Result`][result] and [`io::Result`][io_result]
+
+[result]: http://doc.rust-lang.org/std/result/enum.Result.html
+[io_result]: http://doc.rust-lang.org/std/io/type.Result.html

--- a/examples/error/option_with_result/combinator_combinations/result_try.rs
+++ b/examples/error/option_with_result/combinator_combinations/result_try.rs
@@ -3,14 +3,16 @@ use std::fs::File;
 
 type Result<T> = std::result::Result<T, String>;
 
-// Setup to make this work. Create two files with some info.
+// Setup to make this work. Create two files with some info. Ignore the
+// return values because we don't care about them here.
 fn setup() {
-    // Ignore the return value because we don't care about it.
-    let _ = File::create("a")
-        .and_then(|mut file| file.write_all(b"grape"));
+    File::create("a")
+        .and_then(|mut file| file.write_all(b"grape"))
+        .unwrap();
 
-    let _ = File::create("b")
-        .and_then(|mut file| file.write_all(b"fruit"));
+    File::create("b")
+        .and_then(|mut file| file.write_all(b"fruit"))
+        .unwrap();
 }
 
 // Get the data from each file with the data stored in a `Result`.

--- a/examples/error/option_with_result/combinator_combinations/result_try.rs
+++ b/examples/error/option_with_result/combinator_combinations/result_try.rs
@@ -1,0 +1,49 @@
+use std::io::prelude::*;
+use std::fs::File;
+
+type Result<T> = std::result::Result<T, String>;
+
+// Setup to make this work. Create two files with some info.
+fn setup() {
+    // Ignore the return value because we don't care about it.
+    let _ = File::create("a")
+        .and_then(|mut file| file.write_all(b"grape"));
+
+    let _ = File::create("b")
+        .and_then(|mut file| file.write_all(b"fruit"));
+}
+
+// Get the data from each file with the data stored in a `Result`.
+fn get_data(path: &str) -> Result<String> {
+    File::open(path)
+        .map_err(|err| err.to_string())
+        .and_then(|mut file| {
+            let mut contents = String::new();
+
+            // Read the data into `contents`.
+            file.read_to_string(&mut contents)
+                .map_err(|err| err.to_string())
+                // Ignore the output `read_to_string` returns and return `contents`.
+                .map(|_| contents)
+        })
+}
+
+// Concat the contents of the two files together into a new `Result`.
+fn concat(a: &str, b: &str) -> Result<String> {
+    let (data_a, data_b) = (get_data(a), get_data(b));
+    
+    data_a.and_then(|a|
+        // Return `Ok` when both `a` and `b` are `Ok`. Otherwise return
+        // whichever has the first `Err`.
+        data_b.and_then(|b| Ok(a + &b))
+    )
+}
+
+fn main() {
+    setup();
+
+    match concat("a", "b") {
+        Ok(n)  => println!("{}", n),
+        Err(e) => println!("Error: {:?}", e),
+    }
+}

--- a/examples/error/option_with_result/combinator_combinations/result_try.rs
+++ b/examples/error/option_with_result/combinator_combinations/result_try.rs
@@ -46,6 +46,6 @@ fn main() {
 
     match concat("a", "b") {
         Ok(n)  => println!("{}", n),
-        Err(e) => println!("Error: {:?}", e),
+        Err(e) => println!("Error: {}", e),
     }
 }

--- a/examples/error/option_with_result/enter_try/input.md
+++ b/examples/error/option_with_result/enter_try/input.md
@@ -1,0 +1,26 @@
+The previous problem was awkward because avoiding `unwrap` forced us to nest deeper and
+deeper when what we really wanted was to get the variable *out*. So, is there any way
+to accomodate this approach without `panic`? Well, what is a valid action to take when
+an `Err` is found? It turns out there are two:
+
+1. `panic!` which we already decided to try to avoid if possible
+2. `return` because an `Err` means it cannot be handled
+
+This is exactly the purpose of `try!`; it is *almost*[^1] exactly equivalent to an
+`unwrap` which `returns` instead of `panics` on `Errs`.
+
+{try.play}
+
+This really is a *huge* improvement but there is still the nagging issue of `map_err`. There is
+actually a way to avoid it (we are using it everywhere it seems) but we are still missing some
+details. First, we have to learn how to make better errors.
+
+[^1]: See [re-enter try!][re_enter_try] for more details.
+
+### See also:
+
+[`Result`][result] and [`io::Result`][io_result]
+
+[result]: http://doc.rust-lang.org/std/result/enum.Result.html
+[io_result]: http://doc.rust-lang.org/std/io/type.Result.html
+[re_enter_try]: /error/reenter_try.html

--- a/examples/error/option_with_result/enter_try/try.rs
+++ b/examples/error/option_with_result/enter_try/try.rs
@@ -42,6 +42,6 @@ fn main() {
 
     match concat("a", "b") {
         Ok(n)  => println!("{}", n),
-        Err(e) => println!("Error: {:?}", e),
+        Err(e) => println!("Error: {}", e),
     }
 }

--- a/examples/error/option_with_result/enter_try/try.rs
+++ b/examples/error/option_with_result/enter_try/try.rs
@@ -38,7 +38,7 @@ fn concat(a: &str, b: &str) -> Result<String> {
 
 fn main() {
     // Ignore this result.
-    let _ = setup();
+    setup().unwrap();
 
     match concat("a", "b") {
         Ok(n)  => println!("{}", n),

--- a/examples/error/option_with_result/enter_try/try.rs
+++ b/examples/error/option_with_result/enter_try/try.rs
@@ -1,0 +1,47 @@
+use std::io::prelude::*;
+use std::fs::File;
+
+type Result<T> = std::result::Result<T, String>;
+
+// Setup to make this work. Create two files with some info.
+fn setup() -> std::io::Result<()> {
+    let mut a = try!(File::create("a"));
+    try!(a.write_all(b"grape"));
+
+    let mut b = try!(File::create("b"));
+    b.write_all(b"fruit")
+}
+
+// Get the data from each file with the data stored in a `Result`.
+fn get_data(path: &str) -> Result<String> {
+    // `try` unwraps the value or returns the error.
+    let mut file = try!(File::open(path)
+        // Errors still must be converted to strings.
+        .map_err(|err| err.to_string())
+    );
+    let mut contents = String::new();
+
+    // Read the data into `contents`.
+    try!(file.read_to_string(&mut contents)
+        .map_err(|err| err.to_string())
+    );
+
+    Ok(contents)
+}
+
+// Concat the contents of the two files together into a new `Result`.
+fn concat(a: &str, b: &str) -> Result<String> {
+    let (data_a, data_b) = (try!(get_data(a)), try!(get_data(b)));
+
+    Ok(data_a + &data_b)
+}
+
+fn main() {
+    // Ignore this result.
+    let _ = setup();
+
+    match concat("a", "b") {
+        Ok(n)  => println!("{}", n),
+        Err(e) => println!("Error: {:?}", e),
+    }
+}

--- a/examples/error/option_with_result/input.md
+++ b/examples/error/option_with_result/input.md
@@ -1,0 +1,16 @@
+The previous examples have always been very convenient; a `Result` interacts with the same
+`Results` and an `Option` with the same `Option`. Sometimes it is not this easy though;
+`Options` and `Results` may have to interact or even `Result<T, Error1>` with
+`Result<T, Error2>`.
+
+Here is an example where one returns an `Option` and the other returns an `Result`. Aside
+from messy errors provided by `unwrap`, this looks reasonable:
+
+{option_result.play}
+
+### See also:
+
+[`Result`][result] and [`io::Result`][io_result]
+
+[result]: http://doc.rust-lang.org/std/result/enum.Result.html
+[io_result]: http://doc.rust-lang.org/std/io/type.Result.html

--- a/examples/error/option_with_result/option_result.rs
+++ b/examples/error/option_with_result/option_result.rs
@@ -1,0 +1,20 @@
+// The first attempt conveniently uses `unwrap` with the aforementioned
+// bad errors it results in.
+fn double_first(vec: Vec<&str>) -> i32 {
+    // What if the vector is empty?
+    let first = vec.first().unwrap();
+
+    // What if the element doesn't parse to a number?
+    2 * first.parse::<i32>().unwrap()
+}
+
+fn main() {
+    let numbers = vec!["93", "18"];
+    let empty = vec![];
+    let strings = vec!["tofu", "93", "18"];
+
+    println!("The first doubled is {}", double_first(numbers));
+    println!("The first doubled is {}", double_first(empty));
+    // ^ Comment out this line to see the second error.
+    println!("The first doubled is {}", double_first(strings));
+}

--- a/examples/error/option_with_result/result_string_errors/input.md
+++ b/examples/error/option_with_result/result_string_errors/input.md
@@ -1,0 +1,17 @@
+Eliminating `unwrap` from the previous example requires more care. The two types in play
+being `Option` and `Result`, one valid approach would be to convert both into a `Result`
+with a common `Err` type. We will try it with `Err(String)` which seems like a nice first
+approximation:
+
+{result_string.play}
+
+This is not too bad but it is hardly as nice as the original (it can still be nicer but
+we are not there yet). The question is, does this approach scale well. Consider the next
+example.
+
+### See also:
+
+[`Result`][result] and [`io::Result`][io_result]
+
+[result]: http://doc.rust-lang.org/std/result/enum.Result.html
+[io_result]: http://doc.rust-lang.org/std/io/type.Result.html

--- a/examples/error/option_with_result/result_string_errors/result_string.rs
+++ b/examples/error/option_with_result/result_string_errors/result_string.rs
@@ -1,0 +1,32 @@
+type Result<T> = std::result::Result<T, String>;
+
+fn double_first(vec: Vec<&str>) -> Result<i32> {
+    vec.first()
+       // Convert the `Option` to a `Result` if there is a value; otherwise
+       // use an `Err` containing this `String`.
+       .ok_or("Please use a vector with at least one element.".to_owned())
+       // `parse` returns a `Result<T, ParseIntError>`.
+       .and_then(|s| s.parse::<i32>()
+                      //  The return type is `Result<T, String>`. We need
+                      //  to map only the errors `parse` yields to `String`.
+                      .map_err(|e| e.to_string())
+                      // Apply the double to the number inside.
+                      .map(|i| 2 * i))
+}
+
+fn print(result: Result<i32>) {
+    match result {
+        Ok(n)  => println!("The first doubled is {}", n),
+        Err(e) => println!("Error: {:?}", e),
+    }
+}
+
+fn main() {
+    let numbers = vec!["93", "18"];
+    let empty = vec![];
+    let strings = vec!["tofu", "93", "18"];
+
+    print(double_first(numbers));
+    print(double_first(empty));
+    print(double_first(strings));
+}

--- a/examples/error/option_with_result/result_string_errors/result_string.rs
+++ b/examples/error/option_with_result/result_string_errors/result_string.rs
@@ -17,7 +17,7 @@ fn double_first(vec: Vec<&str>) -> Result<i32> {
 fn print(result: Result<i32>) {
     match result {
         Ok(n)  => println!("The first doubled is {}", n),
-        Err(e) => println!("Error: {:?}", e),
+        Err(e) => println!("Error: {}", e),
     }
 }
 

--- a/examples/error/reenabling_box/input.md
+++ b/examples/error/reenabling_box/input.md
@@ -18,9 +18,9 @@ types. In order to define a valid `Result<T, E>` type, the user has a few choice
 * convert it to `String` or some other intermediate choice
 * box it up into `Box<Error>` via type erasure
 
-Boxing it is a common choice. The only penalty is that the error type is only known
-at runtime and not statically determined. All that needs to be done to enable this
-is implement the `Error` trait:
+Boxing it is a common choice. The only penalty is that the underlying error type is only known
+at runtime and not [statically determined][dynamic_dispatch]. All that needs to be done to enable
+this is implement the `Error` trait:
 
 ```rust
 trait Error: Debug + Display {
@@ -36,6 +36,7 @@ is `Box<Error>` as it was before with `DoubleError`.
 
 ### See also:
 
-[`Error` trait][error]
+[Dynamic dispatch][dynamic_dispatch] and [`Error` trait][error]
 
+[dynamic_dispatch]: http://doc.rust-lang.org/book/trait-objects.html#dynamic-dispatch
 [error]: http://doc.rust-lang.org/std/error/trait.Error.html

--- a/examples/error/reenabling_box/input.md
+++ b/examples/error/reenabling_box/input.md
@@ -1,0 +1,41 @@
+We have seen that by implementing `Display` and `From` for our error type, we have enabled
+usage of almost all of the std library error handling tools. That is, we missed one
+capability: the ability to easily `box` our error type.
+
+Namely, the std library will automatically convert from any type which implements the
+`Error` trait into the trait object `Box<Error>` via `From`. To a library user, this
+conveniently allows the following:
+
+```rust
+// Any error type automatically convertible to `Box<Error>` may be used here.
+fn foo(...) -> Result<T, Box<Error>> { ... }
+```
+
+For example, a user may use a variety of libraries which each provide their own error
+types. In order to define a valid `Result<T, E>` type, the user has a few choices:
+
+* define a new wrapper error type around the external libraries error types
+* convert it to `String` or some other intermediate choice
+* box it up into `Box<Error>` via type erasure
+
+Boxing it is a common choice. The only penalty is that the error type is only known
+at runtime and not statically determined. All that needs to be done to enable this
+is implement the `Error` trait:
+
+```rust
+trait Error: Debug + Display {
+    fn description(&self) -> &str;
+    fn cause(&self) -> Option<&Error>;
+}
+```
+
+By implementing this, our previous example would be just as valid when the error type
+is `Box<Error>` as it was before with `DoubleError`.
+
+{rethink.play}
+
+### See also:
+
+[`Error` trait][error]
+
+[error]: http://doc.rust-lang.org/std/error/trait.Error.html

--- a/examples/error/reenabling_box/rethink.rs
+++ b/examples/error/reenabling_box/rethink.rs
@@ -19,22 +19,22 @@ impl From<ParseIntError> for DoubleError {
 
 impl fmt::Display for DoubleError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "Error: {}", match *self {
-            DoubleError::EmptyVec => 
-                "please use a vector with at least one element".to_owned(),
-            DoubleError::Parse(ref e) => e.to_string(),
-        })
+        match *self {
+            DoubleError::EmptyVec =>
+                write!(f, "please use a vector with at least one element"),
+            DoubleError::Parse(ref e) => e.fmt(f),
+        }
     }
 }
 
 impl error::Error for DoubleError {
     fn description(&self) -> &str {
         match *self {
-            // Trying to use `Display` here results in the string being immediately
-            // dropped which won't compile so we have to write out the phrase again.
-            DoubleError::EmptyVec => "please use a vector with at least one element",
-            // This already impls `Error`, so defer to its implementation.
-            DoubleError::Parse(ref err) => err.description(),
+            // A very short description of the error. Doesn't need to be the
+            // same as `Display`.
+            DoubleError::EmptyVec => "empty vectors not allowed",
+            // This already impls `Error`, so defer to its own implementation.
+            DoubleError::Parse(ref e) => e.description(),
         }
     }
 
@@ -60,7 +60,7 @@ fn double_first(vec: Vec<&str>) -> Result<i32> {
 fn print(result: Result<i32>) {
     match result {
         Ok(n)  => println!("The first doubled is {}", n),
-        Err(e) => println!("{}", e),
+        Err(e) => println!("Error: {}", e),
     }
 }
 

--- a/examples/error/reenabling_box/rethink.rs
+++ b/examples/error/reenabling_box/rethink.rs
@@ -1,0 +1,75 @@
+use std::error;
+use std::fmt;
+use std::num::ParseIntError;
+
+// Change the alias to `Box<error::Error>`.
+type Result<T> = std::result::Result<T, Box<error::Error>>;
+
+#[derive(Debug)]
+enum DoubleError {
+    EmptyVec,
+    Parse(ParseIntError),
+}
+
+impl From<ParseIntError> for DoubleError {
+    fn from(err: ParseIntError) -> DoubleError {
+        DoubleError::Parse(err)
+    }
+}
+
+impl fmt::Display for DoubleError {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        write!(f, "Error: {}", match *self {
+            DoubleError::EmptyVec => 
+                "please use a vector with at least one element".to_owned(),
+            DoubleError::Parse(ref e) => e.to_string(),
+        })
+    }
+}
+
+impl error::Error for DoubleError {
+    fn description(&self) -> &str {
+        match *self {
+            // Trying to use `Display` here results in the string being immediately
+            // dropped which won't compile so we have to write out the phrase again.
+            DoubleError::EmptyVec => "please use a vector with at least one element",
+            // This already impls `Error`, so defer to its implementation.
+            DoubleError::Parse(ref err) => err.description(),
+        }
+    }
+
+    fn cause(&self) -> Option<&error::Error> {
+        match *self {
+            // No underlying cause so return `None`.
+            DoubleError::EmptyVec => None,
+            // The cause is the underlying implementation error type. Is implicitly
+            // cast to the trait object `&error::Error`. This works because the
+            // underlying type already implements the `Error` trait.
+            DoubleError::Parse(ref e) => Some(e),
+        }
+    }
+}
+
+fn double_first(vec: Vec<&str>) -> Result<i32> {
+    let first = try!(vec.first().ok_or(DoubleError::EmptyVec));
+    let parsed = try!(first.parse::<i32>());
+
+    Ok(2 * parsed)
+}
+
+fn print(result: Result<i32>) {
+    match result {
+        Ok(n)  => println!("The first doubled is {}", n),
+        Err(e) => println!("{}", e),
+    }
+}
+
+fn main() {
+    let numbers = vec!["93", "18"];
+    let empty = vec![];
+    let strings = vec!["tofu", "93", "18"];
+
+    print(double_first(numbers));
+    print(double_first(empty));
+    print(double_first(strings));
+}

--- a/examples/error/reenter_try/input.md
+++ b/examples/error/reenter_try/input.md
@@ -1,0 +1,42 @@
+If you will notice from the previous example, when we call `parse`, the immediate reaction
+is to `map` the error from a library error into our new custom error type.
+
+```rust
+.and_then(|s| s.parse::<i32>()
+    .map_err(DoubleError::Parse)
+```
+
+This is a very simple and also common operation so it would be convenient if eliding it
+would work but alas, it does not. `and_then` is not sufficiently flexible that it can handle
+this; `try!` is though.
+
+`try!` has previously been explained as either `unwrap` or `return Err(err)` which is only
+`93%` correct. It actually means `unwrap` or `return Err(From::from(err))`. Since `From::from`
+is a conversion utility between different types, this means if you `try!` something where the
+error is convertible to the return type, it will convert automatically. This means, if we
+rewrite this example with `try!` when `From::from` is implemented for our error type,
+the `map_err` will go away:
+
+{rethink.play}
+
+This is actually fairly clean now. If you compare it with the original `panic`, it is very similar
+to replacing the `unwrap` calls with `try!` except that the return types are `Result` and so
+they must be destructured at the top level.
+
+However, do not expect error handling of this sort to replace all usage of `unwrap` in
+practice. Error handling of this sort tripled our code line count and cannot really be
+called simple even if this is heavily biased by the small code size. Indeed, moving a 1000 line
+library from `unwrap` to more proper error handling might be feasible in an additional
+100 lines of code though the necessary refractoring definitely would not be trivial.
+
+This is a very reasonable place to be. Many libraries might get away with only
+implementing `Display` and then adding `From` on an as needed basis. A serious library
+though will have users with certain expections about how it should implement error handling.
+In those cases, the error handling will need to be taken one step further.
+
+### See also:
+
+[`From::from`][from] and [`try!`][try]
+
+[from]: http://doc.rust-lang.org/std/convert/trait.From.html
+[try]: http://doc.rust-lang.org/std/macro.try!.html

--- a/examples/error/reenter_try/rethink.rs
+++ b/examples/error/reenter_try/rethink.rs
@@ -20,11 +20,11 @@ impl From<ParseIntError> for DoubleError {
 
 impl fmt::Display for DoubleError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "Error: {}", match *self {
-            DoubleError::EmptyVec => 
-                "please use a vector with at least one element".to_owned(),
-            DoubleError::Parse(ref e) => e.to_string(),
-        })
+        match *self {
+            DoubleError::EmptyVec =>
+                write!(f, "please use a vector with at least one element"),
+            DoubleError::Parse(ref e) => e.fmt(f),
+        }
     }
 }
 
@@ -41,7 +41,7 @@ fn double_first(vec: Vec<&str>) -> Result<i32> {
 fn print(result: Result<i32>) {
     match result {
         Ok(n)  => println!("The first doubled is {}", n),
-        Err(e) => println!("{}", e),
+        Err(e) => println!("Error: {}", e),
     }
 }
 

--- a/examples/error/reenter_try/rethink.rs
+++ b/examples/error/reenter_try/rethink.rs
@@ -1,0 +1,56 @@
+use std::num::ParseIntError;
+use std::fmt;
+
+type Result<T> = std::result::Result<T, DoubleError>;
+
+#[derive(Debug)]
+enum DoubleError {
+    EmptyVec,
+    Parse(ParseIntError),
+}
+
+// Implement the conversion from `ParseIntError` to `DoubleError`. This will be
+// automatically called by `try!` if a `ParseIntError` needs converting into
+// a `DoubleError`.
+impl From<ParseIntError> for DoubleError {
+    fn from(err: ParseIntError) -> DoubleError {
+        DoubleError::Parse(err)
+    }
+}
+
+impl fmt::Display for DoubleError {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        write!(f, "Error: {}", match *self {
+            DoubleError::EmptyVec => 
+                "please use a vector with at least one element".to_owned(),
+            DoubleError::Parse(ref e) => e.to_string(),
+        })
+    }
+}
+
+// The same structure as before but rather than chain all `Results`
+// and `Options` along, we `try!` to get the inner value out immediately.
+fn double_first(vec: Vec<&str>) -> Result<i32> {
+    // Still convert to `Result` by stating how to convert `None`.
+    let first = try!(vec.first().ok_or(DoubleError::EmptyVec));
+    let parsed = try!(first.parse::<i32>());
+
+    Ok(2 * parsed)
+}
+
+fn print(result: Result<i32>) {
+    match result {
+        Ok(n)  => println!("The first doubled is {}", n),
+        Err(e) => println!("{}", e),
+    }
+}
+
+fn main() {
+    let numbers = vec!["93", "18"];
+    let empty = vec![];
+    let strings = vec!["tofu", "93", "18"];
+
+    print(double_first(numbers));
+    print(double_first(empty));
+    print(double_first(strings));
+}

--- a/examples/error/result_alias/alias.rs
+++ b/examples/error/result_alias/alias.rs
@@ -1,0 +1,23 @@
+use std::num::ParseIntError;
+use std::result;
+
+// A generic alias for any `Result` with this specific `Err` type.
+type Result<T> = result::Result<T, ParseIntError>;
+
+// Use the alias defined above referring to our specific `Result` type.
+fn double_number(number_str: &str) -> Result<i32> {
+    number_str.parse::<i32>().map(|n| 2 * n)
+}
+
+// Again, the alias saved us from defining it again.
+fn print(result: Result<i32>) {
+    match result {
+        Ok(n)  => println!("n is {}", n),
+        Err(e) => println!("Error: {:?}", e),
+    }
+}
+
+fn main() {
+    print(double_number("10"));
+    print(double_number("t"));
+}

--- a/examples/error/result_alias/alias.rs
+++ b/examples/error/result_alias/alias.rs
@@ -13,7 +13,7 @@ fn double_number(number_str: &str) -> Result<i32> {
 fn print(result: Result<i32>) {
     match result {
         Ok(n)  => println!("n is {}", n),
-        Err(e) => println!("Error: {:?}", e),
+        Err(e) => println!("Error: {}", e),
     }
 }
 

--- a/examples/error/result_alias/input.md
+++ b/examples/error/result_alias/input.md
@@ -1,0 +1,16 @@
+What if the specific `Result` type is reused many many times? Then quickly it becomes tedious
+to write out the full type name. Instead, a generic alias for the specific `Result` may be
+defined.
+
+{alias.play}
+
+This is particularly helpful at a module level because all errors found in a specific module
+may have the same `Err` type; a single alias succinctly defines *all* module `Results`. This
+is so useful that the std library even supplies one: `io::Result` which refers to IO errors.
+
+### See also:
+
+[`Result`][result] and [`io::Result`][io_result]
+
+[result]: http://doc.rust-lang.org/std/result/enum.Result.html
+[io_result]: http://doc.rust-lang.org/std/io/type.Result.html

--- a/examples/error/result_map/input.md
+++ b/examples/error/result_map/input.md
@@ -1,0 +1,21 @@
+To avoid the `unwrap()` in the previous example, we will have to rewrite the example to be
+specific about what type it returns. In this case, the regular element should definitely
+be `i32` but what about the `Err` type? Well, `parse()` is implemented with the
+[`FromStr trait`][from_str] for [`i32`][i32]. That implementation specifies the
+`Err` type as [`ParseIntError`][parse_int_error].
+
+{result.play}
+
+Similar to `Option`, `Result` has many other combinators besides `map` such as `and_then`
+and `unwrap_or`; even ones to handle the errors specifically such as `map_err`.
+`Result` contains the complete listing.
+
+### See also:
+
+[`i32`][i32], [`FromStr`][from_str], [`ParseIntErr`][parse_int_error], and
+[`Result`][result]
+
+[result]: http://doc.rust-lang.org/std/result/enum.Result.html
+[parse_int_error]: http://doc.rust-lang.org/std/num/struct.ParseIntError.html
+[from_str]: http://doc.rust-lang.org/std/str/trait.FromStr.html
+[i32]: http://doc.rust-lang.org/std/primitive.i32.html

--- a/examples/error/result_map/result.rs
+++ b/examples/error/result_map/result.rs
@@ -1,0 +1,34 @@
+use std::num::ParseIntError;
+
+// With the return type rewritten, we proceed to use pattern matching without
+// `unwrap()` but it is tedious. Couldn't a combinator like in the `Option`
+// example also be used here? Yes.
+fn double_number(number_str: &str) -> Result<i32, ParseIntError> {
+    match number_str.parse::<i32>() {
+        Ok(n)  => Ok(2 * n),
+        Err(e) => Err(e),
+    }
+}
+
+// The exact same but written with `map()`. Modify if the value is valid,
+// otherwise pass the error on.
+fn double_number_map(number_str: &str) -> Result<i32, ParseIntError> {
+    number_str.parse::<i32>().map(|n| 2 * n)
+}
+
+fn print(result: Result<i32, ParseIntError>) {
+    match result {
+        Ok(n)  => println!("n is {}", n),
+        Err(e) => println!("Error: {:?}", e),
+    }
+}
+
+fn main() {
+    // Still presents a reasonable answer.
+    let twenty = double_number("10");
+    print(twenty);
+
+    // This is now much better than before with the messy `panic`.
+    let tt = double_number_map("t");
+    print(tt);
+}

--- a/examples/error/result_map/result.rs
+++ b/examples/error/result_map/result.rs
@@ -19,7 +19,7 @@ fn double_number_map(number_str: &str) -> Result<i32, ParseIntError> {
 fn print(result: Result<i32, ParseIntError>) {
     match result {
         Ok(n)  => println!("n is {}", n),
-        Err(e) => println!("Error: {:?}", e),
+        Err(e) => println!("Error: {}", e),
     }
 }
 

--- a/examples/error/unwrap/input.md
+++ b/examples/error/unwrap/input.md
@@ -1,0 +1,23 @@
+We determined a snake is an inappropriate gift for a princess. What if she expected a gift
+but did not receive one? Clearly that would be just as bad but how would it be handled? Well,
+`Option<T>` is the type which is used when absense is a possibility. This manifests itself as
+two choices:
+
+* `Some<T>`: An element `T` was found
+* `None`: No element was found
+
+These can either be explicitly handled via `match` or implicitly with `unwrap`. `unwrap`,
+deferring to the std library, either returns the inner element or `panics`. Regardless of
+explicit or implicit handling, an `enum` such as `Option` will have all cases handled. The
+compiler ensures that none are forgotten giving us more confidence in its robustness.
+
+{unwrap.play}
+
+As you can see, direct control yielded an even nicer result than the original `panic` along
+with the choice to `panic` if we desired. `unwrap` on the other hand, deferring to the std
+library left us with the most generic and unhelpful: "I unwrapped a `None`!" meanwhile yielding
+the good results the rest of the time. A more meaningful message will require a better approach[^1].
+
+[^1]: ignoring [expect][expect] which allows manual customization of the `panic` for now
+
+[expect]: http://doc.rust-lang.org/std/option/enum.Option.html#method.expect

--- a/examples/error/unwrap/unwrap.rs
+++ b/examples/error/unwrap/unwrap.rs
@@ -1,0 +1,36 @@
+// The commoner cannot bring down the task which precludes the option of `panic`.
+// These must all be handled manually. `match` would be the correct approach.
+fn give_commoner(gift: Option<&str>) {
+    // Specify a specific course of action for each case.
+    match gift {
+        Some("snake") => println!("Yuck! Throws the snake in the fire."),
+        Some(inner)   => println!("{}! How nice.", inner),
+        None          => println!("No gift? Oh well."),
+    }
+}
+
+// A princess is allowed to bring down the task at will so `panic` is an option.
+fn give_princess(gift: Option<&str>) {
+    // Using `unwrap` defers the case analysis to the std library which will
+    // `panic` when it receives a `None`.
+    let inside = gift.unwrap();
+    if inside == "snake" { panic!("AAAaaaaa!!!!"); }
+
+    println!("I love {}s!!!!!", inside);
+}
+
+fn main() {
+    let food  = Some("chicken");
+    let snake = Some("snake");
+    let void  = None;
+
+    give_commoner(food);
+    give_commoner(snake);
+    give_commoner(void);
+
+    let bird = Some("robin");
+    let nothing = None;
+
+    give_princess(bird);
+    give_princess(nothing);
+}

--- a/examples/structure.json
+++ b/examples/structure.json
@@ -142,6 +142,22 @@
         { "id": "iter", "title": "Iterators", "children": null },
         { "id": "clone", "title": "Clone", "children": null }
     ] },
+    { "id": "error", "title": "Error handling", "children": [
+        { "id": "unwrap", "title": "Option & unwrap", "children": null },
+        { "id": "map", "title": "map", "children": null },
+        { "id": "more_combinators", "title": "More combinators", "children": null },
+        { "id": "error_vs_absence", "title": "Errors vs Absence", "children": null },
+        { "id": "result_map", "title": "map for Result", "children": null },
+        { "id": "result_alias", "title": "Result as an alias", "children": null },
+        { "id": "option_with_result", "title": "Options with Results", "children": [
+            { "id": "result_string_errors", "title": "Errors as strings", "children": null },
+            { "id": "combinator_combinations", "title": "Combining separate combinators", "children": null },
+            { "id": "enter_try", "title": "Enter try!", "children": null }
+        ] },
+        { "id": "limits_of_strings", "title": "The limits of strings", "children": null },
+        { "id": "reenter_try", "title": "Re-enter try!", "children": null },
+        { "id": "reenabling_box", "title": "Re-enabling box", "children": null }
+    ] },
     { "id": "std", "title": "Std library types", "children": [
         { "id": "box", "title": "Box, stack and heap", "children": null },
         { "id": "vec", "title": "Vectors", "children": null },


### PR DESCRIPTION
I added a new error handling section which I based on the @burntsushi error handling blog doc. In general I think his docs motivate error handling really well however at the end of the docs where they diverge from strings as errors, it wasn't quite as good. You're left wondering why you'd ever bother implementing the `Error` trait and `From` and `Display` when you only need `Display`. Or perhaps you need `From` also. Anyway, I tried a slightly different approach by trying to approach the error trait and others as basically optional depending on the purpose and needs of the library/binary. He probably said more in the case study but I never actually looked at that part (so it may be absolutely wonderful).

In some sense, this may be quite practical because the examples are entirely usable and runnable in comparison to the original. The original, while each is runnable, the playpen links are basically useless which wouldn't work in this case.

I originally didn't like that I had to write the result error handling sections by loading files but after the fact, it seems like a good result and I'm fairly happy with it.

@steveklabnik r?

@burntsushi If you have any opinions/critiques, please add them.

I'm not sure who else I could cc. I could possibly rename some of the sections and perhaps add some more `See also`s because I might not have added enough but I'm not sure.

Sorry it took so long to get this up. I had this mostly to this point for a while but was taking a break and doing other things for a couple weeks I guess.

---

This branch is currently hosted [here](http://mdinger.github.io/rbe_error_handling). The error handling section is [here](http://mdinger.github.io/rbe_error_handling/error.html).