### PR TITLE
std_misc/path: bad substitution

### DIFF
--- a/examples/std_misc/path/input.md
+++ b/examples/std_misc/path/input.md
@@ -3,8 +3,7 @@ two flavors of `Path`: `posix::Path`, for UNIX-like systems, and
 `windows::Path`, for Windows. The prelude exports the appropriate
 platform-specific `Path` variant.
 
-A `Path` can be created from almost any type that implements the
-`OsStr` trait, like a string, and provides several methods to get
+A `Path` can be created from `OsStr` type and provides several methods to get
 information from the file/directory the path points to.
 
 Note that a `Path` is *not* internally represented as an UTF-8 string, but


### PR DESCRIPTION
I did a simple substitution for `BytesContainer`, that's an error. `BytesContainer` is a trait while `OsStr` is a struct. The sentence is fixed.