### PR TITLE
Updated 14.4.5, 14.4.6

### DIFF
--- a/examples/scope/lifetime/lifetime_bounds/bounds.rs
+++ b/examples/scope/lifetime/lifetime_bounds/bounds.rs
@@ -25,6 +25,6 @@ fn main() {
     let x = 7;
     let ref_x = Ref(&x);
     
-    print(ref_x);
     print_ref(&ref_x);
+    print(ref_x);
 }

--- a/examples/scope/lifetime/lifetime_bounds/bounds.rs
+++ b/examples/scope/lifetime/lifetime_bounds/bounds.rs
@@ -24,7 +24,7 @@ fn print_ref<'a, T>(t: &'a T) where
 fn main() {
     let x = 7;
     let ref_x = Ref(&x);
-    
+
     print_ref(&ref_x);
     print(ref_x);
 }

--- a/examples/scope/lifetime/lifetime_bounds/bounds.rs
+++ b/examples/scope/lifetime/lifetime_bounds/bounds.rs
@@ -1,11 +1,11 @@
 use std::fmt::Debug; // Trait to bound with.
 
 #[derive(Debug)]
-// `Ref` contains a reference to type `T` where `T` is unknown
-// with an unknown lifetime `'a`. `T` is bounded such that any
-// references in `T` must outlive `'a`. In addition, the lifetime
-// of `Ref` may not exceed `'a`.
 struct Ref<'a, T: 'a>(&'a T);
+// `Ref` contains a reference to a generic type `T` that has
+// an unknown lifetime `'a`. `T` is bounded such that any
+// *references* in `T` must outlive `'a`. Additionally, the lifetime
+// of `Ref` may not exceed `'a`.
 
 // A generic function which prints using the `Debug` trait.
 fn print<T>(t: T) where
@@ -14,7 +14,7 @@ fn print<T>(t: T) where
 }
 
 // Here a reference to `T` is taken where `T` implements
-// `Debug` and *all* references in `T` outlive `'a`. In
+// `Debug` and all *references* in `T` outlive `'a`. In
 // addition, `'a` must outlive the function.
 fn print_ref<'a, T>(t: &'a T) where
     T: Debug + 'a {
@@ -24,7 +24,7 @@ fn print_ref<'a, T>(t: &'a T) where
 fn main() {
     let x = 7;
     let ref_x = Ref(&x);
-
-    print_ref(&ref_x);
+    
     print(ref_x);
+    print_ref(&ref_x);
 }

--- a/examples/scope/lifetime/lifetime_bounds/input.md
+++ b/examples/scope/lifetime/lifetime_bounds/input.md
@@ -1,16 +1,20 @@
-Just like generic types can be bounded, lifetimes as generics themselves
-utilize bounds also. `:` has a slightly different meaning than in
-[generics][bounds] but `+` hasn't changed. Both are described below:
+Just like generic types can be bounded, lifetimes (themselves generic)
+use bounds as well. The `:` character has a slightly different meaning here, 
+but `+` is the same. Note how the following read:
 
 1. `T: 'a`: *All* references in `T` must outlive lifetime `'a`.
 2. `T: Trait + 'a`: Type `T` must implement trait `Trait` and *all* references
 in `T` must outlive `'a`.
 
+The example below shows the above syntax in action:
+
 {bounds.play}
 
 ### See also:
 
-[generics][generics] and [bounds in generics][bounds]
+[generics][generics], [bounds in generics][bounds], and 
+[multiple bounds in generics][multibounds]
 
 [generics]: /generics.html
 [bounds]: /generics/bounds.html
+[multibounds]: /generics/multi_bounds.html

--- a/examples/scope/lifetime/lifetime_coercion/coercion.rs
+++ b/examples/scope/lifetime/lifetime_coercion/coercion.rs
@@ -1,21 +1,22 @@
-// `x` is a reference with lifetime `'a` which is larger than `'b`.
-// Both `'a` and `'b` are larger than `coerce_first`. Since `'a` is
-// larger than `'b`, it may be coerced.
-fn coerce_first<'a: 'b, 'b>(x: &'a i32, _: &'b i32) -> &'b i32 {
-    x
+// Here, Rust infers a lifetime that is as short as possible.
+// The two references are then coerced to that lifetime.
+fn multiply<'a>(first: &'a i32, second: &'a i32) -> i32 {
+    first * second
+}
+
+// `<'a: 'b, 'b>` reads as lifetime `'a` is at least as long as `'b`.
+// Here, we take in an `&'a i32` and return a `&'b i32` as a result of coercion.
+fn choose_first<'a: 'b, 'b>(first: &'a i32, _: &'b i32) -> &'b i32 {
+    first
 }
 
 fn main() {
-    let x = 800;
-    let y = 8;
-
-    let borrow_big = &x;
+    let first = 2; // Longer lifetime
+    
     {
-        // This reference is inside a scope and therefore is
-        // smaller than the other borrow.
-        let borrow_small = &y;
-
-        let coerced = coerce_first(borrow_big, borrow_small);
-        println!("`coerced` is {}", coerced);
-    }
+        let second = 3; // Shorter lifetime
+        
+        println!("The product is {}", multiply(&first, &second));
+        println!("{} is the first", choose_first(&first, &second));
+    };
 }

--- a/examples/scope/lifetime/lifetime_coercion/input.md
+++ b/examples/scope/lifetime/lifetime_coercion/input.md
@@ -1,4 +1,6 @@
-A lifetime may be coerced into another if the the original is larger than
-the new lifetime:
+A longer lifetime can be coerced into a shorter one 
+so that it works inside a scope it normally wouldn't work in.
+This comes in the form of inferred coercion by the Rust compiler,
+and also in the form of declaring a lifetime difference:
 
 {coercion.play}


### PR DESCRIPTION
Improved readability, changed coercion example to involve less confusion
with respect to scoping (and reduce redundancy)