### PR TITLE
Fix a race condition in the channels example.

### DIFF
--- a/src/std_misc/channels.md
+++ b/src/std_misc/channels.md
@@ -43,13 +43,13 @@ fn main() {
         // `recv` will block the current thread if there are no messages available
         ids.push(rx.recv());
     }
-
-    // Show the order in which the messages were sent
-    println!("{:?}", ids);
-
+    
     // Wait for the threads to complete any remaining work
     for child in children {
         child.join().expect("oops! the child thread panicked");
     }
+
+    // Show the order in which the messages were sent
+    println!("{:?}", ids);
 }
 ```

--- a/src/std_misc/channels.md
+++ b/src/std_misc/channels.md
@@ -49,7 +49,7 @@ fn main() {
 
     // Wait for the threads to complete any remaining work
     for child in children {
-      child.join().expect("oops! the child thread panicked");
+        child.join().expect("oops! the child thread panicked");
     }
 }
 ```


### PR DESCRIPTION
Sometimes, `main()` completes before all the threads have
finished, so let's explicitly wait for them using `join()`

Closes #1099 

<img src="https://user-images.githubusercontent.com/590450/44233623-3cdbd000-a159-11e8-9117-7d643cfafc41.gif" width="400">