### PR TITLE
Fix error response handling for rust playground

### DIFF
--- a/node_modules/gitbook-plugin-rust-playpen/book/editor.js
+++ b/node_modules/gitbook-plugin-rust-playpen/book/editor.js
@@ -169,11 +169,15 @@ function runProgram(program, callback) {
   req.open('POST', "https://play.rust-lang.org/evaluate.json", true);
   req.onload = function(e) {
     if (req.readyState === 4 && req.status === 200) {
-      var result = JSON.parse(req.response).result;
+      var response = JSON.parse(req.response);
+      var result = response.result;
 
       // Need server support to get an accurate version of this.
       var statusCode = SUCCESS;
-      if (result.indexOf("error:") !== -1) {
+      if (response.error) {
+        statusCode = ERROR;
+        result = response.error;
+      } else if (result.indexOf("error:") !== -1) {
         statusCode = ERROR;
       } else if (result.indexOf("warning:") !== -1) {
         statusCode = WARNING;


### PR DESCRIPTION
In the case of compilation failure, the api returns an object with an empty result; and an error in its own field.
This makes it so this error bubbles back to the requestor that is running the program.

I feel really weird editing this in the node_modules folder; however it seems like this package is not on npm ?

I noticed this when doing https://rustbyexample.com/hello/print.html and running it without any change.

Suggestions welcome! :)