### PR TITLE
Fixes #337

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,7 @@
 bin/*
 stage/*
 node_modules/*
+!node_modules/gitbook/theme/templates/book/page.html
 !node_modules/gitbook-plugin-rust-playpen
 node_modules/gitbook-plugin-rust-playpen/book/mode-rust.js
 node_modules/gitbook-plugin-rust-playpen/book/ace

--- a/node_modules/gitbook/theme/templates/book/page.html
+++ b/node_modules/gitbook/theme/templates/book/page.html
@@ -1,0 +1,80 @@
+{% extends "../layout.html" %}
+
+{% block head %}
+    {% parent %}
+    {% if progress.current.next and progress.current.next.path %}
+    <link rel="next" href="{{ basePath }}/{{ progress.current.next.path|mdLink }}" />
+    {% endif %}
+    {% if progress.current.prev and progress.current.prev.path %}
+    <link rel="prev" href="{{ basePath }}/{{ progress.current.prev.path|mdLink }}" />
+    {% endif %}
+{% endblock %}
+
+{% block title %}{{ progress.current.title }} | {{ title }}{% endblock %}
+{% block description %}{% if progress.current.level == "0" %}{{ description }}{% endif %}{% endblock %}
+
+{% block content %}
+    <div class="book" data-level="{{ progress.current.level }}" data-basepath="{{ basePath }}" data-revision="{{ revision }}">
+    {% include "includes/summary.html" %}
+    <div class="book-body">
+        <div class="body-inner">
+            {% include "includes/header.html" %}
+            <div class="page-wrapper" tabindex="-1">
+                <div class="page-inner">
+                {% block page_inner %}
+                {% for section in content %}
+                    <section class="{{ section.type }}" id="section-{{ section.id }}">
+                    {% if section.type == "normal" %}
+                        {% autoescape false %}{{ section.content }}{% endautoescape %}
+                    {% elif section.type == "exercise" %}
+                        {% include "./includes/exercise.html" with {section: section} %}
+                    {% elif section.type == "quiz" %}
+                        {% include "./includes/quiz.html" with {section: section} %}
+                    {% endif %}
+                    {% if progress.current.level != 0 %}
+                    <a href="https://github.com/rust-lang/rust-by-example/blob/master/examples/{{ progress.current.path|replace(".md","") }}/input.md" target="_blank" class="pull-right" aria-label="Edit on Github"><i class="fa fa-github"></i> Edit this page on Github</a>
+                    {% endif %}
+                    </section>
+                {% endfor %}
+                {% endblock %}
+                </div>
+            </div>
+        </div>
+
+        {% if progress.current.prev and progress.current.prev.path %}
+        <a href="{{ basePath }}/{{ progress.current.prev.path|mdLink }}" class="navigation navigation-prev {% if !progress.current.next or !progress.current.next.path %}navigation-unique{% endif %}" aria-label="Previous page: {{ progress.current.prev.title }}"><i class="fa fa-angle-left"></i></a>
+        {% endif %}
+        {% if progress.current.next and progress.current.next.path %}
+        <a href="{{ basePath }}/{{ progress.current.next.path|mdLink }}" class="navigation navigation-next {% if !progress.current.prev or !progress.current.prev.path %}navigation-unique{% endif %}" aria-label="Next page: {{ progress.current.next.title }}"><i class="fa fa-angle-right"></i></a>
+        {% endif %}
+    </div>
+</div>
+{% endblock %}
+
+{% block javascript %}
+<script src="{{ staticBase }}/app.js"></script>
+{% for resource in plugins.resources.js %}
+    {% if resource.url %}
+    <script src="{{ resource.url }}"></script>
+    {% else %}
+    <script src="{{ staticBase }}/plugins/{{ resource.path }}"></script>
+    {% endif %}
+{% endfor %}
+<script>
+require(["gitbook"], function(gitbook) {
+    var config = {% autoescape false %}{{ pluginsConfig }}{% endautoescape %};
+    gitbook.start(config);
+});
+</script>
+{% endblock %}
+
+{% block style %}
+<link rel="stylesheet" href="{{ staticBase }}/style.css">
+{% for resource in plugins.resources.css %}
+    {% if resource.url %}
+    <link rel="stylesheet" href="{{ resource.url }}">
+    {% else %}
+    <link rel="stylesheet" href="{{ staticBase }}/plugins/{{ resource.path }}">
+    {% endif %}
+{% endfor %}
+{% endblock %}


### PR DESCRIPTION
Added a "Edit on Github" link. The button links to the _specific_ page that it is on.

Modified .gitignore to track the Gitbook template file.

The button does not appear in the [Introduction](http://rustbyexample.com/index.html) but it appears on the other pages.

The image below shows the button at the end of [8 Functions](http://rustbyexample.com/fn.html) (see the far right)
![edit-button](https://cloud.githubusercontent.com/assets/11559809/16819274/f5a78984-494b-11e6-9b1f-c5f9adf3196a.png)

So, the above button links to https://github.com/rust-lang/rust-by-example/blob/master/examples/fn/input.md