### PR TITLE
Unify Rust Code Block Syntax

### DIFF
--- a/src/attribute/cfg/custom.md
+++ b/src/attribute/cfg/custom.md
@@ -3,7 +3,7 @@
 Some conditionals like `target_os` are implicitly provided by `rustc`, but
 custom conditionals must be passed to `rustc` using the `--cfg` flag.
 
-```rust,editable,ignore,mdbook-runnable
+```rust,editable
 #[cfg(some_condition)]
 fn conditional_function() {
     println!("condition met!");

--- a/src/conversion/from_into.md
+++ b/src/conversion/from_into.md
@@ -13,7 +13,7 @@ library for conversion of primitive and common types.
 
 For example we can easily convert a `str` into a `String`
 
-```rust
+```rust,ignore
 let my_str = "hello";
 let my_string = String::from(my_str);
 ```

--- a/src/conversion/string.md
+++ b/src/conversion/string.md
@@ -36,7 +36,7 @@ trait is implemented for that type. This is implemented for numerous types
 within the standard library. To obtain this functionality on a user defined type
 simply implement the [`FromStr`] trait for that type.
 
-```rust
+```rust,editable
 fn main() {
     let parsed: i32 = "5".parse().unwrap();
     let turbo_parsed = "10".parse::<i32>().unwrap();

--- a/src/custom_types/constants.md
+++ b/src/custom_types/constants.md
@@ -13,7 +13,7 @@ types must be specifically annotated so that they fulfill the `'static`
 lifetime. This may seem minor though because the required explicit annotation
 hides the distinction.
 
-```rust,editable,ignore,mdbook-runnable
+```rust,editable
 // Globals are declared outside all other scopes.
 static LANGUAGE: &'static str = "Rust";
 const  THRESHOLD: i32 = 10;

--- a/src/error/multiple_error_types.md
+++ b/src/error/multiple_error_types.md
@@ -12,7 +12,7 @@ In the following code, two instances of `unwrap` generate different error
 types. `Vec::first` returns an `Option`, while `parse::<i32>` returns a
 `Result<i32, ParseIntError>`:
 
-```rust,editable,ignore,mdbook-runnable
+```rust,editable
 fn double_first(vec: Vec<&str>) -> i32 {
     let first = vec.first().unwrap(); // Generate error 1
     2 * first.parse::<i32>().unwrap() // Generate error 2

--- a/src/error/option_unwrap.md
+++ b/src/error/option_unwrap.md
@@ -1,29 +1,29 @@
 # `Option` & `unwrap`
 
-In the last example, we showed that we can induce program failure at will. 
-We told our program to `panic` if the princess received an inappropriate 
-gift - a snake. But what if the princess expected a gift and didn't receive 
+In the last example, we showed that we can induce program failure at will.
+We told our program to `panic` if the princess received an inappropriate
+gift - a snake. But what if the princess expected a gift and didn't receive
 one? That case would be just as bad, so it needs to be handled!
 
-We *could* test this against the null string (`""`) as we do with a snake. 
-Since we're using Rust, let's instead have the compiler point out cases 
+We *could* test this against the null string (`""`) as we do with a snake.
+Since we're using Rust, let's instead have the compiler point out cases
 where there's no gift.
 
-An `enum` called `Option<T>` in the `std` library is used when absence is a 
+An `enum` called `Option<T>` in the `std` library is used when absence is a
 possibility. It manifests itself as one of two "options":
 
 * `Some(T)`: An element of type `T` was found
 * `None`: No element was found
 
-These cases can either be explicitly handled via `match` or implicitly with 
+These cases can either be explicitly handled via `match` or implicitly with
 `unwrap`. Implicit handling will either return the inner element or `panic`.
 
-Note that it's possible to manually customize `panic` with [expect][expect], 
-but `unwrap` otherwise leaves us with a less meaningful output than explicit 
-handling. In the following example, explicit handling yields a more 
+Note that it's possible to manually customize `panic` with [expect][expect],
+but `unwrap` otherwise leaves us with a less meaningful output than explicit
+handling. In the following example, explicit handling yields a more
 controlled result while retaining the option to `panic` if desired.
 
-```rust,editable,ignore,mdbook-runnable
+```rust,editable
 // The commoner has seen it all, and can handle any gift well.
 // All gifts are handled explicitly using `match`.
 fn give_commoner(gift: Option<&str>) {

--- a/src/error/panic.md
+++ b/src/error/panic.md
@@ -1,10 +1,10 @@
 # `panic`
 
-The simplest error handling mechanism we will see is `panic`. It prints an 
-error message, starts unwinding the task, and usually exits the program. 
-Here, we explicitly call `panic` on our error condition: 
+The simplest error handling mechanism we will see is `panic`. It prints an
+error message, starts unwinding the task, and usually exits the program.
+Here, we explicitly call `panic` on our error condition:
 
-```rust,editable,ignore,mdbook-runnable
+```rust,editable
 fn give_princess(gift: &str) {
     // Princesses hate snakes, so we need to stop if she disapproves!
     if gift == "snake" { panic!("AAAaaaaa!!!!"); }

--- a/src/error/result.md
+++ b/src/error/result.md
@@ -21,7 +21,7 @@ be possible to parse a string into the other type, so `parse()` returns a
 
 Let's see what happens when we successfully and unsuccessfully `parse()` a string:
 
-```rust,editable,ignore,mdbook-runnable
+```rust,editable
 fn multiply(first_number_str: &str, second_number_str: &str) -> i32 {
     // Let's try using `unwrap()` to get the number out. Will it bite us?
     let first_number = first_number_str.parse::<i32>().unwrap();

--- a/src/flow_control/for.md
+++ b/src/flow_control/for.md
@@ -41,7 +41,7 @@ collection.
 * `iter` - This borrows each element of the collection through each iteration.
   Thus leaving the collection untouched and available for reuse after the loop.
 
-```rust, editable
+```rust,editable
 fn main() {
     let names = vec!["Bob", "Frank", "Ferris"];
 
@@ -58,7 +58,7 @@ fn main() {
   data is provided. Once the collection has been consumed it is no longer
   available for reuse as it has been 'moved' within the loop.
 
-```rust, editable
+```rust,editable
 fn main() {
     let names = vec!["Bob", "Frank", "Ferris"];
 
@@ -74,7 +74,7 @@ fn main() {
 * `iter_mut` - This mutably borrows each element of the collection, allowing for
   the collection to be modified in place.
 
-```rust, editable
+```rust,editable
 fn main() {
     let mut names = vec!["Bob", "Frank", "Ferris"];
 

--- a/src/flow_control/if_let.md
+++ b/src/flow_control/if_let.md
@@ -2,7 +2,7 @@
 
 For some use cases, when matching enums, `match` is awkward. For example:
 
-```rust
+```rust,editable
 // Make `optional` of type `Option<i32>`
 let optional = Some(7);
 

--- a/src/flow_control/while_let.md
+++ b/src/flow_control/while_let.md
@@ -3,7 +3,7 @@
 Similar to `if let`, `while let` can make awkward `match` sequences
 more tolerable. Consider the following sequence that increments `i`:
 
-```rust
+```rust,editable
 // Make `optional` of type `Option<i32>`
 let mut optional = Some(0);
 

--- a/src/fn/closures.md
+++ b/src/fn/closures.md
@@ -3,7 +3,7 @@
 Closures in Rust, also called lambda expressions or lambdas, are functions that can capture 
 the enclosing environment. For example, a closure that captures the x 
 variable:
-```Rust
+```rust,ignore
 |val| val + x
 ```
 

--- a/src/fn/closures/anonymity.md
+++ b/src/fn/closures/anonymity.md
@@ -5,7 +5,7 @@ any consequences? It surely does. Observe how using a closure as a function
 parameter requires [generics], which is necessary because of how they are
 defined:
 
-```rust
+```rust,ignore
 // `F` must be generic.
 fn apply<F>(f: F) where
     F: FnOnce() {

--- a/src/generics/assoc_items/types.md
+++ b/src/generics/assoc_items/types.md
@@ -4,7 +4,7 @@ The use of "Associated types" improves the overall readability of code
 by moving inner types locally into a trait as *output* types. Syntax
 for the `trait` definition is as follows:
 
-```rust
+```rust,ignore
 // `A` and `B` are defined in the trait via the `type` keyword.
 // (Note: `type` in this context is different from `type` when used for
 // aliases).

--- a/src/generics/impl.md
+++ b/src/generics/impl.md
@@ -2,7 +2,7 @@
 
 Similar to functions, implementations require care to remain generic.
 
-```rust
+```rust,ignore
 struct S; // Concrete type `S`
 struct GenericVal<T>(T,); // Generic type `GenericVal`
 

--- a/src/generics/new_types.md
+++ b/src/generics/new_types.md
@@ -6,7 +6,7 @@ to a program.
 For example, an age verification function that checks age in years, *must* be given
 a value of type `Years`.
 
-```rust, editable
+```rust,editable
 struct Years(i64);
 
 struct Days(i64);

--- a/src/hello/print.md
+++ b/src/hello/print.md
@@ -12,7 +12,7 @@ some of which include:
 All parse text in the same fashion. A plus is that the formatting correctness will
 be checked at compile time.
 
-```rust,editable,ignore,mdbook-runnable
+```rust,editable
 fn main() {
     // In general, the `{}` will be automatically replaced with any
     // arguments. These will be stringified.
@@ -45,7 +45,7 @@ fn main() {
     // used.
     println!("My name is {0}, {1} {0}", "Bond");
     // FIXME ^ Add the missing argument: "James"
-    
+
     // Create a structure which contains an `i32`. Name it `Structure`.
     #[allow(dead_code)]
     struct Structure(i32);

--- a/src/hello/print/print_debug.md
+++ b/src/hello/print/print_debug.md
@@ -9,7 +9,7 @@ The `fmt::Debug` `trait` makes this very straightforward. *All* types can
 `derive` (automatically create) the `fmt::Debug` implementation. This is
 not true for `fmt::Display` which must be manually implemented.
 
-```rust
+```rust,ignore
 // This structure cannot be printed either with `fmt::Display` or
 // with `fmt::Debug`
 struct UnPrintable(i32);

--- a/src/hello/print/print_display.md
+++ b/src/hello/print/print_display.md
@@ -5,7 +5,7 @@ customize the output appearance. This is done by manually implementing
 [`fmt::Display`][fmt], which uses the `{}` print marker. Implementing it
 looks like this:
 
-```rust
+```rust,ignore
 // Import (via `use`) the `fmt` module to make it available.
 use std::fmt;
 

--- a/src/meta/doc.md
+++ b/src/meta/doc.md
@@ -4,7 +4,7 @@ Doc comments are very useful for big projects that require documentation. When
 running [Rustdoc][1], these are the comments that get compiled into
 documentation. They are denoted by a `///`, and support [Markdown][2].
 
-```rust,editable,ignore,mdbook-runnable
+```rust,ignore
 #![crate_name = "doc"]
 
 /// A human being is represented here

--- a/src/primitives.md
+++ b/src/primitives.md
@@ -13,7 +13,7 @@ Rust provides access to a wide variety of `primitives`. A sample includes:
 * and the unit type `()`, whose only possible value is an empty tuple: `()`
 
 Despite the value of a unit type being a tuple, it is not considered a
-compound type because it does not contain multiple values. 
+compound type because it does not contain multiple values.
 
 ### Compound Types
 
@@ -24,7 +24,7 @@ Variables can always be *type annotated*. Numbers may additionally be
 annotated via a *suffix* or *by default*. Integers default to `i32` and
 floats to `f64`. Note that Rust can also infer types from context.
 
-```rust,editable,ignore,mdbook-runnable
+```rust,editable
 fn main() {
     // Variables can be type annotated.
     let logical: bool = true;
@@ -35,18 +35,18 @@ fn main() {
     // Or a default will be used.
     let default_float   = 3.0; // `f64`
     let default_integer = 7;   // `i32`
-    
-    // A type can also be inferred from context 
+
+    // A type can also be inferred from context
     let mut inferred_type = 12; // Type i64 is inferred from another line
     inferred_type = 4294967296i64;
-    
+
     // A mutable variable's value can be changed.
     let mut mutable = 12; // Mutable `i32`
     mutable = 21;
-    
+
     // Error! The type of a variable can't be changed.
     mutable = true;
-    
+
     // Variables can be overwritten with shadowing.
     let mutable = true;
 }

--- a/src/primitives/array.md
+++ b/src/primitives/array.md
@@ -6,12 +6,12 @@ at compile time, is part of their type signature `[T; size]`.
 
 Slices are similar to arrays, but their size is not known at compile time.
 Instead, a slice is a two-word object, the first word is a pointer to the data,
-and the second word is the length of the slice. The word size is the same as 
-usize, determined by the processor architecture eg 64 bits on an x86-64. 
-Slices can be used to borrow a section of an array, and have the type signature 
+and the second word is the length of the slice. The word size is the same as
+usize, determined by the processor architecture eg 64 bits on an x86-64.
+Slices can be used to borrow a section of an array, and have the type signature
 `&[T]`.
 
-```rust,editable,ignore,mdbook-runnable
+```rust,editable
 use std::mem;
 
 // This function borrows a slice

--- a/src/scope/borrow.md
+++ b/src/scope/borrow.md
@@ -4,11 +4,11 @@ Most of the time, we'd like to access data without taking ownership over
 it. To accomplish this, Rust uses a *borrowing* mechanism. Instead of
 passing objects by value (`T`), objects can be passed by reference (`&T`).
 
-The compiler statically guarantees (via its borrow checker) that references 
+The compiler statically guarantees (via its borrow checker) that references
 *always* point to valid objects. That is, while references to an object
 exist, the object cannot be destroyed.
 
-```rust,editable,ignore,mdbook-runnable
+```rust,editable
 // This function takes ownership of a box and destroys it
 fn eat_box_i32(boxed_i32: Box<i32>) {
     println!("Destroying box that contains {}", boxed_i32);

--- a/src/scope/borrow/freeze.md
+++ b/src/scope/borrow/freeze.md
@@ -1,9 +1,9 @@
 # Freezing
 
-When data is immutably borrowed, it also *freezes*. *Frozen* data can't be 
+When data is immutably borrowed, it also *freezes*. *Frozen* data can't be
 modified via the original object until all references to it go out of scope:
 
-```rust,editable,ignore,mdbook-runnable
+```rust,editable
 fn main() {
     let mut _mutable_integer = 7i32;
 

--- a/src/scope/borrow/mut.md
+++ b/src/scope/borrow/mut.md
@@ -1,11 +1,11 @@
 # Mutability
 
-Mutable data can be mutably borrowed using `&mut T`. This is called 
+Mutable data can be mutably borrowed using `&mut T`. This is called
 a *mutable reference* and gives read/write access to the borrower.
-In contrast, `&T` borrows the data via an immutable reference, and 
+In contrast, `&T` borrows the data via an immutable reference, and
 the borrower can read the data but not modify it:
 
-```rust,editable,ignore,mdbook-runnable
+```rust,editable
 #[allow(dead_code)]
 #[derive(Clone, Copy)]
 struct Book {
@@ -37,16 +37,16 @@ fn main() {
 
     // Create a mutable copy of `immutabook` and call it `mutabook`
     let mut mutabook = immutabook;
-    
+
     // Immutably borrow an immutable object
     borrow_book(&immutabook);
 
     // Immutably borrow a mutable object
     borrow_book(&mutabook);
-    
+
     // Borrow a mutable object as mutable
     new_edition(&mut mutabook);
-    
+
     // Error! Cannot borrow an immutable object as mutable
     new_edition(&mut immutabook);
     // FIXME ^ Comment out this line

--- a/src/scope/lifetime/explicit.md
+++ b/src/scope/lifetime/explicit.md
@@ -2,18 +2,18 @@
 
 The borrow checker uses explicit lifetime annotations to determine
 how long references should be valid. In cases where lifetimes are not
-elided[^1], Rust requires explicit annotations to determine what the 
-lifetime of a reference should be. The syntax for explicitly annotating 
-a lifetime uses an apostrophe character as follows: 
+elided[^1], Rust requires explicit annotations to determine what the
+lifetime of a reference should be. The syntax for explicitly annotating
+a lifetime uses an apostrophe character as follows:
 
 ```rust,ignore
 foo<'a>
 // `foo` has a lifetime parameter `'a`
 ```
 
-Similar to [closures][anonymity], using lifetimes requires generics. 
-Additionally, this lifetime syntax indicates that the lifetime of `foo` 
-may not exceed that of `'a`. Explicit annotation of a type has the form 
+Similar to [closures][anonymity], using lifetimes requires generics.
+Additionally, this lifetime syntax indicates that the lifetime of `foo`
+may not exceed that of `'a`. Explicit annotation of a type has the form
 `&'a T` where `'a` has already been introduced.
 
 In cases with multiple lifetimes, the syntax is similar:
@@ -27,7 +27,7 @@ In this case, the lifetime of `foo` cannot exceed that of either `'a` *or* `'b`.
 
 See the following example for explicit lifetime annotation in use:
 
-```rust,editable,ignore,mdbook-runnable
+```rust,editable
 // `print_refs` takes two references to `i32` which have different
 // lifetimes `'a` and `'b`. These two lifetimes must both be at
 // least as long as the function `print_refs`.
@@ -41,7 +41,7 @@ fn failed_borrow<'a>() {
 
     // ERROR: `_x` does not live long enough
     //let y: &'a i32 = &_x;
-    // Attempting to use the lifetime `'a` as an explicit type annotation 
+    // Attempting to use the lifetime `'a` as an explicit type annotation
     // inside the function will fail because the lifetime of `&_x` is shorter
     // than that of `y`. A short lifetime cannot be coerced into a longer one.
 }
@@ -49,15 +49,15 @@ fn failed_borrow<'a>() {
 fn main() {
     // Create variables to be borrowed below.
     let (four, nine) = (4, 9);
-    
+
     // Borrows (`&`) of both variables are passed into the function.
     print_refs(&four, &nine);
-    // Any input which is borrowed must outlive the borrower. 
-    // In other words, the lifetime of `four` and `nine` must 
+    // Any input which is borrowed must outlive the borrower.
+    // In other words, the lifetime of `four` and `nine` must
     // be longer than that of `print_refs`.
-    
+
     failed_borrow();
-    // `failed_borrow` contains no references to force `'a` to be 
+    // `failed_borrow` contains no references to force `'a` to be
     // longer than the lifetime of the function, but `'a` is longer.
     // Because the lifetime is never constrained, it defaults to `'static`.
 }

--- a/src/std/hash/hashset.md
+++ b/src/std/hash/hashset.md
@@ -5,19 +5,19 @@ Consider a `HashSet` as a `HashMap` where we just care about the keys (
 
 "What's the point of that?" you ask. "I could just store the keys in a `Vec`."
 
-A `HashSet`'s unique feature is that 
-it is guaranteed to not have duplicate elements. 
-That's the contract that any set collection fulfills. 
+A `HashSet`'s unique feature is that
+it is guaranteed to not have duplicate elements.
+That's the contract that any set collection fulfills.
 `HashSet` is just one implementation. (see also: [`BTreeSet`][treeset])
 
-If you insert a value that is already present in the `HashSet`, 
-(i.e. the new value is equal to the existing and they both have the same hash), 
+If you insert a value that is already present in the `HashSet`,
+(i.e. the new value is equal to the existing and they both have the same hash),
 then the new value will replace the old.
 
-This is great for when you never want more than one of something, 
+This is great for when you never want more than one of something,
 or when you want to know if you've already got something.
 
-But sets can do more than that. 
+But sets can do more than that.
 
 Sets have 4 primary operations (all of the following calls return an iterator):
 
@@ -27,12 +27,12 @@ Sets have 4 primary operations (all of the following calls return an iterator):
 
 * `intersection`: get all the elements that are only in *both* sets.
 
-* `symmetric_difference`: 
+* `symmetric_difference`:
 get all the elements that are in one set or the other, but *not* both.
 
 Try all of these in the following example:
 
-```rust,editable,ignore,mdbook-runnable
+```rust,editable
 use std::collections::HashSet;
 
 fn main() {

--- a/src/std/option.md
+++ b/src/std/option.md
@@ -8,7 +8,7 @@ The `Option<T>` enum has two variants:
 * `None`, to indicate failure or lack of value, and
 * `Some(value)`, a tuple struct that wraps a `value` with type `T`.
 
-```rust,editable,ignore,mdbook-runnable
+```rust,editable
 // An integer division that doesn't `panic!`
 fn checked_division(dividend: i32, divisor: i32) -> Option<i32> {
     if divisor == 0 {

--- a/src/std/panic.md
+++ b/src/std/panic.md
@@ -7,7 +7,7 @@ resources *owned* by the thread by calling the destructor of all its objects.
 Since we are dealing with programs with only one thread, `panic!` will cause the
 program to report the panic message and exit.
 
-```rust,editable,ignore,mdbook-runnable
+```rust,editable
 // Re-implementation of integer division (/)
 fn division(dividend: i32, divisor: i32) -> i32 {
     if divisor == 0 {
@@ -40,15 +40,15 @@ $ rustc panic.rs && valgrind ./panic
 ==4401== Copyright (C) 2002-2013, and GNU GPL'd, by Julian Seward et al.
 ==4401== Using Valgrind-3.10.0.SVN and LibVEX; rerun with -h for copyright info
 ==4401== Command: ./panic
-==4401== 
+==4401==
 thread '<main>' panicked at 'division by zero', panic.rs:5
-==4401== 
+==4401==
 ==4401== HEAP SUMMARY:
 ==4401==     in use at exit: 0 bytes in 0 blocks
 ==4401==   total heap usage: 18 allocs, 18 frees, 1,648 bytes allocated
-==4401== 
+==4401==
 ==4401== All heap blocks were freed -- no leaks are possible
-==4401== 
+==4401==
 ==4401== For counts of detected and suppressed errors, rerun with: -v
 ==4401== ERROR SUMMARY: 0 errors from 0 contexts (suppressed: 0 from 0)
 ```

--- a/src/std/result.md
+++ b/src/std/result.md
@@ -2,7 +2,7 @@
 
 We've seen that the `Option` enum can be used as a return value from functions
 that may fail, where `None` can be returned to indicate failure. However,
-sometimes it is important to express *why* an operation failed. To do this we 
+sometimes it is important to express *why* an operation failed. To do this we
 have the `Result` enum.
 
 The `Result<T, E>` enum has two variants:
@@ -12,7 +12,7 @@ The `Result<T, E>` enum has two variants:
 * `Err(why)`, which indicates that the operation failed, and wraps `why`,
   which (hopefully) explains the cause of the failure. (`why` has type `E`)
 
-```rust,editable,ignore,mdbook-runnable
+```rust,editable
 mod checked {
     // Mathematical "errors" we want to catch
     #[derive(Debug)]

--- a/src/std/result/question_mark.md
+++ b/src/std/result/question_mark.md
@@ -2,11 +2,11 @@
 
 Chaining results using match can get pretty untidy; luckily, the `?` operator
 can be used to make things pretty again. `?` is used at the end of an expression
-returning a `Result`, and is equivalent to a match expression, where the 
+returning a `Result`, and is equivalent to a match expression, where the
 `Err(err)` branch expands to an early `Err(From::from(err))`, and the `Ok(ok)`
 branch expands to an `ok` expression.
 
-```rust,editable,ignore,mdbook-runnable
+```rust,editable
 mod checked {
     #[derive(Debug)]
     enum MathError {

--- a/src/std/str.md
+++ b/src/std/str.md
@@ -96,7 +96,7 @@ fn main() {
 Sometimes there are just too many characters that need to be escaped or it's just
 much more convenient to write a string out as-is. This is where raw string literals come into play.
 
-```rust, editable
+```rust,editable
 fn main() {
     let raw_str = r"Escapes don't work here: \x3F \u{211D}";
     println!("{}", raw_str);
@@ -115,7 +115,7 @@ fn main() {
 Want a string that's not UTF-8? (Remember, `str` and `String` must be valid UTF-8)
 Or maybe you want an array of bytes that's mostly text? Byte strings to the rescue!
 
-```rust, editable
+```rust,editable
 use std::str;
 
 fn main() {

--- a/src/std/vec.md
+++ b/src/std/vec.md
@@ -7,7 +7,7 @@ indicates how much memory is reserved for the vector. The vector can grow as
 long as the length is smaller than the capacity. When this threshold needs to
 be surpassed, the vector is reallocated with a larger capacity.
 
-```rust,editable,ignore,mdbook-runnable
+```rust,editable
 fn main() {
     // Iterators can be collected into vectors
     let collected_iterator: Vec<i32> = (0..10).collect();

--- a/src/std_misc/file/open.md
+++ b/src/std_misc/file/open.md
@@ -5,7 +5,7 @@ The `open` static method can be used to open a file in read-only mode.
 A `File` owns a resource, the file descriptor and takes care of closing the
 file when it is `drop`ed.
 
-```rust,editable,ignore
+```rust,ignore
 use std::error::Error;
 use std::fs::File;
 use std::io::prelude::*;

--- a/src/std_misc/process.md
+++ b/src/std_misc/process.md
@@ -3,7 +3,7 @@
 The `process::Output` struct represents the output of a finished child process,
 and the `process::Command` struct is a process builder.
 
-```rust,editable,ignore
+```rust,editable
 use std::process::Command;
 
 fn main() {

--- a/src/testing/unit_testing.md
+++ b/src/testing/unit_testing.md
@@ -170,7 +170,7 @@ test result: ok. 0 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out
 Tests can be marked with the`#[ignore]` attribute to exclude some tests. Or to run
 them with command `cargo test -- --ignored`
 
-```rust
+```rust,ignore
 pub fn add(a: i32, b: i32) -> i32 {
     a + b
 }

--- a/src/types/cast.md
+++ b/src/types/cast.md
@@ -7,7 +7,7 @@ Rules for converting between integral types follow C conventions generally,
 except in cases where C has undefined behavior. The behavior of all casts
 between integral types is well defined in Rust.
 
-```rust,editable,ignore,mdbook-runnable
+```rust,editable
 // Suppress all warnings from casts which overflow.
 #![allow(overflowing_literals)]
 

--- a/src/variable_bindings/declare.md
+++ b/src/variable_bindings/declare.md
@@ -4,7 +4,7 @@ It's possible to declare variable bindings first, and initialize them later.
 However, this form is seldom used, as it may lead to the use of uninitialized
 variables.
 
-```rust,editable,ignore,mdbook-runnable
+```rust,editable
 fn main() {
     // Declare a variable binding
     let a_binding;

--- a/src/variable_bindings/mut.md
+++ b/src/variable_bindings/mut.md
@@ -3,7 +3,7 @@
 Variable bindings are immutable by default, but this can be overridden using
 the `mut` modifier.
 
-```rust,editable,ignore,mdbook-runnable
+```rust,editable
 fn main() {
     let _immutable_binding = 1;
     let mut mutable_binding = 1;

--- a/src/variable_bindings/scope.md
+++ b/src/variable_bindings/scope.md
@@ -4,7 +4,7 @@ Variable bindings have a scope, and are constrained to live in a *block*. A
 block is a collection of statements enclosed by braces `{}`. Also, [variable
 shadowing][variable-shadow] is allowed.
 
-```rust,editable,ignore,mdbook-runnable
+```rust,editable
 fn main() {
     // This binding lives in the main function
     let long_lived_binding = 1;
@@ -28,10 +28,10 @@ fn main() {
     // FIXME ^ Comment out this line
 
     println!("outer long: {}", long_lived_binding);
-    
+
     // This binding also *shadows* the previous binding
     let long_lived_binding = 'a';
-    
+
     println!("outer long: {}", long_lived_binding);
 }
 ```


### PR DESCRIPTION
Currently there is a mix of syntaxes for Rust code blocks. This leads to some minor stylistic inconsistencies and play buttons on some non-runnable code.

All Rust code blocks now conform to one of two labels invocation syntaxes

**Editable:**
```
```rust,editable
```

**Non-Editable**
```
```rust,ignore
```

In cases where neither `editable` or `ignore` were specified, I've based the addition on if the code is runnable and produces an output.

🦄