### PR TITLE
Use structs, not tuples, for generics impl example.

### DIFF
--- a/examples/generics/impl/impl.rs
+++ b/examples/generics/impl/impl.rs
@@ -1,19 +1,24 @@
-struct Val (f64,);
-struct GenVal<T>(T,);
+struct Val {
+    val: f64
+}
+
+struct GenVal<T>{
+    gen_val: T
+}
 
 // impl of Val
 impl Val {
-    fn value(&self) -> &f64 { &self.0 }
+    fn value(&self) -> &f64 { &self.val }
 }
 
 // impl of GenVal for a generic type `T`
 impl <T> GenVal<T> {
-    fn value(&self) -> &T { &self.0 }
+    fn value(&self) -> &T { &self.gen_val }
 }
 
 fn main() {
-    let x = Val(3.0);
-    let y = GenVal(3i32);
+    let x = Val { val: 3.0 };
+    let y = GenVal { gen_val: 3i32 };
     
     println!("{}, {}", x.value(), y.value());
 }


### PR DESCRIPTION
Over IRC, had a user say they found the usage of tuple get syntax
to be confusing (`self.0`) so this patch replaces the usage of
that with more mundane syntax so that learners can focus on
the impl syntax.