### PR TITLE
Improve wording around the compiler vs borrow checker

### DIFF
--- a/src/scope/lifetime.md
+++ b/src/scope/lifetime.md
@@ -1,16 +1,16 @@
 # Lifetimes
 
-A *lifetime* is a construct the compiler (also called the borrow checker)
-uses to ensure all borrows are valid. Specifically, a variable's lifetime 
-begins when it is created and ends when it is destroyed. While lifetimes 
-and scopes are often referred to together, they are not the same. 
+A *lifetime* is a construct the compiler (or more specifically, its *borrow
+checker*) uses to ensure all borrows are valid. Specifically, a variable's
+lifetime begins when it is created and ends when it is destroyed. While
+lifetimes and scopes are often referred to together, they are not the same.
 
-Take, for example, the case where we borrow a variable via `&`. The 
-borrow has a lifetime that is determined by where it is declared. As a result, 
-the borrow is valid as long as it ends before the lender is destroyed. However, 
+Take, for example, the case where we borrow a variable via `&`. The
+borrow has a lifetime that is determined by where it is declared. As a result,
+the borrow is valid as long as it ends before the lender is destroyed. However,
 the scope of the borrow is determined by where the reference is used.
 
-In the following example and in the rest of this section, we will see how 
+In the following example and in the rest of this section, we will see how
 lifetimes relate to scopes, as well as how the two differ.
 
 ```rust,editable


### PR DESCRIPTION
Previously it made it seem as if the borrow checker was *the* compiler itself, which while not entirely wrong, isn't as accurate as it could be. The new wording emphasises that the borrow checker is one part of the compiler.