### PR TITLE
Cargo update

### DIFF
--- a/src/cargo/deps.md
+++ b/src/cargo/deps.md
@@ -9,10 +9,10 @@ To create a new Rust project,
 
 ```sh
 # A binary
-cargo new --bin foo
+cargo new foo
 
 # OR A library
-cargo new foo
+cargo new --lib foo
 ```
 
 For the rest of this chapter, I will assume we are making a binary, rather than


### PR DESCRIPTION
In Rust 1.25 `cargo new` will now default to generating a binary, rather than a library