### PR TITLE
Change links from '/foo.html' to 'foo.html'

### DIFF
--- a/src/attribute.md
+++ b/src/attribute.md
@@ -23,6 +23,6 @@ Attributes can take arguments with different syntaxes:
 * `#[attribute(key = "value")]`
 * `#[attribute(value)]`
 
-[cfg]: /attribute/cfg.html
-[crate]: /attribute/crate.html
+[cfg]: attribute/cfg.html
+[crate]: attribute/crate.html
 [lint]: https://en.wikipedia.org/wiki/Lint_%28software%29

--- a/src/attribute/cfg.md
+++ b/src/attribute/cfg.md
@@ -37,5 +37,5 @@ fn main() {
 [the reference][ref], [`cfg!`][cfg], and [macros][macros].
 
 [cfg]: https://doc.rust-lang.org/std/macro.cfg!.html
-[macros]: /macros.html
+[macros]: macros.html
 [ref]: https://doc.rust-lang.org/reference/attributes.html#conditional-compilation

--- a/src/cargo/test.md
+++ b/src/cargo/test.md
@@ -2,7 +2,7 @@
 
 As we know testing is integral to any piece of software! Rust has first-class
 support for unit and integration testing ([see that chapter for
-more](https://rustbyexample.com/meta/test.html); or [this
+more](meta/test.html); or [this
 chapter](https://doc.rust-lang.org/book/second-edition/ch11-00-testing.html) in
 TRPL).
 

--- a/src/crates/lib.md
+++ b/src/crates/lib.md
@@ -28,4 +28,4 @@ Libraries get prefixed with "lib", and by default they get named after their
 crate file, but this default name can be overridden using the [`crate_name`
 attribute][crate-name].
 
-[crate-name]: /attribute/crate.html
+[crate-name]: attribute/crate.html

--- a/src/custom_types/constants.md
+++ b/src/custom_types/constants.md
@@ -43,4 +43,4 @@ fn main() {
 https://github.com/rust-lang/rfcs/blob/master/text/0246-const-vs-static.md),
 [`'static` lifetime][static]
 
-[static]: /scope/lifetime/static_lifetime.html
+[static]: scope/lifetime/static_lifetime.html

--- a/src/custom_types/enum.md
+++ b/src/custom_types/enum.md
@@ -60,8 +60,8 @@ fn main() {
 
 [`attributes`][attributes], [`match`][match], [`fn`][fn], and [`String`][str]
 
-[attributes]: /attribute.html
+[attributes]: attribute.html
 [c_struct]: https://en.wikipedia.org/wiki/Struct_(C_programming_language)
-[match]: /flow_control/match.html
-[fn]: /fn.html
-[str]: /std/str.html
+[match]: flow_control/match.html
+[fn]: fn.html
+[str]: std/str.html

--- a/src/custom_types/enum/c_like.md
+++ b/src/custom_types/enum/c_like.md
@@ -34,4 +34,4 @@ fn main() {
 
 [casting][cast]
 
-[cast]: /types/cast.html
+[cast]: types/cast.html

--- a/src/custom_types/enum/enum_use.md
+++ b/src/custom_types/enum/enum_use.md
@@ -46,5 +46,5 @@ fn main() {
 
 [`match`][match] and [`use`][use] 
 
-[use]: /mod/use.html
-[match]: /flow_control/match.html
+[use]: mod/use.html
+[match]: flow_control/match.html

--- a/src/custom_types/enum/testcase_linked_list.md
+++ b/src/custom_types/enum/testcase_linked_list.md
@@ -75,5 +75,5 @@ fn main() {
 
 [`Box`][box] and [methods][methods]
 
-[box]: /std/box.html
-[methods]: /fn/methods.html
+[box]: std/box.html
+[methods]: fn/methods.html

--- a/src/custom_types/structs.md
+++ b/src/custom_types/structs.md
@@ -84,6 +84,6 @@ fn main() {
 
 [`attributes`][attributes] and [destructuring][destructuring]
 
-[attributes]: /attribute.html
+[attributes]: attribute.html
 [c_struct]: https://en.wikipedia.org/wiki/Struct_(C_programming_language)
-[destructuring]: /flow_control/match/destructuring.html
+[destructuring]: flow_control/match/destructuring.html

--- a/src/error/multiple_error_types/option_result.md
+++ b/src/error/multiple_error_types/option_result.md
@@ -55,4 +55,4 @@ fn main() {
 }
 ```
 
-[enter_question_mark]: /error/result/enter_question_mark.html
+[enter_question_mark]: error/result/enter_question_mark.html

--- a/src/error/multiple_error_types/reenter_question_mark.md
+++ b/src/error/multiple_error_types/reenter_question_mark.md
@@ -86,4 +86,4 @@ top level.
 [`From::from`][from] and [`?`][q_mark]
 
 [from]: https://doc.rust-lang.org/std/convert/trait.From.html
-[q_mark]: https://doc.rust-lang.org/reference/expressions.html#the--operator
+[q_mark]: https://doc.rust-lang.org/reference/expressions/operator-expr.html#the--operator

--- a/src/error/multiple_error_types/wrap_error.md
+++ b/src/error/multiple_error_types/wrap_error.md
@@ -91,5 +91,5 @@ plate for you.
 [`From::from`][from] and [`Enums`][enums]
 
 [from]: https://doc.rust-lang.org/std/convert/trait.From.html
-[q_mark]: https://doc.rust-lang.org/reference/expressions.html#the--operator
-[enums]: /custom_types/enum.html
+[q_mark]: https://doc.rust-lang.org/reference/expressions/operator-expr.html#the--operator
+[enums]: custom_types/enum.html

--- a/src/error/option_unwrap/and_then.md
+++ b/src/error/option_unwrap/and_then.md
@@ -71,6 +71,6 @@ fn main() {
 
 [closures][closures], [`Option`][option], and [`Option::and_then()`][and_then]
 
-[closures]: /fn/closures.html
+[closures]: fn/closures.html
 [option]: https://doc.rust-lang.org/std/option/enum.Option.html
 [and_then]: https://doc.rust-lang.org/std/option/enum.Option.html#method.and_then

--- a/src/error/option_unwrap/map.md
+++ b/src/error/option_unwrap/map.md
@@ -81,6 +81,6 @@ fn main() {
 [closures][closures], [`Option`][option], [`Option::map()`][map]
 
 [combinators]: https://doc.rust-lang.org/book/glossary.html#combinators
-[closures]: /fn/closures.html
+[closures]: fn/closures.html
 [option]: https://doc.rust-lang.org/std/option/enum.Option.html
 [map]: https://doc.rust-lang.org/std/option/enum.Option.html#method.map

--- a/src/error/result/enter_question_mark.md
+++ b/src/error/result/enter_question_mark.md
@@ -69,4 +69,4 @@ fn main() {
 
 [^1]: See [re-enter ?][re_enter_?] for more details.
 
-[re_enter_?]: /error/multiple_error_types/reenter_question_mark.html
+[re_enter_?]: error/multiple_error_types/reenter_question_mark.html

--- a/src/error/result/result_alias.md
+++ b/src/error/result/result_alias.md
@@ -42,5 +42,5 @@ fn main() {
 
 [`io::Result`][io_result]
 
-[typealias]: /types/alias.html
+[typealias]: types/alias.html
 [io_result]: https://doc.rust-lang.org/std/io/type.Result.html

--- a/src/flow_control/for.md
+++ b/src/flow_control/for.md
@@ -89,4 +89,4 @@ implies differing actions that are able to be performed.
 
 [Iterator][iter]
 
-[iter]: /trait/iter.html
+[iter]: trait/iter.html

--- a/src/flow_control/if_let.md
+++ b/src/flow_control/if_let.md
@@ -63,6 +63,6 @@ fn main() {
 
 [`enum`][enum], [`Option`][option], and the [RFC][if_let_rfc]
 
-[enum]: /custom_types/enum.html
+[enum]: custom_types/enum.html
 [if_let_rfc]: https://github.com/rust-lang/rfcs/pull/160
-[option]: /std/option.html
+[option]: std/option.html

--- a/src/flow_control/match/binding.md
+++ b/src/flow_control/match/binding.md
@@ -27,6 +27,6 @@ fn main() {
 ```
 
 ### See also:
-[functions][functions]
+[functions]
 
-[functions]: /fn.html
+[functions]: fn.html

--- a/src/flow_control/match/destructuring.md
+++ b/src/flow_control/match/destructuring.md
@@ -8,7 +8,7 @@ A `match` block can destructure items in a variety of ways.
 * [Destructuring Tuples][tuple]
 
 
-[enum]: /flow_control/match/destructuring/destructure_enum.html
-[refs]: /flow_control/match/destructuring/destructure_pointers.html
-[struct]: /flow_control/match/destructuring/destructure_structures.html
-[tuple]: /flow_control/match/destructuring/destructure_tuple.html
+[enum]: flow_control/match/destructuring/destructure_enum.html
+[refs]: flow_control/match/destructuring/destructure_pointers.html
+[struct]: flow_control/match/destructuring/destructure_structures.html
+[tuple]: flow_control/match/destructuring/destructure_tuple.html

--- a/src/flow_control/match/guard.md
+++ b/src/flow_control/match/guard.md
@@ -20,4 +20,4 @@ fn main() {
 
 ### See also:
 
-[Tuples](/primitives/tuples.html)
+[Tuples](primitives/tuples.html)

--- a/src/flow_control/while_let.md
+++ b/src/flow_control/while_let.md
@@ -57,6 +57,6 @@ fn main() {
 
 [`enum`][enum], [`Option`][option], and the [RFC][while_let_rfc]
 
-[enum]: /custom_types/enum.html
-[option]: /std/option.html
+[enum]: custom_types/enum.html
+[option]: std/option.html
 [while_let_rfc]: https://github.com/rust-lang/rfcs/pull/214

--- a/src/fn/closures/anonymity.md
+++ b/src/fn/closures/anonymity.md
@@ -49,7 +49,7 @@ fn main() {
 [A thorough analysis][thorough_analysis], [`Fn`][fn], [`FnMut`][fn_mut],
 and [`FnOnce`][fn_once]
 
-[generics]: /generics.html
+[generics]: generics.html
 [fn]: https://doc.rust-lang.org/std/ops/trait.Fn.html
 [fn_mut]: https://doc.rust-lang.org/std/ops/trait.FnMut.html
 [fn_once]: https://doc.rust-lang.org/std/ops/trait.FnOnce.html

--- a/src/fn/closures/capture.md
+++ b/src/fn/closures/capture.md
@@ -73,5 +73,5 @@ fn main() {
 
 [`Box`][box] and [`std::mem::drop`][drop]
 
-[box]: /std/box.html
+[box]: std/box.html
 [drop]: https://doc.rust-lang.org/std/mem/fn.drop.html

--- a/src/fn/closures/output_parameters.md
+++ b/src/fn/closures/output_parameters.md
@@ -46,8 +46,8 @@ fn main() {
 
 [Boxing][box], [`Fn`][fn], [`FnMut`][fnmut], and [Generics][generics].
 
-[box]: /std/box.html
+[box]: std/box.html
 [fn]: https://doc.rust-lang.org/std/ops/trait.Fn.html
 [fnmut]: https://doc.rust-lang.org/std/ops/trait.FnMut.html
 [fnbox]: https://doc.rust-lang.org/std/boxed/trait.FnBox.html 
-[generics]: /generics.html
+[generics]: generics.html

--- a/src/generics.md
+++ b/src/generics.md
@@ -60,5 +60,5 @@ fn main() {
 
 [`struct`s][structs]
 
-[structs]: /custom_types/structs.html
+[structs]: custom_types/structs.html
 [camelcase]: https://en.wikipedia.org/wiki/CamelCase

--- a/src/generics/assoc_items/the_problem.md
+++ b/src/generics/assoc_items/the_problem.md
@@ -63,5 +63,5 @@ fn main() {
 
 [`struct`s][structs], and [`trait`s][traits]
 
-[structs]: /custom_types/structs.html
-[traits]: /trait.html
+[structs]: custom_types/structs.html
+[traits]: trait.html

--- a/src/generics/bounds.md
+++ b/src/generics/bounds.md
@@ -74,8 +74,8 @@ some cases to be more expressive.
 
 [`std::fmt`][fmt], [`struct`s][structs], and [`trait`s][traits]
 
-[fmt]: /hello/print.html
-[methods]: /fn/methods.html
-[structs]: /custom_types/structs.html
-[traits]: /trait.html
-[where]: /generics/where.html
+[fmt]: hello/print.html
+[methods]: fn/methods.html
+[structs]: custom_types/structs.html
+[traits]: trait.html
+[where]: generics/where.html

--- a/src/generics/bounds/testcase_empty.md
+++ b/src/generics/bounds/testcase_empty.md
@@ -40,4 +40,4 @@ fn main() {
 
 [eq]: https://doc.rust-lang.org/std/cmp/trait.Eq.html
 [ord]: https://doc.rust-lang.org/std/cmp/trait.Ord.html
-[traits]: /trait.html
+[traits]: trait.html

--- a/src/generics/gen_fn.md
+++ b/src/generics/gen_fn.md
@@ -55,5 +55,5 @@ fn main() {
 
 [functions][fn] and [`struct`s][structs]
 
-[fn]: /fn.html
-[structs]: /custom_types/structs.html
+[fn]: fn.html
+[structs]: custom_types/structs.html

--- a/src/generics/gen_trait.md
+++ b/src/generics/gen_trait.md
@@ -41,5 +41,5 @@ fn main() {
 [`Drop`][Drop], [`struct`][structs], and [`trait`][traits]
 
 [Drop]: https://doc.rust-lang.org/std/ops/trait.Drop.html
-[structs]: /custom_types/structs.html
-[traits]: /trait.html
+[structs]: custom_types/structs.html
+[traits]: trait.html

--- a/src/generics/impl.md
+++ b/src/generics/impl.md
@@ -46,7 +46,7 @@ fn main() {
 [functions returning references][fn], [`impl`][methods], and [`struct`][structs]
 
 
-[fn]: /scope/lifetime/fn.html
-[methods]: /fn/methods.html
+[fn]: scope/lifetime/fn.html
+[methods]: fn/methods.html
 [specialization_plans]: https://blog.rust-lang.org/2015/05/11/traits.html#the-future
-[structs]: /custom_types/structs.html
+[structs]: custom_types/structs.html

--- a/src/generics/multi_bounds.md
+++ b/src/generics/multi_bounds.md
@@ -33,5 +33,5 @@ fn main() {
 
 [`std::fmt`][fmt] and [`trait`s][traits]
 
-[fmt]: /hello/print.html
-[traits]: /trait.html
+[fmt]: hello/print.html
+[traits]: trait.html

--- a/src/generics/new_types.md
+++ b/src/generics/new_types.md
@@ -47,5 +47,5 @@ Uncomment the last print statement to observe that the type supplied must be `Ye
 
 [`structs`][struct]
 
-[struct]: /custom_types/structs.html
+[struct]: custom_types/structs.html
 

--- a/src/generics/phantom.md
+++ b/src/generics/phantom.md
@@ -57,7 +57,7 @@ fn main() {
 
 [Derive], [struct], and [TupleStructs]
 
-[Derive]: /trait/derive.html
-[struct]: /custom_types/structs.html
-[TupleStructs]: /custom_types/structs.html
+[Derive]: trait/derive.html
+[struct]: custom_types/structs.html
+[TupleStructs]: custom_types/structs.html
 [std::marker::PhantomData]: https://doc.rust-lang.org/std/marker/struct.PhantomData.html

--- a/src/generics/phantom/testcase_units.md
+++ b/src/generics/phantom/testcase_units.md
@@ -77,12 +77,12 @@ fn main() {
 [Borrowing (`&`)], [Bounds (`X: Y`)], [enum], [impl & self],
 [Overloading], [ref], [Traits (`X for Y`)], and [TupleStructs].
 
-[Borrowing (`&`)]: /scope/borrow.html
-[Bounds (`X: Y`)]: /generics/bounds.html
-[enum]: /custom_types/enum.html
-[impl & self]: /fn/methods.html
-[Overloading]: /trait/ops.html
-[ref]: /scope/borrow/ref.html
-[Traits (`X for Y`)]: /trait.html
-[TupleStructs]: /custom_types/structs.html
+[Borrowing (`&`)]: scope/borrow.html
+[Bounds (`X: Y`)]: generics/bounds.html
+[enum]: custom_types/enum.html
+[impl & self]: fn/methods.html
+[Overloading]: trait/ops.html
+[ref]: scope/borrow/ref.html
+[Traits (`X for Y`)]: trait.html
+[TupleStructs]: custom_types/structs.html
 [std::marker::PhantomData]: https://doc.rust-lang.org/std/marker/struct.PhantomData.html

--- a/src/generics/where.md
+++ b/src/generics/where.md
@@ -50,6 +50,6 @@ fn main() {
 
 [RFC][where], [`struct`][struct], and [`trait`][trait]
 
-[struct]: /custom_types/structs.html
-[trait]: /trait.html
+[struct]: custom_types/structs.html
+[trait]: trait.html
 [where]: https://github.com/rust-lang/rfcs/blob/master/text/0135-where.md

--- a/src/hello.md
+++ b/src/hello.md
@@ -46,4 +46,4 @@ Hello World!
 I'm a Rustacean!
 ```
 
-[macros]: ./macros.html
+[macros]: macros.html

--- a/src/hello/comment.md
+++ b/src/hello/comment.md
@@ -48,4 +48,4 @@ fn main() {
 
 [Library documentation][docs]
 
-[docs]: /meta/doc.html
+[docs]: meta/doc.html

--- a/src/hello/print.md
+++ b/src/hello/print.md
@@ -83,7 +83,7 @@ for these types. To print text for custom types, more steps are required.
 and [`traits`][traits]
 
 [fmt]: https://doc.rust-lang.org/std/fmt/
-[macros]: /macros.html
-[string]: /std/str.html
-[structs]: /custom_types/structs.html
-[traits]: /trait.html
+[macros]: macros.html
+[string]: std/str.html
+[structs]: custom_types/structs.html
+[traits]: trait.html

--- a/src/hello/print/print_debug.md
+++ b/src/hello/print/print_debug.md
@@ -78,7 +78,7 @@ One can manually implement `fmt::Display` to control the display.
 and [`struct`][structs]
 
 [attributes]: https://doc.rust-lang.org/reference/attributes.html
-[derive]: /trait/derive.html
+[derive]: trait/derive.html
 [fmt]: https://doc.rust-lang.org/std/fmt/
-[structs]: /custom_types/structs.html
+[structs]: custom_types/structs.html
 

--- a/src/hello/print/print_display.md
+++ b/src/hello/print/print_display.md
@@ -120,9 +120,9 @@ Debug: Complex { real: 3.3, imag: 7.2 }
 [`derive`][derive], [`std::fmt`][fmt], [macros], [`struct`][structs],
 [`trait`][traits], and [use][use]
 
-[derive]: /trait/derive.html
+[derive]: trait/derive.html
 [fmt]: https://doc.rust-lang.org/std/fmt/
-[macros]: /macros.html
-[structs]: /custom_types/structs.html
-[traits]: /trait.html
-[use]: /mod/use.html
+[macros]: macros.html
+[structs]: custom_types/structs.html
+[traits]: trait.html
+[use]: mod/use.html

--- a/src/hello/print/print_display/testcase_list.md
+++ b/src/hello/print/print_display/testcase_list.md
@@ -71,9 +71,9 @@ Try changing the program so that the index of each element in the vector is also
 [`for`][for], [`ref`][ref], [`Result`][result], [`struct`][struct],
 [`?`][q_mark], and [`vec!`][vec]
 
-[for]: /flow_control/for.html
-[result]: /std/result.html
-[ref]: /scope/borrow/ref.html
-[struct]: /custom_types/structs.html
-[q_mark]: /std/result/question_mark.html
-[vec]: /std/vec.html
+[for]: flow_control/for.html
+[result]: std/result.html
+[ref]: scope/borrow/ref.html
+[struct]: custom_types/structs.html
+[q_mark]: std/result/question_mark.html
+[vec]: std/vec.html

--- a/src/macros/syntax.md
+++ b/src/macros/syntax.md
@@ -3,6 +3,6 @@
 In following subsections, we will show how to define macros in Rust.
 There are three basic ideas:
 
-- [Patterns and Designators](designators.md)
-- [Overloading](overload.md)
-- [Repetition](repeat.md)
+- [Patterns and Designators](macros/designators.md)
+- [Overloading](macros/overload.md)
+- [Repetition](macros/repeat.md)

--- a/src/mod/split.md
+++ b/src/mod/split.md
@@ -93,4 +93,4 @@ called `my::indirect_access()`, that
 called `my::nested::function()`
 ```
 
-[visibility]: /mod/visibility.html
+[visibility]: mod/visibility.html

--- a/src/mod/struct_visibility.md
+++ b/src/mod/struct_visibility.md
@@ -55,5 +55,5 @@ fn main() {
 
 [generics][generics] and [methods][methods]
 
-[generics]: /generics.html
-[methods]: /fn/methods.html
+[generics]: generics.html
+[methods]: fn/methods.html

--- a/src/primitives.md
+++ b/src/primitives.md
@@ -57,6 +57,6 @@ fn main() {
 [the `std` library][std], [`mut`][mut], [inference], and [shadowing]
 
 [std]: https://doc.rust-lang.org/std/
-[mut]: https://rustbyexample.com/variable_bindings/mut.html
-[inference]: https://rustbyexample.com/cast/inference.html
-[shadowing]: https://rustbyexample.com/variable_bindings/scope.html
+[mut]: variable_bindings/mut.html
+[inference]: types/inference.html
+[shadowing]: variable_bindings/scope.html

--- a/src/primitives/literals.md
+++ b/src/primitives/literals.md
@@ -42,5 +42,5 @@ fn main() {
 }
 ```
 
-[rust op-prec]: https://doc.rust-lang.org/reference/expressions.html#operator-precedence
+[rust op-prec]: https://doc.rust-lang.org/reference/expressions.html#expression-precedence
 [op-prec]: https://en.wikipedia.org/wiki/Operator_precedence#Programming_languages

--- a/src/primitives/tuples.md
+++ b/src/primitives/tuples.md
@@ -94,4 +94,4 @@ fn main() {
     ( 1.2 2.2 )
     ```
 
-[print_display]: /hello/print/print_display.html
+[print_display]: hello/print/print_display.html

--- a/src/scope/borrow/mut.md
+++ b/src/scope/borrow/mut.md
@@ -56,4 +56,4 @@ fn main() {
 ### See also:
 [`static`][static]
 
-[static]: ../lifetime/static_lifetime.html
+[static]: scope/lifetime/static_lifetime.html

--- a/src/scope/lifetime/explicit.md
+++ b/src/scope/lifetime/explicit.md
@@ -63,13 +63,13 @@ fn main() {
 }
 ```
 
-[^1]: [elision][elision] implicitly annotates lifetimes and so is different.
+[^1]: [elision] implicitly annotates lifetimes and so is different.
 
 ### See also:
 
 [generics][generics] and [closures][closures]
 
-[anonymity]: /fn/closures/anonymity.html
-[closures]: /fn/closures.html
-[elision]: /scope/lifetime/elision.html
-[generics]: /generics.html
+[anonymity]: fn/closures/anonymity.html
+[closures]: fn/closures.html
+[elision]: scope/lifetime/elision.html
+[generics]: generics.html

--- a/src/scope/lifetime/fn.md
+++ b/src/scope/lifetime/fn.md
@@ -59,5 +59,5 @@ fn main() {
 
 [functions][fn]
 
-[elision]: /scope/lifetime/elision.html
-[fn]: /fn.html
+[elision]: scope/lifetime/elision.html
+[fn]: fn.html

--- a/src/scope/lifetime/lifetime_bounds.md
+++ b/src/scope/lifetime/lifetime_bounds.md
@@ -48,6 +48,6 @@ fn main() {
 [generics][generics], [bounds in generics][bounds], and 
 [multiple bounds in generics][multibounds]
 
-[generics]: /generics.html
-[bounds]: /generics/bounds.html
-[multibounds]: /generics/multi_bounds.html
+[generics]: generics.html
+[bounds]: generics/bounds.html
+[multibounds]: generics/multi_bounds.html

--- a/src/scope/lifetime/methods.md
+++ b/src/scope/lifetime/methods.md
@@ -23,6 +23,6 @@ fn main() {
 
 ### See also:
 
-[methods][methods]
+[methods]
 
-[methods]: /fn/methods.html
+[methods]: fn/methods.html

--- a/src/scope/lifetime/static_lifetime.md
+++ b/src/scope/lifetime/static_lifetime.md
@@ -49,4 +49,4 @@ fn main() {
 
 [`'static` constants][static_const]
 
-[static_const]: /custom_types/constants.html
+[static_const]: custom_types/constants.html

--- a/src/scope/lifetime/struct.md
+++ b/src/scope/lifetime/struct.md
@@ -43,4 +43,4 @@ fn main() {
 [`structs`][structs]
 
 
-[structs]: /custom_types/structs.html
+[structs]: custom_types/structs.html

--- a/src/scope/move.md
+++ b/src/scope/move.md
@@ -57,4 +57,4 @@ fn main() {
 }
 ```
 
-[references]: /flow_control/match/destructuring/destructure_pointers.html
+[references]: flow_control/match/destructuring/destructure_pointers.html

--- a/src/scope/raii.md
+++ b/src/scope/raii.md
@@ -91,6 +91,6 @@ fn main() {
 [Box][box]
 
 [raii]: https://en.wikipedia.org/wiki/Resource_Acquisition_Is_Initialization
-[box]: /std/box.html
+[box]: std/box.html
 [valgrind]: http://valgrind.org/info/
 [`Drop`]: https://doc.rust-lang.org/std/ops/trait.Drop.html

--- a/src/std.md
+++ b/src/std.md
@@ -11,7 +11,7 @@ the `primitives`. Some of these include:
 
 ### See also:
 
-[primitives][primitives] and [the std library][std]
+[primitives] and [the std library][std]
 
-[primitives]: /primitives.html
+[primitives]: primitives.html
 [std]: https://doc.rust-lang.org/std/

--- a/src/std_misc.md
+++ b/src/std_misc.md
@@ -7,11 +7,11 @@ things such as:
 * Channels
 * File I/O
 
-These expand beyond what the [primitives][primitives] provide.
+These expand beyond what the [primitives] provide.
 
 ### See also:
 
-[primitives][primitives] and [the std library][std]
+[primitives] and [the std library][std]
 
-[primitives]: /primitives.html
+[primitives]: primitives.html
 [std]: https://doc.rust-lang.org/std/

--- a/src/std_misc/fs.md
+++ b/src/std_misc/fs.md
@@ -144,4 +144,4 @@ fn cat(path: &Path) -> io::Result<String> {
 
 [`cfg!`][cfg]
 
-[cfg]: /attribute/cfg.html
+[cfg]: attribute/cfg.html

--- a/src/testing.md
+++ b/src/testing.md
@@ -18,9 +18,9 @@ Also Rust has support for specifying additional dependencies for tests:
 * [The Book][doc-testing] chapter on testing
 * [API Guidelines][doc-nursery] on doc-testing
 
-[unit]: ./testing/unit_testing.html
-[doc]: ./testing/doc_testing.html
-[integration]: ./testing/integration_testing.html
-[dev-dependencies]: ./testing/dev_dependencies.html
+[unit]: testing/unit_testing.html
+[doc]: testing/doc_testing.html
+[integration]: testing/integration_testing.html
+[dev-dependencies]: testing/dev_dependencies.html
 [doc-testing]: https://doc.rust-lang.org/book/second-edition/ch11-00-testing.html
 [doc-nursery]: https://rust-lang-nursery.github.io/api-guidelines/documentation.html

--- a/src/testing/doc_testing.md
+++ b/src/testing/doc_testing.md
@@ -1,7 +1,7 @@
 # Documentation testing
 
 The primary way of documenting a Rust project is through annotating the source
-code. Documentation comments are written in [markdown][markdown] and support code
+code. Documentation comments are written in [markdown] and support code
 blocks in them. Rust takes care about correctness, so these code blocks are
 compiled and used as tests.
 

--- a/src/testing/integration_testing.md
+++ b/src/testing/integration_testing.md
@@ -83,5 +83,5 @@ fn test_add() {
 Modules with common code follow the ordinary [modules][mod] rules, so it's ok to
 create common module as `tests/common/mod.rs`.
 
-[unit]: ./testing/unit_testing.html
-[mod]: ./mod.html
+[unit]: testing/unit_testing.html
+[mod]: mod.html

--- a/src/testing/unit_testing.md
+++ b/src/testing/unit_testing.md
@@ -224,7 +224,7 @@ running 0 tests
 test result: ok. 0 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out
 ```
 
-[attribute]: ../attribute.html
-[panic]: ../std/panic.html
-[macros]: ../macros.html
-[mod]: ../mod.html
+[attribute]: attribute.html
+[panic]: std/panic.html
+[macros]: macros.html
+[mod]: mod.html

--- a/src/trait/derive.md
+++ b/src/trait/derive.md
@@ -64,7 +64,7 @@ fn main() {
 ### See also:
 [`derive`][derive]
 
-[attribute]: /attribute.html
+[attribute]: attribute.html
 [eq]: https://doc.rust-lang.org/std/cmp/trait.Eq.html
 [partial-eq]: https://doc.rust-lang.org/std/cmp/trait.PartialEq.html
 [ord]: https://doc.rust-lang.org/std/cmp/trait.Ord.html

--- a/src/types/alias.md
+++ b/src/types/alias.md
@@ -33,4 +33,4 @@ is an alias for the `Result<T, IoError>` type.
 
 ### See also:
 
-[Attributes](/attribute.html)
+[Attributes](attribute.html)

--- a/src/types/literals.md
+++ b/src/types/literals.md
@@ -38,6 +38,6 @@ yet, here's a brief explanation for the impatient readers:
   is defined in the `std` *crate*. For more details, see
   [modules][mod] and [crates][crate].
 
-[borrow]: /scope/borrow.html
-[mod]: /mod.html
-[crate]: /crates.html
+[borrow]: scope/borrow.html
+[mod]: mod.html
+[crate]: crates.html


### PR DESCRIPTION
With mdbook, relative links in any document are relative to the
top level of the book, so there's no need to start them with
'/'s.

There were also incorrect links in macros/syntax.md because of
this - they have been fixed.

There were also incorrect links to the stable Reference. These
have also been updated.

I did not change the doc.rlo links, as even though they could
have been made relative for when RBE is on doc.rlo, we're still
going to keep RBE.com's rendering up until RBE renders on stable
docs, which is going to be awhile. But when RBE.com is just a
redirect, they should be changed to "../std/MOAR" and
"../book/MOAR" and "../reference/MOAR" as appropriate too.