### PR TITLE
fn/hof: destructure in `filter` like `take_while`

### DIFF
--- a/examples/fn/hof/hof.rs
+++ b/examples/fn/hof/hof.rs
@@ -28,7 +28,7 @@ fn main() {
     let sum_of_squared_odd_numbers: u32 =
         (0..).map(|n| n * n)             // All natural numbers squared
              .take_while(|&n| n < upper) // Below upper limit
-             .filter(|n| is_odd(*n))     // That are odd
+             .filter(|&n| is_odd(n))     // That are odd
              .fold(0, |sum, i| sum + i); // Sum them
     println!("functional style: {}", sum_of_squared_odd_numbers);
 }


### PR DESCRIPTION
This makes it more consistent with the fn/closures/closure_examples.