### PR TITLE
add wrapping main function for examples execution

### DIFF
--- a/src/flow_control/for.md
+++ b/src/flow_control/for.md
@@ -42,12 +42,14 @@ collection.
   Thus leaving the collection untouched and available for reuse after the loop.
 
 ```rust, editable
-let names = vec!["Bob", "Frank", "Ferris"];
+fn main() {
+    let names = vec!["Bob", "Frank", "Ferris"];
 
-for name in names.iter() {
-    match name {
-        &"Ferris" => println!("There is a rustacean among us!"),
-        _ => println!("Hello {}", name),
+    for name in names.iter() {
+        match name {
+            &"Ferris" => println!("There is a rustacean among us!"),
+            _ => println!("Hello {}", name),
+        }
     }
 }
 ```
@@ -57,12 +59,14 @@ for name in names.iter() {
   available for reuse as it has been 'moved' within the loop.
 
 ```rust, editable
-let names = vec!["Bob", "Frank", "Ferris"];
+fn main() {
+    let names = vec!["Bob", "Frank", "Ferris"];
 
-for name in names.into_iter() {
-    match name {
-        "Ferris" => println!("There is a rustacean among us!"),
-        _ => println!("Hello {}", name),
+    for name in names.into_iter() {
+        match name {
+            "Ferris" => println!("There is a rustacean among us!"),
+            _ => println!("Hello {}", name),
+        }
     }
 }
 ```
@@ -71,12 +75,14 @@ for name in names.into_iter() {
   the collection to be modified in place.
 
 ```rust, editable
-let mut names = vec!["Bob", "Frank", "Ferris"];
+fn main() {
+    let mut names = vec!["Bob", "Frank", "Ferris"];
 
-for name in names.iter_mut() {
-    match name {
-        &mut "Ferris" => println!("There is a rustacean among us!"),
-        _ => println!("Hello {}", name),
+    for name in names.iter_mut() {
+        match name {
+            &mut "Ferris" => println!("There is a rustacean among us!"),
+            _ => println!("Hello {}", name),
+        }
     }
 }
 ```


### PR DESCRIPTION
as mentioned in #1013 the additonal examples cannot be executed due to a missing wrapping main function.