### PR TITLE
Add an example about returning values with break

### DIFF
--- a/examples/flow_control/loop/return/input.md
+++ b/examples/flow_control/loop/return/input.md
@@ -1,0 +1,6 @@
+One of the uses of a `loop` is to retry an operation until it succeded. If the
+operation returns a value though, you might need to pass it to the rest of the
+code: put it after the `break`, and it will be returned by the `loop`
+expression.
+
+{return.play}

--- a/examples/flow_control/loop/return/return.rs
+++ b/examples/flow_control/loop/return/return.rs
@@ -1,0 +1,13 @@
+fn main() {
+    let mut counter = 0;
+
+    let result = loop {
+        counter += 1;
+
+        if counter == 10 {
+            break counter * 2;
+        }
+    };
+
+    assert_eq!(result, 20);
+}

--- a/examples/structure.json
+++ b/examples/structure.json
@@ -37,7 +37,8 @@
     { "id": "flow_control", "title": "Flow Control", "children": [
         { "id": "if_else", "title": "if/else", "children": null },
         { "id": "loop", "title": "loop", "children": [
-            { "id": "nested", "title": "Nesting and labels", "children": null }
+            { "id": "nested", "title": "Nesting and labels", "children": null },
+            { "id": "return", "title": "Returning from loops", "children": null }
         ] },
         { "id": "while", "title": "while", "children": null },
         { "id": "for", "title": "for and range", "children": null },


### PR DESCRIPTION
This pull request adds an example for the `loop_break_value` feature (which should be stabilized after all the documentation is ready), tracked in issue rust-lang/rust#37339.

The example doesn't do much, but without introducing random things, threads or the network in it there aren't many things to retry.