### PR TITLE
Fix dead link in "aliases for Result"

### DIFF
--- a/src/error/result/result_alias.md
+++ b/src/error/result/result_alias.md
@@ -42,5 +42,5 @@ fn main() {
 
 [`io::Result`][io_result]
 
-[typealias]: /cast/alias.html
+[typealias]: /types/alias.html
 [io_result]: https://doc.rust-lang.org/std/io/type.Result.html


### PR DESCRIPTION
Dead link because folder was renamed. Maybe caused by a005ceddb37bcc6773145534c86a89e6b99f00cb.