### PR TITLE
Updated Ch16.7, 16.7.1

### DIFF
--- a/examples/error/option_with_result/input.md
+++ b/examples/error/option_with_result/input.md
@@ -1,16 +1,16 @@
-The previous examples have always been very convenient; a `Result` interacts with the same
-`Results` and an `Option` with the same `Option`. Sometimes it is not this easy though;
-`Options` and `Results` may have to interact or even `Result<T, Error1>` with
-`Result<T, Error2>`.
+In the following sections, we will see how to combine separate operations returning 
+`Option` and `Result` into a single operation that returns whichever one makes the 
+most sense.
 
-Here is an example where one returns an `Option` and the other returns an `Result`. Aside
-from messy errors provided by `unwrap`, this looks reasonable:
+The previous examples have always been very convenient; a `Result` interacted 
+with another `Result` and an `Option` interacted with another `Option`. Unfortunately, 
+it's not always that easy. An `Option` may have to interact with a `Result`, and a 
+`Result<T, Error1>` may have to interact with a `Result<T, Error2>`.
+
+To start us off, the example below uses `Vec::first` and `parse::<i32>` with `unwrap` to 
+generate errors. `Vec::first` returns an `Option`, while `parse::<i32>` 
+returns a `Result<i32, ParseIntError>`.
+
+Note that this code "works", but is meant to showcase **improper** error handling: 
 
 {option_result.play}
-
-### See also:
-
-[`Result`][result] and [`io::Result`][io_result]
-
-[result]: http://doc.rust-lang.org/std/result/enum.Result.html
-[io_result]: http://doc.rust-lang.org/std/io/type.Result.html

--- a/examples/error/option_with_result/option_result.rs
+++ b/examples/error/option_with_result/option_result.rs
@@ -1,10 +1,9 @@
-// The first attempt conveniently uses `unwrap` with the aforementioned
-// bad errors it results in.
+// Our first attempt uses `unwrap` and provides unhelpful errors.
 fn double_first(vec: Vec<&str>) -> i32 {
-    // What if the vector is empty?
+    // Returns an error if the input vector is empty:
     let first = vec.first().unwrap();
 
-    // What if the element doesn't parse to a number?
+    // Returns an error if the element doesn't parse to a number:
     2 * first.parse::<i32>().unwrap()
 }
 
@@ -14,7 +13,11 @@ fn main() {
     let strings = vec!["tofu", "93", "18"];
 
     println!("The first doubled is {}", double_first(numbers));
+    
+    // This line results in the first error:
     println!("The first doubled is {}", double_first(empty));
-    // ^ Comment out this line to see the second error.
+    // ^ Comment this out to see the second error.
+    
+    // This line results in a second error:
     println!("The first doubled is {}", double_first(strings));
 }

--- a/examples/error/option_with_result/result_string_errors/input.md
+++ b/examples/error/option_with_result/result_string_errors/input.md
@@ -1,17 +1,11 @@
-Eliminating `unwrap` from the previous example requires more care. The two types in play
-being `Option` and `Result`, one valid approach would be to convert both into a `Result`
-with a common `Err` type. We will try it with `Err(String)` which seems like a nice first
-approximation:
+From our previous example, one method of solving our issue with `unwrap` is to remove it.
+In doing so, we must move from implicit to explicit error handling. Since the only 
+types in play are `Option` and `Result`, we can consider converting both into 
+`Result`s with the same `Err` type. For our first attempt at this solution, 
+let's try using a `String` for our error:
 
 {result_string.play}
 
-This is not too bad but it is hardly as nice as the original (it can still be nicer but
-we are not there yet). The question is, does this approach scale well. Consider the next
-example.
-
-### See also:
-
-[`Result`][result] and [`io::Result`][io_result]
-
-[result]: http://doc.rust-lang.org/std/result/enum.Result.html
-[io_result]: http://doc.rust-lang.org/std/io/type.Result.html
+This is not too bad, but it is hardly as nice as the original (it can still be nicer but
+we are not there yet). Unfortunately, this approach scales poorly with increasing 
+numbers of `Result`s, as will be seen in the next example.

--- a/examples/error/option_with_result/result_string_errors/result_string.rs
+++ b/examples/error/option_with_result/result_string_errors/result_string.rs
@@ -1,16 +1,17 @@
+// Use `String` as our error type
 type Result<T> = std::result::Result<T, String>;
 
 fn double_first(vec: Vec<&str>) -> Result<i32> {
     vec.first()
-       // Convert the `Option` to a `Result` if there is a value; otherwise
-       // use an `Err` containing this `String`.
+       // Convert the `Option` to a `Result` if there is a value.
+       // Otherwise, provide an `Err` containing this `String`.
        .ok_or("Please use a vector with at least one element.".to_owned())
-       // `parse` returns a `Result<T, ParseIntError>`.
+       // Recall that `parse` returns a `Result<T, ParseIntError>`.
        .and_then(|s| s.parse::<i32>()
-                      //  The return type is `Result<T, String>`. We need
-                      //  to map only the errors `parse` yields to `String`.
+                      // Map the errors `parse` yields to `String`.
+                      // The return type is then `Result<T, String>`.
                       .map_err(|e| e.to_string())
-                      // Apply the double to the number inside.
+                      // At this point, we can double the number inside.
                       .map(|i| 2 * i))
 }
 

--- a/examples/structure.json
+++ b/examples/structure.json
@@ -148,7 +148,7 @@
             { "id": "result_alias", "title": "aliases for Result", "children": null }
         ] }, 
         { "id": "option_with_result", "title": "Options with Results", "children": [
-            { "id": "result_string_errors", "title": "Errors as strings", "children": null },
+            { "id": "result_string_errors", "title": "Strings as errors", "children": null },
             { "id": "combinator_combinations", "title": "Combining separate combinators", "children": null },
             { "id": "enter_try", "title": "Enter try!", "children": null }
         ] },


### PR DESCRIPTION
Reword sections for clarity
Renamed "Errors as strings" to "Strings as errors"
Removed unhelpful See Also links