### PR TITLE
Adding license header to deploy.sh

### DIFF
--- a/deploy.sh
+++ b/deploy.sh
@@ -1,3 +1,13 @@
+# Copyright 2012-2014 The Rust Project Developers. See the COPYRIGHT
+# file at the top-level directory of this distribution and at
+# http://rust-lang.org/COPYRIGHT.
+#
+# Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+# http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+# <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+# option. This file may not be copied, modified, or distributed
+# except according to those terms.
+
 #!/bin/bash
 
 rev=$(git rev-parse --short HEAD)


### PR DESCRIPTION
This should make tidy happy for [https://github.com/rust-lang/rust/pull/46196](https://github.com/rust-lang/rust/pull/46196).