### PR TITLE
Made if let page a bit more obvious for beginners

### DIFF
--- a/src/flow_control/if_let.md
+++ b/src/flow_control/if_let.md
@@ -59,6 +59,41 @@ fn main() {
 }
 ```
 
+In the same way, `if let` can be used to match any enum value:
+
+```rust,editable
+// Our example enum
+enum Foo {
+    Bar,
+    Baz,
+    Qux(u32)
+}
+
+fn main() {
+    // Create example variables
+    let a = Foo::Bar;
+    let b = Foo::Baz;
+    let c = Foo::Qux(100);
+    
+    // Variable a matches Foo::Bar
+    if let Foo::Bar = a {
+        println!("a is foobar");
+    }
+    
+    // Variable b does not match Foo::Bar
+    // So this will print nothing
+    if let Foo::Bar = b {
+        println!("b is foobar");
+    }
+    
+    // Variable c matches Foo::Qux which has a value
+    // Similar to Some() in the previous example
+    if let Foo::Qux(value) = c {
+        println!("c is {}", value);
+    }
+}
+```
+
 ### See also:
 
 [`enum`][enum], [`Option`][option], and the [RFC][if_let_rfc]

--- a/src/flow_control/if_let.md
+++ b/src/flow_control/if_let.md
@@ -1,6 +1,6 @@
 # if let
 
-For some use cases, `match` is awkward. For example:
+For some use cases, when matching enums, `match` is awkward. For example:
 
 ```rust
 // Make `optional` of type `Option<i32>`


### PR DESCRIPTION
This PR attempts to make it a little bit more obvious that `if let` is used for matching enums, and not just `Option`.

I am currently learning Rust, and I ran into the issue today where in my head I hadn't made the connection yet that `Option` is actually an enum. So I didn't realise that `if let` could be used to match any enum value. This PR simply adds a couple of words to the page that may help someone else in the future get to the point of realisation faster.