### PR TITLE
c_like: Fix broken link

### DIFF
--- a/src/custom_types/enum/c_like.md
+++ b/src/custom_types/enum/c_like.md
@@ -34,4 +34,4 @@ fn main() {
 
 [casting][cast]
 
-[cast]: /cast.html
+[cast]: /types/cast.html


### PR DESCRIPTION
The link to the `cast` page isn't working anymore because in commit a005ceddb37bcc6773145534c86a89e6b99f00cb the `cast.md` file has been moved into `types` dir and the link wasn't updated.