### PR TITLE
fn/closures/capture/capture.rs: minor fix

### DIFF
--- a/examples/fn/closures/capture/capture.rs
+++ b/examples/fn/closures/capture/capture.rs
@@ -1,6 +1,6 @@
 fn main() {
     use std::mem;
-    
+
     let color = "green";
 
     // A closure to print `color` which immediately borrows (`&`)
@@ -11,7 +11,6 @@ fn main() {
     let print = || println!("`color`: {}", color);
 
     // Call the closure using the borrow.
-    print();
     print();
 
     let mut count = 0;
@@ -34,7 +33,7 @@ fn main() {
 
     //let reborrow = &mut count;
     // ^ TODO: try uncommenting this line.
-    
+
     // A non-copy type.
     let movable = Box::new(3);
 


### PR DESCRIPTION
Remove duplicate `print()`
