### PR TITLE
Fixed a typo in SUMMARY.md

### DIFF
--- a/src/SUMMARY.md
+++ b/src/SUMMARY.md
@@ -130,7 +130,7 @@
     - [Clone](trait/clone.md)
 
 - [macro_rules!](macros.md)
-    - [Syntax](macro/syntax.md)
+    - [Syntax](macros/syntax.md)
         - [Designators](macros/designators.md)
         - [Overload](macros/overload.md)
         - [Repeat](macros/repeat.md)


### PR DESCRIPTION
I was testing rust-lang-nursery/mdbook#491 against `rust-by-example` and noticed the `create_missing` feature automatically created a random file. It looks like there was a typo in `SUMMARY.md`.