### PR TITLE
generics/gen_fn: fix warning about unused variable

### DIFF
--- a/examples/generics/gen_fn/fn.rs
+++ b/examples/generics/gen_fn/fn.rs
@@ -7,21 +7,21 @@ struct SGen<T>(T); // Generic type `SGen`.
 
 // Define a function `reg_fn` that takes an argument `s` of type `S`.
 // This has no `<T>` so this is not a generic function.
-fn reg_fn(s: S) {}
+fn reg_fn(_s: S) {}
 
 // Define a function `gen_spec_t` that takes an argument `s` of type `SGen<T>`
 // that has been explicitly given the type parameter `A`. Because A has not 
 // been specified as a generic type parameter for gen_spec_t, it is not generic.
-fn gen_spec_t(s: SGen<A>) {}
+fn gen_spec_t(_s: SGen<A>) {}
 
 // Define a function `gen_spec_i32` that takes an argument `s` of type `SGen<i32>`
 // that has been explicitly given the type parameter `i32`.
 // This function is also not generic.
-fn gen_spec_i32(s: SGen<i32>) {}
+fn gen_spec_i32(_s: SGen<i32>) {}
 
 // Define a function `generic` that takes an argument `s` of type `SGen<T>`.
 // Because `SGen<T>` is preceded by `<T>`, this function is generic over `T`.
-fn generic<T>(s: SGen<T>) {}
+fn generic<T>(_s: SGen<T>) {}
 
 fn main() {
     // Using the non-generic functions


### PR DESCRIPTION
This is a small fix to remove the following
```
warning: unused variable: `s`, #[warn(unused_variables)] on by default
```
in the code of the `generics/gen_fn` example.