### PR TITLE
Fix install instructions in readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ If you'd like to read it locally, [install Rust], and then:
 > cd rust-by-example
 > cargo install mdbook
 > mdbook build
-> mdbook open
+> mdbook serve # To serve the book from local machine
 ```
 
 [install Rust]: http://rust-lang.org/install.html


### PR DESCRIPTION
The current README has wrong command to serve the book. `mdbook open`is not valid anymore. This PR changes it to `mdbook serve`.