### PR TITLE
Functions/Closures/Examples (8.2.6.2) fix typo

### DIFF
--- a/examples/fn/closures/closure_examples/iter_find/input.md
+++ b/examples/fn/closures/closure_examples/iter_find/input.md
@@ -1,5 +1,5 @@
 `Iterator::find` is a function which when passed an iterator, will return
-the first element which satisfies the predicate as an `Option`. It's
+the first element which satisfies the predicate as an `Option`. Its
 signature:
 
 ```rust


### PR DESCRIPTION
Possessive "Its" rather than contraction "It's"