### PR TITLE
Fixes #1115 by correcting the typo from into_iterator to into_iter

### DIFF
--- a/src/trait/iter.md
+++ b/src/trait/iter.md
@@ -7,7 +7,7 @@ which may be manually defined in an `impl` block or automatically
 defined (as in arrays and ranges).
 
 As a point of convenience for common situations, the `for` construct 
-turns some collections into iterators using the [`.into_iterator()`][intoiter] method.
+turns some collections into iterators using the [`.into_iter()`][intoiter] method.
 
 ```rust,editable
 struct Fibonacci {


### PR DESCRIPTION
Like the title says, This fixes issue 1115 by correcting a typo. Ironically enough, I typoed the issue number in the commit message.