### PR TITLE
cast/alias: Fix typing ambiguity.

### DIFF
--- a/examples/cast/alias/input.md
+++ b/examples/cast/alias/input.md
@@ -4,7 +4,7 @@ exception to this rule are the primitive types: `usize`, `f32`, etc.
 
 {alias.play}
 
-The main use of aliases is to reduce typing; for example the `IoResult<T>` type
+The main use of aliases is to reduce boilerplate; for example the `IoResult<T>` type
 is an alias for the `Result<T, IoError>` type.
 
 ### See also:


### PR DESCRIPTION
Issue: #854

This caused my a little bit of confusion because I thought maybe typing was some sort of concept that was good to reduce, turns out it just means punching in letters on the keyboard.

Changed typing -> boilerplate.

