### PR TITLE
Clarify the result of running the sample code for the wait section

### DIFF
--- a/src/std_misc/process/wait.md
+++ b/src/std_misc/process/wait.md
@@ -16,7 +16,6 @@ fn main() {
 
 ```bash
 $ rustc wait.rs && ./wait
+# `wait` keeps running for 5 seconds until the `sleep 5` command finishes
 reached end of main
-# `wait` keeps running for 5 seconds
-# `sleep 5` command ends, and then our `wait` program finishes
 ```


### PR DESCRIPTION
This changes the order of the sleep comment and print output to make it
match the correct order that those events happen in.

Fixes #1088.