### PR TITLE
closures/output_parameters: fix typo

### DIFF
--- a/examples/fn/closures/output_parameters/input.md
+++ b/examples/fn/closures/output_parameters/input.md
@@ -1,4 +1,4 @@
-Using closures as input parameters are possible, so returning closures as 
+Closures as input parameters are possible, so returning closures as 
 output parameters should also be possible. However, returning closure types 
 are problematic because Rust currently only supports returning concrete 
 (non-generic) types. Anonymous closure types are, by definition, unknown 


### PR DESCRIPTION
I'm not English native, but I believe it is the action of "Using closures as input parameters" that is possible, thus the verb should be singular right?