### PR TITLE
Replaced wrong 'reduce by two' with 'half the number'

### DIFF
--- a/src/flow_control/if_else.md
+++ b/src/flow_control/if_else.md
@@ -24,7 +24,7 @@ fn main() {
             // This expression returns an `i32`.
             10 * n
         } else {
-            println!(", and is a big number, reduce by two");
+            println!(", and is a big number, half the number");
 
             // This expression must return an `i32` as well.
             n / 2


### PR DESCRIPTION
Minor change

In the case of a large number, the expression resolves to `n / 2`, which is half of n. 

Although this is the value the expression resolves to, `println !` logs `reduce by two`, which is
incorrect.