### PR TITLE
Removed unneeded usage of std::result.

### DIFF
--- a/examples/error/result/result_alias/alias.rs
+++ b/examples/error/result/result_alias/alias.rs
@@ -1,8 +1,7 @@
 use std::num::ParseIntError;
-use std::result;
 
 // Define a generic alias for a `Result` with the error type `ParseIntError`.
-type AliasedResult<T> = result::Result<T, ParseIntError>;
+type AliasedResult<T> = Result<T, ParseIntError>;
 
 // Use the above alias to refer to our specific `Result` type.
 fn double_number(number_str: &str) -> AliasedResult<i32> {


### PR DESCRIPTION
Fixed issue #821: Usage of std::result in "aliases for Result" chapter.