### PR TITLE
Removed derive attribute, to avoid confusion

### DIFF
--- a/examples/flow_control/match/destructuring/destructure_enum/enum.rs
+++ b/examples/flow_control/match/destructuring/destructure_enum/enum.rs
@@ -1,8 +1,6 @@
-// Must derive `Debug` so `println!` can be used.
 // `allow` required to silence warnings because only
 // one variant is used.
 #[allow(dead_code)]
-#[derive(Debug)]
 enum Color {
     // These 3 are specified solely by their name.
     Red,

--- a/examples/flow_control/match/destructuring/destructure_enum/input.md
+++ b/examples/flow_control/match/destructuring/destructure_enum/input.md
@@ -4,10 +4,8 @@ An `enum` is destructured similarly:
 
 ### See also:
 
-[`#[allow(...)]`][allow], [color models][color_models], [`enum`][enum],
-and [`#[derive(...)]`][derive]
+[`#[allow(...)]`][allow], [color models][color_models] and [`enum`][enum]
 
 [allow]: /attribute/unused.html
 [color_models]: http://en.wikipedia.org/wiki/Color_model
-[derive]: /trait/derive.html
 [enum]: /custom_types/enum.html


### PR DESCRIPTION
I think the '#[derive(Debug)]' is redundant here. Removing it could save people like me from confusion. 