### PR TITLE
Use method syntax when getting the description of an error

### DIFF
--- a/examples/std_misc/file/create/create.rs
+++ b/examples/std_misc/file/create/create.rs
@@ -20,7 +20,7 @@ fn main() {
     let mut file = match File::create(&path) {
         Err(why) => panic!("couldn't create {}: {}",
                            display,
-                           Error::description(&why)),
+                           why.description()),
         Ok(file) => file,
     };
 
@@ -28,7 +28,7 @@ fn main() {
     match file.write_all(LOREM_IPSUM.as_bytes()) {
         Err(why) => {
             panic!("couldn't write to {}: {}", display,
-                                               Error::description(&why))
+                                               why.description())
         },
         Ok(_) => println!("successfully wrote to {}", display),
     }

--- a/examples/std_misc/file/open/open.rs
+++ b/examples/std_misc/file/open/open.rs
@@ -13,7 +13,7 @@ fn main() {
         // The `description` method of `io::Error` returns a string that
         // describes the error
         Err(why) => panic!("couldn't open {}: {}", display,
-                                                   Error::description(&why)),
+                                                   why.description()),
         Ok(file) => file,
     };
 
@@ -21,7 +21,7 @@ fn main() {
     let mut s = String::new();
     match file.read_to_string(&mut s) {
         Err(why) => panic!("couldn't read {}: {}", display,
-                                                   Error::description(&why)),
+                                                   why.description()),
         Ok(_) => print!("{} contains:\n{}", display, s),
     }
 

--- a/examples/std_misc/process/pipe/pipe.rs
+++ b/examples/std_misc/process/pipe/pipe.rs
@@ -11,7 +11,7 @@ fn main() {
                                 .stdin(Stdio::piped())
                                 .stdout(Stdio::piped())
                                 .spawn() {
-        Err(why) => panic!("couldn't spawn wc: {}", Error::description(&why)),
+        Err(why) => panic!("couldn't spawn wc: {}", why.description()),
         Ok(process) => process,
     };
 
@@ -21,7 +21,7 @@ fn main() {
     // must have one, we can directly `unwrap` it.
     match process.stdin.unwrap().write_all(PANGRAM.as_bytes()) {
         Err(why) => panic!("couldn't write to wc stdin: {}",
-                           Error::description(&why)),
+                           why.description()),
         Ok(_) => println!("sent pangram to wc"),
     }
 
@@ -35,7 +35,7 @@ fn main() {
     let mut s = String::new();
     match process.stdout.unwrap().read_to_string(&mut s) {
         Err(why) => panic!("couldn't read wc stdout: {}",
-                           Error::description(&why)),
+                           why.description()),
         Ok(_) => print!("wc responded with:\n{}", s),
     }
 }

--- a/src/markdown.rs
+++ b/src/markdown.rs
@@ -170,6 +170,6 @@ impl<'a, 'b> Markdown<'a, 'b> {
         let path = Path::new(path_str);
 
         file::write(&path, &self.content)
-            .map_err(|ref e| Error::description(e).to_string())
+            .map_err(|ref e| e.description().to_string())
     }
 }


### PR DESCRIPTION
These get copied enough by newbies that then show up on Stack Overflow that I decided to nip it at the source. :-)