### PR TITLE
Moving macro section to after traits

### DIFF
--- a/examples/structure.json
+++ b/examples/structure.json
@@ -69,12 +69,6 @@
         ] },
         { "id": "hof", "title": "Higher Order Functions", "children": null }
     ] },
-    { "id": "macros", "title": "macro_rules!", "children": [
-        { "id": "designators", "title": "Designators", "children": null },
-        { "id": "overload", "title": "Overload", "children": null },
-        { "id": "repeat", "title": "Repeat", "children": null },
-        { "id": "dry", "title": "DRY (Don't Repeat Yourself)", "children": null }
-    ] },
     { "id": "mod", "title": "Modules", "children": [
         { "id": "visibility", "title": "Visibility", "children": null },
         { "id": "struct_visibility", "title": "Struct visibility", "children": null },
@@ -138,6 +132,12 @@
         { "id": "drop", "title": "Drop", "children": null },
         { "id": "iter", "title": "Iterators", "children": null },
         { "id": "clone", "title": "Clone", "children": null }
+    ] },
+    { "id": "macros", "title": "macro_rules!", "children": [
+        { "id": "designators", "title": "Designators", "children": null },
+        { "id": "overload", "title": "Overload", "children": null },
+        { "id": "repeat", "title": "Repeat", "children": null },
+        { "id": "dry", "title": "DRY (Don't Repeat Yourself)", "children": null }
     ] },
     { "id": "error", "title": "Error handling", "children": [
         { "id": "unwrap", "title": "Option & unwrap", "children": null },


### PR DESCRIPTION
Even as a lisp veteran none of the macro examples were useful without understanding the basics first. Some of the more complex macro examples introduce trait restrictions on generics. A new Rustacean needs to learn about traits and scope and ownership before they can follow the `macro_expand!` section.