### PR TITLE
Fix some first edition links

### DIFF
--- a/src/error.md
+++ b/src/error.md
@@ -8,4 +8,4 @@ saves the rest of the program from various pitfalls.
 For a more rigorous discussion of error handling, refer to the error
 handling section in the [official book][book].
 
-[book]: https://doc.rust-lang.org/book/error-handling.html
+[book]: https://doc.rust-lang.org/book/second-edition/ch09-00-error-handling.html

--- a/src/scope/lifetime/elision.md
+++ b/src/scope/lifetime/elision.md
@@ -1,11 +1,11 @@
 # elision
 
-Some lifetime patterns are overwelmingly common and so the borrow checker 
-will implicitly add them to save typing and to improve readability. 
+Some lifetime patterns are overwelmingly common and so the borrow checker
+will implicitly add them to save typing and to improve readability.
 This process of implicit addition is called elision. Elision exists in Rust
 solely because these patterns are common.
 
-The following code shows a few examples of elision. For a more comprehensive 
+The following code shows a few examples of elision. For a more comprehensive
 description of elision, see [lifetime elision][elision] in the book.
 
 ```rust,editable
@@ -27,7 +27,7 @@ fn annotated_pass<'a>(x: &'a i32) -> &'a i32 { x }
 
 fn main() {
     let x = 3;
-    
+
     elided_input(&x);
     annotated_input(&x);
 
@@ -40,4 +40,4 @@ fn main() {
 
 [elision][elision]
 
-[elision]: https://doc.rust-lang.org/book/lifetimes.html#lifetime-elision
+[elision]: https://doc.rust-lang.org/book/second-edition/ch10-03-lifetime-syntax.html#lifetime-elision

--- a/src/std_misc/threads/testcase_mapreduce.md
+++ b/src/std_misc/threads/testcase_mapreduce.md
@@ -72,7 +72,7 @@ fn main() {
         // * takes ownership of its captured variables ('move') and
         // * returns an unsigned 32-bit integer ('-> u32')
         //
-        // Rust is smart enough to infer the '-> u32' from 
+        // Rust is smart enough to infer the '-> u32' from
         // the closure itself so we could have left that out.
         //
         // TODO: try removing the 'move' and see what happens
@@ -115,7 +115,7 @@ fn main() {
     //
     // we use the "turbofish" ::<> to provide sum() with a type hint.
     //
-    // TODO: try without the turbofish, by instead explicitly 
+    // TODO: try without the turbofish, by instead explicitly
     // specifying the type of intermediate_sums
     let final_result = intermediate_sums.iter().sum::<u32>();
 
@@ -143,10 +143,10 @@ defined by a static constant at the beginning of the program.
 [thread]: /std_misc/threads.html
 [vectors]: /std/vec.html
 [iterators]: /trait/iter.html
-[destructuring]: https://doc.rust-lang.org/book/patterns.html#destructuring
+[destructuring]: https://doc.rust-lang.org/book/second-edition/ch18-03-pattern-syntax.html#destructuring-to-break-apart-values
 [closures]: /fn/closures.html
 [move]: /scope/move.html
-[move_closure]: https://doc.rust-lang.org/book/closures.html#move-closures
+[move_closure]: https://doc.rust-lang.org/book/second-edition/ch13-01-closures.html#closures-can-capture-their-environment
 [turbofish]: https://doc.rust-lang.org/std/iter/trait.Iterator.html#method.collect
 [unwrap]: /error/option_unwrap.html
 [enumerate]: https://doc.rust-lang.org/book/loops.html#enumerate

--- a/src/trait/ops.md
+++ b/src/trait/ops.md
@@ -2,8 +2,8 @@
 
 In Rust, many of the operators can be overloaded via traits. That is, some operators can
 be used to accomplish different tasks based on their input arguments. This is possible
-because operators are syntactic sugar for method calls. For example, the `+` operator in 
-`a + b` calls the `add` method (as in `a.add(b)`). This `add` method is part of the `Add` 
+because operators are syntactic sugar for method calls. For example, the `+` operator in
+`a + b` calls the `add` method (as in `a.add(b)`). This `add` method is part of the `Add`
 trait. Hence, the `+` operator can be used by any implementor of the `Add` trait.
 
 A list of the traits, such as `Add`, that overload operators is available [here][ops].
@@ -58,4 +58,4 @@ fn main() {
 
 [add]: https://doc.rust-lang.org/core/ops/trait.Add.html
 [ops]: https://doc.rust-lang.org/core/ops/
-[syntax]: https://doc.rust-lang.org/book/syntax-index.html
+[syntax]:https://doc.rust-lang.org/book/second-edition/appendix-02-operators.html

--- a/src/unsafe.md
+++ b/src/unsafe.md
@@ -1,11 +1,10 @@
 # Unsafe Operations
 
-As an introduction to this section, to borrow from [the official docs](
-https://doc.rust-lang.org/book/unsafe.html), "one should try to minimize the
-amount of unsafe code in a code base." With that in mind, let's get started!
-Unsafe blocks in Rust are used to bypass protections put in place by the
-compiler; specifically, there are four primary things that unsafe blocks are
-used for:
+As an introduction to this section, to borrow from [the official docs][unsafe],
+"one should try to minimize the amount of unsafe code in a code base." With that
+in mind, let's get started! Unsafe blocks in Rust are used to bypass protections
+put in place by the compiler; specifically, there are four primary things that
+unsafe blocks are used for:
 
 * dereferencing raw pointers
 * calling a function over FFI (but this is covered in [a previous
@@ -42,3 +41,5 @@ fn main() {
     }
 }
 ```
+
+[unsafe]: https://doc.rust-lang.org/book/second-edition/ch19-01-unsafe-rust.html


### PR DESCRIPTION
Partially addresses #918, with some remaining links specified in the issue. Those mentioned don't have any clear mapping in the second book that I could determine.