### PR TITLE
fix typo in examples/trait/ops/input.md

### DIFF
--- a/examples/trait/ops/input.md
+++ b/examples/trait/ops/input.md
@@ -4,7 +4,7 @@ because operators are syntactic sugar for method calls. For example, the `+` ope
 `a + b` calls the `add` method (as in `a.add(b)`). This `add` method is part of the `Add` 
 trait. Hence, the `+` operator can be used by any implementor of the `Add` trait.
 
-A list of the traits, such as `Add`, that overload operators are available [here][ops].
+A list of the traits, such as `Add`, that overload operators is available [here][ops].
 
 {operator.play}
 


### PR DESCRIPTION
'list' is singular so 'is' is the correct form of be to pair with it,
not 'are'.