### PR TITLE
fixed typo

### DIFF
--- a/examples/scope/borrow/ref/ref.rs
+++ b/examples/scope/borrow/ref/ref.rs
@@ -40,7 +40,7 @@ fn main() {
     let mut mutable_tuple = (Box::new(5u32), 3u32);
     
     {
-        // Destructure `mutable_ tuple` to change the value of `last`.
+        // Destructure `mutable_tuple` to change the value of `last`.
         let (_, ref mut last) = mutable_tuple;
         *last = 2u32;
     }


### PR DESCRIPTION
scope/borrow/ref: fix typo, drop unnecessary space in variable name in comment