### PR TITLE
add example of using `move` keyword

### DIFF
--- a/src/fn/closures/capture.md
+++ b/src/fn/closures/capture.md
@@ -69,6 +69,30 @@ fn main() {
 }
 ```
 
+Using `move` before vertical pipes forces closure
+to take ownership of captured variables:
+
+```rust,editable
+fn main() {
+    // `Vec` has non-copy semantics.
+    let haystack = vec![1, 2, 3];
+
+    let contains = move |needle| haystack.contains(needle);
+
+    println!("{}", contains(&1));
+    println!("{}", contains(&4));
+
+    // `println!("There're {} elements in vec", haystack.len());`
+    // ^ Uncommenting above line will result in compile-time error
+    // because borrow checker doesn't allow re-using variable after it
+    // has been moved.
+    
+    // Removing `move` from closure's signature will cause closure
+    // to borrow _haystack_ variable immutably, hence _haystack_ is still
+    // available and uncommenting above line will not cause an error.
+}
+```
+
 ### See also:
 
 [`Box`][box] and [`std::mem::drop`][drop]


### PR DESCRIPTION
Show how to use `move` keyword to force closure to take ownership
of captured variables.