### PR TITLE
scope/borrow/alias/alias.rs: more info

### DIFF
--- a/examples/scope/borrow/alias/alias.rs
+++ b/examples/scope/borrow/alias/alias.rs
@@ -36,10 +36,15 @@ fn main() {
         //println!("Point Z coordinate is {}", point.z);
         // TODO ^ Try uncommenting this line
 
+        // Ok! Mutable references can be passed as immutable to `println!`
+        println!("Point has coordinates: ({}, {}, {})",
+                 mutable_borrow.x, mutable_borrow.y, mutable_borrow.z);
+
         // Mutable reference goes out of scope
     }
 
     // Immutable references to point are allowed again
+    let borrowed_point = &point;
     println!("Point now has coordinates: ({}, {}, {})",
-             point.x, point.y, point.z);
+             borrowed_point.x, borrowed_point.y, borrowed_point.z);
 }


### PR DESCRIPTION
Clarify single mutable reference vs multiple references

p.s. Maybe `alias` is not a super good name in this example, because I think is more correct
in the context of `type` aliasing. In this context we are just creating multiple references 
(different type from the owner) and not aliases (same type of the owner with different names).

Hope it helps :smiley: 