### PR TITLE
Fix broken links in destructuring.md

### DIFF
--- a/src/flow_control/match/destructuring.md
+++ b/src/flow_control/match/destructuring.md
@@ -2,13 +2,13 @@
 
 A `match` block can destructure items in a variety of ways.
 
-* [Destructuring Enums](enum)
-* [Destructuring Pointers](refs)
-* [Destructuring Structutures](struct)
-* [Destructuring Tuples](tuple)
+* [Destructuring Enums][enum]
+* [Destructuring Pointers][refs]
+* [Destructuring Structutures][struct]
+* [Destructuring Tuples][tuple]
 
 
-[enum]: destructuring/destructure_enum.md
-[refs]: destructuring/destructure_pointers.md
-[struct]: destructuring/destructure_structures.md
-[tuple]:destructuring/destructure_tuple.md
+[enum]: /flow_control/match/destructuring/destructure_enum.html
+[refs]: /flow_control/match/destructuring/destructure_pointers.html
+[struct]: /flow_control/match/destructuring/destructure_structures.html
+[tuple]: /flow_control/match/destructuring/destructure_tuple.html


### PR DESCRIPTION
References were made with `()` instead of `[]` and the links pointed to `.md` instead of `.html`.