### PR TITLE
RAII: Prefix unused box variables with "_"

### DIFF
--- a/examples/scope/raii/raii.rs
+++ b/examples/scope/raii/raii.rs
@@ -1,21 +1,21 @@
 // raii.rs
 fn create_box() {
     // Allocate an integer on the heap
-    let box1 = Box::new(3i32);
+    let _box1 = Box::new(3i32);
 
-    // `box1` is destroyed here, and memory gets freed
+    // `_box1` is destroyed here, and memory gets freed
 }
 
 fn main() {
     // Allocate an integer on the heap
-    let box2 = Box::new(5i32);
+    let _box2 = Box::new(5i32);
 
     // A nested scope:
     {
         // Allocate an integer on the heap
-        let box3 = Box::new(4i32);
+        let _box3 = Box::new(4i32);
 
-        // `box3` is destroyed here, and memory gets freed
+        // `_box3` is destroyed here, and memory gets freed
     }
 
     // Creating lots of boxes just for fun
@@ -24,5 +24,5 @@ fn main() {
         create_box();
     }
 
-    // `box2` is destroyed here, and memory gets freed
+    // `_box2` is destroyed here, and memory gets freed
 }


### PR DESCRIPTION
This example explains the concept of RAII but never use the `box*` variables.
It currently triggers compiler warning, which is confusing for new users and could
be easily avoided by prefixing the variables with an underscore.