### PR TITLE
Redirect to the desired path from the old site

### DIFF
--- a/404.html
+++ b/404.html
@@ -6,7 +6,7 @@
   <title>Rust By Example Has Moved</title>
   <script type="text/javascript">
     window.addEventListener('load', function () {
-      document.location.replace('/index.html');
+      document.location.replace('https://doc.rust-lang.org/stable/rust-by-example' + document.location.pathname);
     })
   </script>
 </head>


### PR DESCRIPTION
Whatever path the user tries to access on rustbyexample.com, pass it through when redirecting to the rust-by-example/ pages on doc.rust-lang.org.