### PR TITLE
Updates to 13. Generics and rename 12.1 to `dead_code`

### DIFF
--- a/examples/attribute/cfg/input.md
+++ b/examples/attribute/cfg/input.md
@@ -3,7 +3,7 @@ Conditional compilation is possible through two different operators:
 * the `cfg` attribute: `#[cfg(...)]` in attribute position
 * the `cfg!` macro: `cfg!(...)` in boolean expressions
 
-Both utilize identical syntax.
+Both utilize identical argument syntax.
 
 {cfg.play}
 

--- a/examples/generics/generics.rs
+++ b/examples/generics/generics.rs
@@ -15,11 +15,12 @@ fn main() {
     // `Single` is concrete and explicitly takes `A`.
     let _s = Single(A);
     
-    // Instantiating generic types can be explicit or implicit.
-    // `SingleGen` explicitly specialized:
+    // Here, `SingleGen` is explicitly specialized. This reads as:
+    // Create a variable `_char` of type `SingleGen<char>`
+    // and give it the value `SingleGen('a')`
     let _char: SingleGen<char> = SingleGen('a');
 
-    // `SingleGen` implicitly specialized:
+    // `SingleGen` can also be implicitly specialized:
     let _t    = SingleGen(A); // Uses `A` defined at the top.
     let _i32  = SingleGen(6); // Uses `i32`.
     let _char = SingleGen('a'); // Uses `char`.

--- a/examples/generics/generics.rs
+++ b/examples/generics/generics.rs
@@ -1,25 +1,26 @@
-// A concrete type `T`.
-struct T;
+// A concrete type `A`.
+struct A;
 
-// The first use of `T` was not preceded by `<T>` so `Single` must
-// be a concrete type. `T` is defined at the top.
-struct Single(T);
-//            ^ Here is `Single`s first use of the type `T`.
+// In defining the type `Single`, the first use of `A` is not preceded by `<A>`.
+// Therefore, `Single` is a concrete type, and `A` is defined as above.
+struct Single(A);
+//            ^ Here is `Single`s first use of the type `A`.
 
-// The first use of `T` is preceded by `<T>`. `SingleGen` must be
-// generic and has not yet been specialized. `T` could be anything
-// including `T` at the top.
+// Here, `<T>` precedes the first use of `T`, so `SingleGen` is a generic type.
+// Because the type parameter `T` is generic, it could be anything, including
+// the concrete type `A` defined at the top.
 struct SingleGen<T>(T);
 
-// Instantiating the types can be implicit or explicit.
 fn main() {
-    // Regular `Single`.
-    let _s = Single(T);
-
-    // `SingleGen` explicity specialized.
+    // `Single` is concrete and explicitly takes `A`.
+    let _s = Single(A);
+    
+    // Instantiating generic types can be explicit or implicit.
+    // `SingleGen` explicitly specialized:
     let _char: SingleGen<char> = SingleGen('a');
 
-    // `SingleGen`s implicitly specialized.
-    let _t   = SingleGen(T); // Uses `T` at top.
-    let _i32 = SingleGen(6); // Uses `i32`.
+    // `SingleGen` implicitly specialized:
+    let _t    = SingleGen(A); // Uses `A` defined at the top.
+    let _i32  = SingleGen(6); // Uses `i32`.
+    let _char = SingleGen('a'); // Uses `char`.
 }

--- a/examples/generics/input.md
+++ b/examples/generics/input.md
@@ -7,19 +7,21 @@ is actually considered valid.
 A type parameter is specified as generic by the use of angle brackets and
 [camel case][camelcase]: `<A, B, ...>`. "Generic type parameters" are
 typically represented as `<T>`. In Rust, "generic" also describes anything that
-accepts one or more generic type parameters `<T>`. For example, defining a
-*generic function* named `foo` that takes an argument `T` of any type:
+accepts one or more generic type parameters `<T>`. Any type specified as a 
+generic type parameter is generic, and everything else is concrete (non-generic).
+
+For example, defining a *generic function* named `foo` that takes an argument
+`T` of any type:
 
 ```rust
 fn foo<T>(T) { ... }
 ```
 
-There are 2 basic rules regarding this which are applied at the type's first use:
+Because `T` has been specified as a generic type parameter, it is considered
+generic when used here as `(T)`. This is the case even if `T` has previously
+been defined as a `struct`.
 
-* Any type previously specified to be generic is generic.
-* Everything else is concrete (non-generic).
-
-These rules play out like this:
+This example shows some of the syntax in action:
 
 {generics.play}
 

--- a/examples/generics/input.md
+++ b/examples/generics/input.md
@@ -1,14 +1,22 @@
-Generics is the topic of generalizing types and functionality to be more broad
-than one specific type. This is extremely useful in reducing code duplication
-in many ways. We will find though that being generic will involve taking
-great care to actually specify what types a generic type is actually valid
-over. This will require a rather involving syntax, though it seems
-straightforward at first.
+Generics is the topic of generalizing types and functionality to broader
+cases. This is extremely useful in reducing code duplication in many ways,
+but requires a rather involving syntax. However, we will find that being 
+generic involves taking great care to specify over what types a generic type 
+is actually considered valid.
 
-A type is specified as generic by `<A, B, ...>`. There are 2 basic rules
-regarding this which are applied *at* the type's first use:
+A type parameter is specified as generic by the use of angle brackets and
+[camel case][camelcase]: `<A, B, ...>`. "Generic type parameters" are
+typically represented as `<T>`. In Rust, "generic" also describes anything that
+accepts one or more generic type parameters `<T>`. For example, defining a
+*generic function* named `foo` that takes an argument `T` of any type:
 
-* Any type previously and locally specified to be generic is generic.
+```rust
+fn foo<T>(T) { ... }
+```
+
+There are 2 basic rules regarding this which are applied at the type's first use:
+
+* Any type previously specified to be generic is generic.
 * Everything else is concrete (non-generic).
 
 These rules play out like this:
@@ -20,3 +28,4 @@ These rules play out like this:
 [`struct`s][structs]
 
 [structs]: /custom_types/structs.html
+[camelcase]: https://en.wikipedia.org/wiki/CamelCase

--- a/examples/structure.json
+++ b/examples/structure.json
@@ -87,7 +87,7 @@
         { "id": "link", "title": "`extern crate`", "children": null }
     ] },
     { "id": "attribute", "title": "Attributes", "children": [
-        { "id": "unused", "title": "Unused", "children": null },
+        { "id": "unused", "title": "`dead_code`", "children": null },
         { "id": "crate", "title": "Crates", "children": null },
         { "id": "cfg", "title": "`cfg`", "children": [
             { "id": "custom", "title": "Custom", "children": null }


### PR DESCRIPTION
12.1 to `dead_code` to more accurately reflect contents.
13. Generics - Readability and reducing confusion with wording.