### PR TITLE
Remove confusing reuse of variables `a` and `b`

### DIFF
--- a/examples/error/option_with_result/combinator_combinations/result_try.rs
+++ b/examples/error/option_with_result/combinator_combinations/result_try.rs
@@ -31,8 +31,8 @@ fn get_data(path: &str) -> Result<String> {
 }
 
 // Concat the contents of the two files together into a new `Result`.
-fn concat(a: &str, b: &str) -> Result<String> {
-    let (data_a, data_b) = (get_data(a), get_data(b));
+fn concat(filename_a: &str, filename_b: &str) -> Result<String> {
+    let (data_a, data_b) = (get_data(filename_a), get_data(filename_b));
     
     data_a.and_then(|a|
         // Return `Ok` when both `a` and `b` are `Ok`. Otherwise return


### PR DESCRIPTION
The `concat` function takes two strings that represent the filenames of the two file to open.
Later in the code, the two closures use `a` and `b` as the name of the argument, this is confusing
and could be avoided if we rename the arguments of `concat` to `filename_a` and `filename_b`.