### PR TITLE
Fix typos (hello/comment, std_misc/channels)

### DIFF
--- a/examples/hello/comment/comment.rs
+++ b/examples/hello/comment/comment.rs
@@ -6,20 +6,20 @@ fn main() {
     // println!("Hello, world!");
 
     // Run it. See? Now try deleting the two slashes, and run it again.
-    
+
     /* 
      * This is another type of comment, the block comment. In general,
      * the line comment is the recommended comment style however the
      * block comment is extremely useful for debugging
      */
-     
+
      /*
      Note, the previous column of `*` was entirely for style. There's
      no actual need for it.
      */
-     
+
      // Observe how block comments allow easy expression manipulation
-     // which line comments do not. Deleting the comment deliminators
+     // which line comments do not. Deleting the comment delimiters
      // will change the result:
      let x = 5 + /* 90 + */ 5;
      println!("Is `x` 10 or 100? x = {}", x);

--- a/examples/hello/comment/input.md
+++ b/examples/hello/comment/input.md
@@ -3,7 +3,7 @@ a few different varieties:
 
 * *Regular comments* which are ignored by the compiler:
  - `// Line comments which go to the end of the line.`
- - `/* Block comments which go to the closing deliminator. */`
+ - `/* Block comments which go to the closing delimiter. */`
 * *Doc comments* which are parsed into HTML library
 [documentation][docs]:
  - `/// Generate library docs for the following item.`

--- a/examples/std_misc/channels/input.md
+++ b/examples/std_misc/channels/input.md
@@ -1,5 +1,5 @@
 Rust provides asynchronous `channels` for communication between threads. Channels
-allow an unidirectional flow of information between two end-points: the
+allow a unidirectional flow of information between two end-points: the
 `Sender` and the `Receiver`.
 
 {channels.play}


### PR DESCRIPTION
Made a couple tiny fixes, but my editor also trimmed some whitespace. If that's a problem I can add the whitespace back :)