### PR TITLE
Add access of tuple struct fields in structs example.

### DIFF
--- a/examples/custom_types/structs/structs.rs
+++ b/examples/custom_types/structs/structs.rs
@@ -39,6 +39,9 @@ fn main() {
     // Instantiate a tuple struct
     let pair = Pair(1, 0.1);
 
+    // Access the fields of a tuple struct
+    println!("pair contains {:?} and {:?}", pair.0, pair.1);
+
     // Destructure a tuple struct
     let Pair(integer, decimal) = pair;
 


### PR DESCRIPTION
This is where I would expect to find an example on this part
of the syntax, ergo upon not finding it, I decided to add it.