### PR TITLE
reword definition to be more precise

### DIFF
--- a/src/crates.md
+++ b/src/crates.md
@@ -2,9 +2,10 @@
 
 A crate is a compilation unit in Rust. Whenever `rustc some_file.rs` is called,
 `some_file.rs` is treated as the *crate file*. If `some_file.rs` has `mod`
-declarations in it, then the contents of the module files will get merged with
-the crate file *before* running the compiler over it. In other words, modules
-do *not* get compiled individually, only crates get compiled.
+declarations in it, then the contents of the module files would be inserted in
+places where `mod` declarations in the crate file are found, *before* running
+the compiler over it. In other words, modules do *not* get compiled
+individually, only crates get compiled.
 
 A crate can be compiled into a binary or into a library. By default, `rustc`
 will produce a binary from a crate. This behavior can be overridden by passing


### PR DESCRIPTION
I used this comment
// This declaration will look for a file named `my.rs` or `my/mod.rs` and will
// insert its contents inside a module named `my` under this scope
from [book's previous page](https://rustbyexample.com/mod/split.html])