### PR TITLE
generics/phantom/testcase_units/units.rs: more info

### DIFF
--- a/examples/generics/phantom/testcase_units/units.rs
+++ b/examples/generics/phantom/testcase_units/units.rs
@@ -7,11 +7,12 @@ enum Inch {}
 #[derive(Debug, Clone, Copy)]
 enum Mm {}
 
-/// `Length` is a type with phantom type parameter `Unit`.
+/// `Length` is a type with phantom type parameter `Unit`,
+/// and is not generic over the length type (that is `f64`).
 ///
 /// `f64` already implements the `Clone` and `Copy` traits.
 #[derive(Debug, Clone, Copy)]
-struct Length<Unit>(f64,PhantomData<Unit>);
+struct Length<Unit>(f64, PhantomData<Unit>);
 
 /// The `Add` trait defines the behavior of the `+` operator.
 impl<Unit> Add for Length<Unit> {
@@ -38,8 +39,8 @@ fn main() {
     let two_meters = one_meter + one_meter;
 
     // Addition works.
-    println!("one foot + one_foot = {:?}", two_feet);
-    println!("one meter + one_meter = {:?}", two_meters);
+    println!("one foot + one_foot = {:?} in", two_feet.0);
+    println!("one meter + one_meter = {:?} mm", two_meters.0);
 
     // Nonsensical operations fail as they should:
     // Compile-time Error: type mismatch.


### PR DESCRIPTION
- More info to final `println!` messages:
	- I think that the whole point of this exercise is to understand
	that we can use a generic Phantom parameter to enforce type constraints 
	at compile time, indeed is good to explicitly show the result of the sum with
	the two different unit of measure in the printed messages.
	
- More doc info about `Length` struct:
	- While I was re writing the example I wanted to add a `Bit` enum
	and use `Length` over `u32` (something like `let one_byte = // sum 8 one_bit `)
        value but then I realized that `Length` is not generic over the length itself.	
	
- I think it would be nice to extend this example using `Length`
	that is generic over `T`, is it feasible ?