### PR TITLE
Fix whitespace in playpen result

### DIFF
--- a/node_modules/gitbook-plugin-rust-playpen/book/editor.css
+++ b/node_modules/gitbook-plugin-rust-playpen/book/editor.css
@@ -28,7 +28,7 @@
   display: none;
   border-radius: 4px;
   font-family: Menlo, Monaco, Consolas, monospace;
-  white-space: normal;
+  white-space: pre-wrap;
 }
 
 #reset-code {


### PR DESCRIPTION
This fixes the results display with any leading whitespace, as in the "formatted print" code on chapter 1.2. Specifically this line:

```rust
    // You can right-align text with a specified width. This will output
    // "     1". 5 white spaces and a "1".
    println!("{number:>width$}", number=1, width=6);
```