### PR TITLE
Update book.toml

### DIFF
--- a/book.toml
+++ b/book.toml
@@ -1,6 +1,8 @@
+[book]
 title = "Rust By Example"
 description = "A description"
 author = "The Rust Community"
 
 [output.html.playpen]
 editable = true
+editor = "ace"


### PR DESCRIPTION
This specifies the new mdBook syntax (properties under `[book]` table).

It also adds the `editor = "ace"` config, which will fix #963. Once https://github.com/rust-lang-nursery/mdBook/pull/515 is merged, this won't be necessary.