### PR TITLE
5.3: trivial_numeric_casts is now allowed by default

### DIFF
--- a/examples/cast/alias/alias.rs
+++ b/examples/cast/alias/alias.rs
@@ -7,8 +7,6 @@ type Inch = u64;
 type u64_t = u64;
 // TODO ^ Try removing the attribute
 
-// Use an attribute to silence warnings
-#[allow(trivial_numeric_casts)]
 fn main() {
     // `NanoSecond` = `Inch` = `u64_t` = `u64`.
     let nanoseconds: NanoSecond = 5 as u64_t;


### PR DESCRIPTION
Fix #729