### PR TITLE
Fix incorrect compiling error of reborrowing in Functions.Closures.Capturing chapter

### DIFF
--- a/src/fn/closures/capture.md
+++ b/src/fn/closures/capture.md
@@ -47,7 +47,7 @@ fn main() {
     inc();
     inc();
 
-    //let reborrow = &mut count;
+    //let _reborrow = &mut count;
     // ^ TODO: try uncommenting this line.
     
     // A non-copy type.


### PR DESCRIPTION
With `let reborrow` compiler complains first about unused variable, which is not intended and may disorient people:
```
warning: unused variable: `reborrow`
  --> src/main.rs:35:9
   |
35 |     let reborrow = &mut count;
   |         ^^^^^^^^ help: consider using `_reborrow` instead
   |
   = note: #[warn(unused_variables)] on by default
```

`let _reborrow` instead allows to display the only desired error about borrowing:
```
   Compiling playground v0.0.1 (file:///playground)
error[E0499]: cannot borrow `count` as mutable more than once at a time
  --> src/main.rs:35:26
   |
26 |     let mut inc = || {
   |                   -- first mutable borrow occurs here
27 |         count += 1;
   |         ----- previous borrow occurs due to use of `count` in closure
...
35 |     let _reborrow = &mut count;
   |                          ^^^^^ second mutable borrow occurs here
...
54 | }
   | - first borrow ends here
```