### PR TITLE
error: Fix formatting by removing trailing spaces

### DIFF
--- a/examples/error/input.md
+++ b/examples/error/input.md
@@ -1,9 +1,9 @@
-Error handling is the process of handling the possibility of failure. For 
-example, failing to read a file and then continuing to use that *bad* input 
-would clearly be problematic. Noticing and explicitly managing those errors  
+Error handling is the process of handling the possibility of failure. For
+example, failing to read a file and then continuing to use that *bad* input
+would clearly be problematic. Noticing and explicitly managing those errors
 saves the rest of the program from various pitfalls.
 
-For a more rigorous discussion of error handling, refer to the error 
+For a more rigorous discussion of error handling, refer to the error
 handling section in the [official book][book].
 
 [book]: https://doc.rust-lang.org/book/error-handling.html


### PR DESCRIPTION
There's currently a line break at this point due to extraneous trailing spaces:

> Noticing and explicitly managing those errors`<br>`
> saves the rest of the program from various pitfalls.

See http://rustbyexample.com/error.html