### PR TITLE
Reordering and rewording in Ch8.2, 8.2.2

### DIFF
--- a/examples/fn/closures/input.md
+++ b/examples/fn/closures/input.md
@@ -1,13 +1,18 @@
-Closures in Rust, also called lambdas, are functions 
-that can capture the enclosing environment. Their syntax and capabilities make them
-very convenient for on the fly usage. Some characteristics include:
+Closures in Rust, also called lambdas, are functions that can capture 
+the enclosing environment. For example, a closure that captures the x 
+variable:
+```Rust
+|val| val + x
+```
 
-* uses `||` instead of `()` around input variables.
-* *both* input and return *types* can be inferred.
-* input variable *names* must be specified.
-* body delimination (`{}`) is optional for a single expression. Mandatory
-otherwise.
-* the outer environment variables *may* be captured.
-* calling a closure is exactly like a function: `call(var)`.
+The syntax and capabilities of closures make them very convenient for 
+on the fly usage. Calling a closure is exactly like calling a function.
+However, both input and return types *can* be inferred and input 
+variable names *must* be specified.
+
+Other characteristics of closures include:
+* using `||` instead of `()` around input variables.
+* optional body delimination (`{}`) for a single expression (mandatory otherwise).
+* optional capturing of the outer environment variables.
 
 {closures.play}

--- a/examples/fn/closures/input.md
+++ b/examples/fn/closures/input.md
@@ -13,6 +13,6 @@ variable names *must* be specified.
 Other characteristics of closures include:
 * using `||` instead of `()` around input variables.
 * optional body delimination (`{}`) for a single expression (mandatory otherwise).
-* optional capturing of the outer environment variables.
+* the ability to capture the outer environment variables.
 
 {closures.play}

--- a/examples/fn/closures/input_parameters/input.md
+++ b/examples/fn/closures/input_parameters/input.md
@@ -1,23 +1,24 @@
-It has been noted that Rust chooses how to capture variables on the fly
-without annotation. This is all very convenient in normal usage however when
-writing functions, this ambiguity is not allowed. The closure's complete
-type, including which capturing type, must be annotated. The manner of capture
-a closure uses is annotated as one of the following `traits`:
+While Rust chooses how to capture variables on the fly mostly without 
+annotation, this ambiguity is not allowed when writing functions. When 
+taking a closure as an input parameter, Rust will preferentially capture 
+variables in the least restrictive manner possible on a variable-by-variable 
+basis.
 
-* `Fn`: takes captures by reference (`&T`)
-* `FnMut`: takes captures by mutable reference (`&mut T`)
-* `FnOnce`: takes captures by value (`T`)
+A closure's complete type must be annotated, including the captured type, as 
+one of the following `traits`:
+
+* `Fn`: the closure takes capture by reference (`&T`)
+* `FnMut`: the closure takes capture by mutable reference (`&mut T`)
+* `FnOnce`: the closure takes capture by value (`T`)
 
 Even annotated, these are very flexible: a parameter of `FnOnce` specifies
-the closure *may* capture by `T` or `&mut T` or `&T` at will (if a move is
-possible, any type of borrow should also be possible). The reverse is not
-true: if the parameter is `Fn`, then nothing lower is allowed. Therefore,
-the rule is:
+the closure *may* capture by `T`, `&mut T`, or `&T` at will. This is because  
+if a move is possible, then any type of borrow should also be possible. The 
+reverse is not true: if the parameter is `Fn`, then nothing lower on the 
+list is allowed. 
 
-* any annotated parameter restricts capture to itself and above
-
-In addition, Rust will preferentially capture variables in the least
-restrictive manner possible on a variable-by-variable basis:
+In the following example, try swapping the usage of `Fn`, `FnMut`, and 
+`FnOnce` to see what happens:
 
 {input_parameters.play}
 

--- a/examples/fn/closures/input_parameters/input.md
+++ b/examples/fn/closures/input_parameters/input.md
@@ -1,21 +1,25 @@
-While Rust chooses how to capture variables on the fly mostly without 
+While Rust chooses how to capture variables on the fly mostly without type 
 annotation, this ambiguity is not allowed when writing functions. When 
-taking a closure as an input parameter, Rust will preferentially capture 
-variables in the least restrictive manner possible on a variable-by-variable 
-basis.
+taking a closure as an input parameter, the closure's complete type must be 
+annotated using one of a few `traits`. In order of decreasing restriction, 
+they are:
 
-A closure's complete type must be annotated, including the captured type, as 
-one of the following `traits`:
+* `Fn`: the closure captures by reference (`&T`)
+* `FnMut`: the closure captures by mutable reference (`&mut T`)
+* `FnOnce`: the closure captures by value (`T`)
 
-* `Fn`: the closure takes capture by reference (`&T`)
-* `FnMut`: the closure takes capture by mutable reference (`&mut T`)
-* `FnOnce`: the closure takes capture by value (`T`)
+On a variable-by-variable basis, the compiler will capture variables in the 
+least restrictive manner possible. 
 
-Even annotated, these are very flexible: a parameter of `FnOnce` specifies
-the closure *may* capture by `T`, `&mut T`, or `&T` at will. This is because  
-if a move is possible, then any type of borrow should also be possible. The 
-reverse is not true: if the parameter is `Fn`, then nothing lower on the 
-list is allowed. 
+For instance, consider a parameter annotated as `FnOnce`. This specifies 
+that the closure *may* capture by `&T`, `&mut T`, or `T`, but the compiler 
+will ultimately choose based on how the captured variables are used in the 
+closure.
+
+This is because if a move is possible, then any type of borrow should also 
+be possible. Note that the reverse is not true. If the parameter is 
+annotated as `Fn`, then capturing variables by `&mut T` or `T` are not 
+allowed.
 
 In the following example, try swapping the usage of `Fn`, `FnMut`, and 
 `FnOnce` to see what happens:


### PR DESCRIPTION
Based on some comments in issue #770:

The new wording in 8.2 should better introduce closures as they work in
Rust.

Did some reordering in 8.2.2 to make it less misleading if reader skims
the page. Length stayed roughly the same, but hopefully it's clearer in
general.