### PR TITLE
Make code editable

### DIFF
--- a/src/trait/derive.md
+++ b/src/trait/derive.md
@@ -13,7 +13,7 @@ The following is a list of derivable traits:
 * [`Default`][default], to create an empty instance of a data type.
 * [`Debug`][debug], to format a value using the `{:?}` formatter.
  
-```rust,example
+```rust,editable
 // `Centimeters`, a tuple struct that can be compared
 #[derive(PartialEq, PartialOrd)]
 struct Centimeters(f64);


### PR DESCRIPTION
Makes the code in chapter 16.1 editable. Seems to be an error that is is set as `example` rather than `editable` as the code contains comments prompting a user to try editing the code.