### PR TITLE
Talk about `unsafe` functions in general instead of just `transmute`

### DIFF
--- a/src/unsafe.md
+++ b/src/unsafe.md
@@ -9,7 +9,7 @@ unsafe blocks are used for:
 * dereferencing raw pointers
 * calling a function over FFI (but this is covered in [a previous
   chapter](std_misc/ffi.html) of the book)
-* changing types through `std::mem::transmute`
+* calling functions which are `unsafe`
 * inline assembly
 
 ### Raw Pointers
@@ -28,18 +28,34 @@ fn main() {
 }
 ```
 
-### Transmute
-Allows simple conversion from one type to another, however both types must have
-the same size and alignment:
+### Calling Unsafe Functions
+Some functions can be declared as `unsafe`, meaning it is the programmer's
+responsibility to ensure correctness instead of the compiler's. One example
+of this is [`std::slice::from_raw_parts`] which will create a slice given a
+pointer to the first element and a length.
 
 ```rust,editable
+use std::slice;
+
 fn main() {
-    let u: &[u8] = &[49, 50, 51];
+    let some_vector = vec![1, 2, 3, 4];
+
+    let pointer = some_vector.as_ptr();
+    let length = some_vector.len();
 
     unsafe {
-        assert!(u == std::mem::transmute::<&str, &[u8]>("123"));
+        let my_slice: &[u32] = slice::from_raw_parts(pointer, length);
+        
+        assert_eq!(some_vector.as_slice(), my_slice);
     }
 }
 ```
 
+For `slice::from_raw_parts`, one of the assumptions which *must* be upheld is 
+that the pointer passed in points to valid memory and that the memory pointed to
+is of the correct type. If these invariants aren't upheld then the program's 
+behaviour is undefined and there is no knowing what will happen.
+
+
 [unsafe]: https://doc.rust-lang.org/book/second-edition/ch19-01-unsafe-rust.html
+[`std::slice::from_raw_parts`]: https://doc.rust-lang.org/std/slice/fn.from_raw_parts.html


### PR DESCRIPTION
In the `unsafe` chapter it's probably more correct to say that you need `unsafe` when calling `unsafe` functions, instead of just `std::mem::transmute` (which is only one example of an `unsafe` function).

I've also put a bit more emphasis on the fact that `unsafe` means the programmer is taking on the job of ensuring your program is correct.

I also feel like people shouldn't need to know about `transmute` because there is almost always a better way. 