### PR TITLE
Fix a typo in the "Filesystem Operations" section

### DIFF
--- a/src/std_misc/fs.md
+++ b/src/std_misc/fs.md
@@ -1,7 +1,6 @@
 # Filesystem Operations
 
-The `std::io::fs` module contains several functions that deal with the
-filesystem.
+The `std::fs` module contains several functions that deal with the filesystem.
 
 ```rust,ignore
 use std::fs;


### PR DESCRIPTION
There is no `std::io::fs` module.