### PR TITLE
hello/print/print_display/testcase_list: replace try! with ?. Close #834

### DIFF
--- a/examples/hello/print/print_display/testcase_list/input.md
+++ b/examples/hello/print/print_display/testcase_list/input.md
@@ -1,7 +1,8 @@
 Implementing `fmt::Display` for a structure where the elements must each be
 handled sequentially is tricky. The problem is that each `write!` generates a
 `fmt::Result`. Proper handling of this requires dealing with *all* the
-results. Rust provides the `try!` macro for exactly this purpose.
+results. Rust provides the `try!` macro and alternatively the equivalent 
+`?` operator for exactly this purpose.
 
 Using `try!` on `write!` looks like this:
 
@@ -11,7 +12,13 @@ Using `try!` on `write!` looks like this:
 try!(write!(f, "{}", value));
 ```
 
-With `try!` available, implementing `fmt::Display` for a `Vec` is
+The `?` shorthand alternative looks like this:
+
+```rust
+write!(f, "{}", value)?;
+```
+
+With `?` available, implementing `fmt::Display` for a `Vec` is
 straightforward:
 
 {testcase_list.play}

--- a/examples/hello/print/print_display/testcase_list/testcase_list.rs
+++ b/examples/hello/print/print_display/testcase_list/testcase_list.rs
@@ -9,15 +9,15 @@ impl fmt::Display for List {
         // via destructuring.
         let List(ref vec) = *self;
 
-        try!(write!(f, "["));
+        write!(f, "[")?;
 
         // Iterate over `vec` in `v` while enumerating the iteration
         // count in `count`.
         for (count, v) in vec.iter().enumerate() {
-            // For every element except the first, add a comma
-            // before calling `write!`. Use `try!` to return on errors.
-            if count != 0 { try!(write!(f, ", ")); }
-            try!(write!(f, "{}", v));
+            // For every element except the first, add a comma.
+            // Use the ? operator, or try!, to return on errors.
+            if count != 0 { write!(f, ", ")?; }
+            write!(f, "{}", v)?;
         }
 
         // Close the opened bracket and return a fmt::Result value


### PR DESCRIPTION
This commit replaces the try! macro with the ? operator in 1.2.2.1 hello/print/print_display/testcase_list, and mentions their equivalence.