### PR TITLE
Fix open subcommands in readme

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -56,7 +56,7 @@ To build RBE, [install Rust], and then:
 
 [install Rust]: http://rust-lang.org/install.html
 
-The files will be in the `book` directory at the top-level; `mdbook open` will
+The files will be in the `book` directory at the top-level; `mdbook serve` will
 open the contents in your web browser.
 
 To run the tests:

--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ If you'd like to read it locally, [install Rust], and then:
 > cd rust-by-example
 > cargo install mdbook
 > mdbook build
-> mdbook open
+> mdbook serve
 ```
 
 [install Rust]: http://rust-lang.org/install.html


### PR DESCRIPTION
Hi. When i type in terminal: `mdbook open` i get some error:
> error: Found argument 'open' which wasn't expected, or isn't valid in this context.

I found a new subcommand that launches book on localhost by default: `serve`.
*Serve the book at localhost:3000. Rebuild and reload on change.*

My mdbook version: `mdbook v0.0.25`.