### PR TITLE
Minor change in activity for fmt::Display

### DIFF
--- a/src/hello/print/print_display.md
+++ b/src/hello/print/print_display.md
@@ -111,7 +111,7 @@ After checking the output of the above example, use the `Point2D` struct as
 guide to add a Complex struct to the example. When printed in the same
 way, the output should be:
 ```
-Display: 3.3 + 7.2i
+Display: 3.3 +7.2i
 Debug: Complex { real: 3.3, imag: 7.2 }
 ```
 


### PR DESCRIPTION
A generic solution for an output format like `3.3 + 7.2i `is not achievable without a conditional(?) and, IMHO can't be solved by std::fmt alone. Changing the expected output to `3.3 +7.2i` (removing a whitespace) makes this easier, because it's simply the result of using `"{real} {imag:+}i"` as format string.