### PR TITLE
Add field init shorthand example.

### DIFF
--- a/examples/custom_types/structs/structs.rs
+++ b/examples/custom_types/structs/structs.rs
@@ -33,6 +33,13 @@ fn main() {
         p2: point,
     };
 
+    // Create a struct using field initialization shorthand. When local names
+    // match the names of the public fields of the struct, you don't have to
+    // type them twice!
+    let p1 = 0.1;
+    let p2 = 0.3;
+    let _shorthand = Point { p1, p2 };
+
     // Instantiate a unit struct
     let _nil = Nil;
 


### PR DESCRIPTION
**Note:** this should *not* be merged until 1.17 lands and the field init shorthand feature lands.

Though this isn't *required* for https://github.com/rust-lang/rust/issues/37340, I'd call it a nice bonus to have it ready to go when it does.