### PR TITLE
New `Iter<Result>` section in Error Chapter.

### DIFF
--- a/src/SUMMARY.md
+++ b/src/SUMMARY.md
@@ -143,7 +143,7 @@
     - [Defining an error type](error/define_error_type.md)
     - [Other uses of `try!`](error/reenter_try.md)
     - [`Box`ing errors](error/boxing_errors.md)
-    - [`Iter<Result<_>>`](error/iter_result.md)
+    - [Iterating over `Result`s](error/iter_result.md)
 
 - [Std library types](std.md)
     - [Box, stack and heap](std/box.md)

--- a/src/SUMMARY.md
+++ b/src/SUMMARY.md
@@ -143,6 +143,7 @@
     - [Defining an error type](error/define_error_type.md)
     - [Other uses of `try!`](error/reenter_try.md)
     - [`Box`ing errors](error/boxing_errors.md)
+    - [`Iter<Result<_>>`](error/iter_result.md)
 
 - [Std library types](std.md)
     - [Box, stack and heap](std/box.md)

--- a/src/error/iter_result.md
+++ b/src/error/iter_result.md
@@ -5,9 +5,9 @@ An `Iter::map` operation might fail, for example:
 ```rust,editable
 fn main() {
     let strings = vec!["tofu", "93", "18"];
-    let possible_numbers: Vec<Result<i32, _>> = strings
+    let possible_numbers: Vec<_> = strings
         .into_iter()
-        .map(|s| s.parse())
+        .map(|s| s.parse::<i32>())
         .collect();
     println!("Results: {:?}", possible_numbers);
 }
@@ -22,9 +22,9 @@ Let's step through strategies for handling this.
 ```rust,editable
 fn main() {
     let strings = vec!["tofu", "93", "18"];
-    let numbers: Vec<i32> = strings
+    let numbers: Vec<_> = strings
         .into_iter()
-        .map(|s| s.parse())
+        .map(|s| s.parse::<i32>())
         .filter_map(Result::ok)
         .collect();
     println!("Results: {:?}", numbers);
@@ -40,9 +40,9 @@ can be turned into a result with a vector (`Result<Vec<T>, E>`). Once an
 ```rust,editable
 fn main() {
     let strings = vec!["tofu", "93", "18"];
-    let numbers: Result<Vec<i32>, _> = strings
+    let numbers: Result<Vec<_>, _> = strings
         .into_iter()
-        .map(|s| s.parse())
+        .map(|s| s.parse::<i32>())
         .collect();
     println!("Results: {:?}", numbers);
 }
@@ -55,9 +55,9 @@ This same technique can be used with `Option`.
 ```rust,editable
 fn main() {
     let strings = vec!["tofu", "93", "18"];
-    let (numbers, errors): (Vec<Result<i32, _>>, Vec<_>) = strings
+    let (numbers, errors): (Vec<_>, Vec<_>) = strings
         .into_iter()
-        .map(|s| s.parse())
+        .map(|s| s.parse::<i32>())
         .partition(Result::is_ok);
     println!("Numbers: {:?}", numbers);
     println!("Errors: {:?}", errors);
@@ -70,9 +70,9 @@ When you look at the results, you'll note that everything is still wrapped in
 ```rust,editable
 fn main() {
     let strings = vec!["tofu", "93", "18"];
-    let (numbers, errors): (Vec<Result<i32, _>>, Vec<_>) = strings
+    let (numbers, errors): (Vec<_>, Vec<_>) = strings
         .into_iter()
-        .map(|s| s.parse())
+        .map(|s| s.parse::<i32>())
         .partition(Result::is_ok);
     let numbers: Vec<_> = numbers.into_iter().map(Result::unwrap).collect();
     let errors: Vec<_> = errors.into_iter().map(Result::unwrap_err).collect();

--- a/src/error/iter_result.md
+++ b/src/error/iter_result.md
@@ -1,6 +1,7 @@
-# `Iter<Result<_>>`
+# Iterating over `Result`s
 
-A function you call on an iterable might fail, for example:
+An `Iter::map` operation might fail, for example:
+
 ```rust,editable
 fn main() {
     let strings = vec!["tofu", "93", "18"];
@@ -32,8 +33,8 @@ fn main() {
 
 ## Fail the entire operation with `collect()`
 
-`Result` implements `FromIter` so that a vector of results (Vec<Result<T, E>>)
-can be turned into a result with a vector (Result<Vec<T>, E>). Once an
+`Result` implements `FromIter` so that a vector of results (`Vec<Result<T, E>>`)
+can be turned into a result with a vector (`Result<Vec<T>, E>`). Once an
 `Result::Err` is found, the iteration will terminate.
 
 ```rust,editable
@@ -47,7 +48,7 @@ fn main() {
 }
 ```
 
-This same technique can be used with `Option` as well.
+This same technique can be used with `Option`.
 
 ## Collect all valid values and failures with `partition()`
 

--- a/src/error/iter_result.md
+++ b/src/error/iter_result.md
@@ -1,0 +1,81 @@
+# `Iter<Result<_>>`
+
+A function you call on an iterable might fail, for example:
+```rust,editable
+fn main() {
+    let strings = vec!["tofu", "93", "18"];
+    let possible_numbers: Vec<Result<i32, _>> = strings
+        .into_iter()
+        .map(|s| s.parse())
+        .collect();
+    println!("Results: {:?}", possible_numbers);
+}
+```
+
+Let's step through strategies for handling this.
+
+## Ignore the failed items with `filter_map()`
+
+`filter_map` calls a function and filters out the results that are `None`.
+
+```rust,editable
+fn main() {
+    let strings = vec!["tofu", "93", "18"];
+    let numbers: Vec<i32> = strings
+        .into_iter()
+        .map(|s| s.parse())
+        .filter_map(Result::ok)
+        .collect();
+    println!("Results: {:?}", numbers);
+}
+```
+
+## Fail the entire operation with `collect()`
+
+`Result` implements `FromIter` so that a vector of results (Vec<Result<T, E>>)
+can be turned into a result with a vector (Result<Vec<T>, E>). Once an
+`Result::Err` is found, the iteration will terminate.
+
+```rust,editable
+fn main() {
+    let strings = vec!["tofu", "93", "18"];
+    let numbers: Result<Vec<i32>, _> = strings
+        .into_iter()
+        .map(|s| s.parse())
+        .collect();
+    println!("Results: {:?}", numbers);
+}
+```
+
+This same technique can be used with `Option` as well.
+
+## Collect all valid values and failures with `partition()`
+
+```rust,editable
+fn main() {
+    let strings = vec!["tofu", "93", "18"];
+    let (numbers, errors): (Vec<Result<i32, _>>, Vec<_>) = strings
+        .into_iter()
+        .map(|s| s.parse())
+        .partition(Result::is_ok);
+    println!("Numbers: {:?}", numbers);
+    println!("Errors: {:?}", errors);
+}
+```
+
+When you look at the results, you'll note that everything is still wrapped in
+`Result`.  A little more boilerplate is needed for this.
+
+```rust,editable
+fn main() {
+    let strings = vec!["tofu", "93", "18"];
+    let (numbers, errors): (Vec<Result<i32, _>>, Vec<_>) = strings
+        .into_iter()
+        .map(|s| s.parse())
+        .partition(Result::is_ok);
+    let numbers: Vec<_> = numbers.into_iter().map(Result::unwrap).collect();
+    let errors: Vec<_> = errors.into_iter().map(Result::unwrap_err).collect();
+    println!("Numbers: {:?}", numbers);
+    println!("Errors: {:?}", errors);
+}
+```


### PR DESCRIPTION
Inspired by [Karol's blog post](http://xion.io/post/code/rust-iter-patterns.html).

Tested by visually inspecting the pages served by `mdbook serve` and
running each of the blocks of code.

Fixes #895.