### PR TITLE
hello/display: Change 'Point2' to 'Point2D'

### DIFF
--- a/examples/hello/print/print_display/display.rs
+++ b/examples/hello/print/print_display/display.rs
@@ -15,13 +15,13 @@ impl fmt::Display for MinMax {
 
 // Define a structure where the fields are nameable for comparison.
 #[derive(Debug)]
-struct Point2 {
+struct Point2D {
     x: f64,
     y: f64,
 }
 
-// Similarly, implement for Point2
-impl fmt::Display for Point2 {
+// Similarly, implement for Point2D
+impl fmt::Display for Point2D {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         // Customize so only `x` and `y` are denoted.
         write!(f, "x: {}, y: {}", self.x, self.y)
@@ -42,7 +42,7 @@ fn main() {
              small = small_range,
              big = big_range);
 
-    let point = Point2 { x: 3.3, y: 7.2 };
+    let point = Point2D { x: 3.3, y: 7.2 };
 
     println!("Compare points:");
     println!("Display: {}", point);


### PR DESCRIPTION
I had some confusion over the naming of the 'Point2' struct, and whether it was supposed to be named 'Point2D'. This change renames the struct.

Closes #841