### PR TITLE
Use [Open|Closed]Box

### DIFF
--- a/examples/mod/struct_visibility/struct.rs
+++ b/examples/mod/struct_visibility/struct.rs
@@ -1,19 +1,19 @@
 mod my {
     // A public struct with a public field of generic type `T`
-    pub struct WhiteBox<T> {
+    pub struct OpenBox<T> {
         pub contents: T,
     }
 
     // A public struct with a private field of generic type `T`
     #[allow(dead_code)]
-    pub struct BlackBox<T> {
+    pub struct ClosedBox<T> {
         contents: T,
     }
 
-    impl<T> BlackBox<T> {
+    impl<T> ClosedBox<T> {
         // A public constructor method
-        pub fn new(contents: T) -> BlackBox<T> {
-            BlackBox {
+        pub fn new(contents: T) -> ClosedBox<T> {
+            ClosedBox {
                 contents: contents,
             }
         }
@@ -22,22 +22,22 @@ mod my {
 
 fn main() {
     // Public structs with public fields can be constructed as usual
-    let white_box = my::WhiteBox { contents: "public information" };
+    let open_box = my::OpenBox { contents: "public information" };
 
     // and their fields can be normally accessed.
-    println!("The white box contains: {}", white_box.contents);
+    println!("The open box contains: {}", open_box.contents);
 
     // Public structs with private fields cannot be constructed using field names.
-    // Error! `BlackBox` has private fields
-    //let black_box = my::BlackBox { contents: "classified information" };
+    // Error! `ClosedBox` has private fields
+    //let closed_box = my::ClosedBox { contents: "classified information" };
     // TODO ^ Try uncommenting this line
 
     // However, structs with private fields can be created using
     // public constructors
-    let _black_box = my::BlackBox::new("classified information");
+    let _closed_box = my::ClosedBox::new("classified information");
 
     // and the private fields of a public struct cannot be accessed.
     // Error! The `contents` field is private
-    //println!("The black box contains: {}", _black_box.contents);
+    //println!("The closed box contains: {}", _closed_box.contents);
     // TODO ^ Try uncommenting this line
 }


### PR DESCRIPTION
Similar to how `[safe|block]list` is better terminology I think the same concerns apply here.

This commit changes this exapmle to use `[Open|Closed]Box`.