### PR TITLE
scope/borrow/borrow.rs: more info

### DIFF
--- a/examples/scope/borrow/borrow.rs
+++ b/examples/scope/borrow/borrow.rs
@@ -1,34 +1,35 @@
-// This function takes ownership of a box and destroys it 
-fn eat_box(boxed_int: Box<i32>) {
-    println!("Destroying box that contains {}", boxed_int);
+// This function takes ownership of a box and destroys it
+fn eat_box_i32(boxed_i32: Box<i32>) {
+    println!("Destroying box that contains {}", boxed_i32);
 }
 
 // This function borrows an i32
-fn borrow_box(borrowed_int: &i32) {
-    println!("This int is: {}", borrowed_int);
+fn borrow_i32(borrowed_i32: &i32) {
+    println!("This int is: {}", borrowed_i32);
 }
 
 fn main() {
-    // Create a boxed integer
-    let boxed_int = Box::new(5);
+    // Create a boxed i32, and a stacked i32
+    let boxed_i32 = Box::new(5_i32);
+    let stacked_i32 = 6_i32;
 
     // Borrow the contents of the box. Ownership is not taken,
     // so the contents can be borrowed again.
-    borrow_box(&boxed_int);
-    borrow_box(&boxed_int);
+    borrow_i32(&boxed_i32);
+    borrow_i32(&stacked_i32);
 
     {
         // Take a reference to the data contained inside the box
-        let _ref_to_int: &i32 = &boxed_int;
+        let _ref_to_i32: &i32 = &boxed_i32;
 
-        // Error! 
-        // Can't destroy `boxed_int` while the inner value is borrowed.
-        eat_box(boxed_int);
+        // Error!
+        // Can't destroy `boxed_i32` while the inner value is borrowed.
+        eat_box_i32(boxed_i32);
         // FIXME ^ Comment out this line
 
-        // `_ref_to_int` goes out of scope and is no longer borrowed.
+        // `_ref_to_i32` goes out of scope and is no longer borrowed.
     }
 
-    // Box can now give up ownership to `eat_box` and be destroyed
-    eat_box(boxed_int);
+    // `boxed_i32` can now give up ownership to `eat_box` and be destroyed
+    eat_box_i32(boxed_i32);
 }


### PR DESCRIPTION
I think that `borrow_i32` is a better name in this case
because it is not restricted to `Box<i32>` but it can borrow
also a stack-allocated `i32`.

More emphasis is given to the type system using `i32` instead of `int`
in variables names. We can revert back to `int` if you don't like 
the book's syntax highlight.

Comments are changed accordingly.