### PR TITLE
More accurate grammar terms in example

### DIFF
--- a/examples/hello/print/print.rs
+++ b/examples/hello/print/print.rs
@@ -11,10 +11,10 @@ fn main() {
     println!("{0}, this is {1}. {1}, this is {0}", "Alice", "Bob");
 
     // As can named arguments.
-    println!("{subject} {verb} {predicate}",
-             predicate="over the lazy dog",
+    println!("{subject} {verb} {object}",
+             object="the lazy dog",
              subject="the quick brown fox",
-             verb="jumps");
+             verb="jumps over");
 
     // Special formatting can be specified after a `:`.
     println!("{} of {:b} people know binary, the other half don't", 1, 2);


### PR DESCRIPTION
"Predicate" here would be the entire latter part of the sentence, verb + object. See https://en.wikipedia.org/wiki/Predicate_(grammar) . Could alternatively write "verb_phrase" for "verb". This is admittedly a petty commit. Thanks so much for excellent starter materials!