### PR TITLE
fix incorrect note

### DIFF
--- a/src/std/result/question_mark.md
+++ b/src/std/result/question_mark.md
@@ -3,8 +3,8 @@
 Chaining results using match can get pretty untidy; luckily, the `?` operator
 can be used to make things pretty again. `?` is used at the end of an expression
 returning a `Result`, and is equivalent to a match expression, where the 
-`Err(err)` branch expands to an early `return Err(err)`, and the `Ok(ok)` branch 
-expands to an `ok` expression.
+`Err(err)` branch expands to an early `Err(From::from(err))`, and the `Ok(ok)`
+branch expands to an `ok` expression.
 
 ```rust,editable,ignore,mdbook-runnable
 mod checked {


### PR DESCRIPTION
I referenced https://rustbyexample.com/error/multiple_error_types/reenter_question_mark.html

```
? was previously explained as either unwrap or return Err(err).
This is only mostly true. It actually means unwrap or return Err(From::from(err))
```