### PR TITLE
Add missing i128, u128 primitive types

### DIFF
--- a/src/primitives.md
+++ b/src/primitives.md
@@ -5,8 +5,9 @@ Rust provides access to a wide variety of `primitives`. A sample includes:
 
 ### Scalar Types
 
-* signed integers: `i8`, `i16`, `i32`, `i64` and `isize` (pointer size)
-* unsigned integers: `u8`, `u16`, `u32`, `u64` and `usize` (pointer size)
+* signed integers: `i8`, `i16`, `i32`, `i64`, `i128` and `isize` (pointer size)
+* unsigned integers: `u8`, `u16`, `u32`, `u64`, `u128` and `usize` (pointer
+  size)
 * floating point: `f32`, `f64`
 * `char` Unicode scalar values like `'a'`, `'α'` and `'∞'` (4 bytes each)
 * `bool` either `true` or `false`


### PR DESCRIPTION
Adds into `Primitives` chapter missing `i128` and `u128` integer primitive types, which were added in latest Rust releases.