### PR TITLE
make check-line-lenght.sh report consistently with contribution guide

### DIFF
--- a/check-line-length.sh
+++ b/check-line-length.sh
@@ -17,8 +17,8 @@ if [[ $status == 0 ]]; then
       continue
     fi
     any_offender=true
-    echo "> $suspect exceeds 79 chars"
-    awk 'length($0) > 79' $suspect
+    echo "> $suspect exceeds 99 chars"
+    awk 'length($0) > 99' $suspect
   done
 
 fi


### PR DESCRIPTION
CONTRIBUTING.md mentions line lengths of rust code should be 99 characters or less.

The `check-line-length.sh` script that Travis executes, however, is internally inconsistent after an incomplete update.
It triggers if any lines are 100+ chars long, but if it does, it reports all lines of 80+

This quick fix brings all parts of the line-checker _in-line_ :drum: