### PR TITLE
scope/lifetime/methods/methods.rs: minor fix

### DIFF
--- a/examples/scope/lifetime/methods/methods.rs
+++ b/examples/scope/lifetime/methods/methods.rs
@@ -2,7 +2,7 @@ struct Owner(i32);
 
 impl Owner {
     // Annotate lifetimes as in a standalone function.
-    fn add_one<'a>(&'a mut self) { self.0 += 1 }
+    fn add_one<'a>(&'a mut self) { self.0 += 1; }
     fn print<'a>(&'a self) {
         println!("`print`: {}", self.0);
     }


### PR DESCRIPTION
Put a semicolon and implicitly return the unit type.