### PR TITLE
Add an example to demonstrate long tuple cannot be printed

### DIFF
--- a/src/primitives/tuples.md
+++ b/src/primitives/tuples.md
@@ -31,7 +31,7 @@ fn main() {
 
     // Tuples can be tuple members
     let tuple_of_tuples = ((1u8, 2u16, 2u32), (4u64, -1i8), -2i16);
-    
+
     // Tuples are printable
     println!("tuple of tuples: {:?}", tuple_of_tuples);
     

--- a/src/primitives/tuples.md
+++ b/src/primitives/tuples.md
@@ -31,9 +31,14 @@ fn main() {
 
     // Tuples can be tuple members
     let tuple_of_tuples = ((1u8, 2u16, 2u32), (4u64, -1i8), -2i16);
-
+    
     // Tuples are printable
     println!("tuple of tuples: {:?}", tuple_of_tuples);
+    
+    // But long Tuples cannot be printed
+    // let too_long_tuple = (1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13);
+    // println!("too long tuple: {:?}", too_long_tuple);
+    // TODO ^ Uncomment the above 2 lines to see the compiler error
 
     let pair = (1, true);
     println!("pair is {:?}", pair);


### PR DESCRIPTION
An attempt to fix the bug #589 .