### PR TITLE
hello/input: fix typo

### DIFF
--- a/examples/hello/input.md
+++ b/examples/hello/input.md
@@ -25,7 +25,7 @@ line with a second `println!` macro so that the output
 shows:
 ```
 Hello World!
-I'm a Rustacian!
+I'm a Rustacean!
 ```
 
 [macros]: ./macros.html


### PR DESCRIPTION
According to the Rust book ([https://doc.rust-lang.org/book/getting-started.html](url)), Rustacian should be written Rustacean.