### PR TITLE
fn/methods: Clarify method comparison to static call with reference.

### DIFF
--- a/examples/fn/methods/methods.rs
+++ b/examples/fn/methods/methods.rs
@@ -80,7 +80,7 @@ fn main() {
 
     // Instance methods are called using the dot operator
     // Note that the first argument `&self` is implicitly passed, i.e.
-    // `rectangle.perimeter()` === `perimeter(&rectangle)`
+    // `rectangle.perimeter()` === `Rectangle::perimeter(&rectangle)`
     println!("Rectangle perimeter: {}", rectangle.perimeter());
     println!("Rectangle area: {}", rectangle.area());
 


### PR DESCRIPTION
When going through the example, I think it would be more clear if the full `Rectangle::` resolution was provided to make it clear that a static method is being compared against.

If the user were to copy and paste `perimeter(&rectangle)` into their editor to try it out, they will get a `unresolved name` error.