### PR TITLE
Fixed curly braces in the `To and from Strings` chapter to be parentheses

### DIFF
--- a/src/conversion/string.md
+++ b/src/conversion/string.md
@@ -42,7 +42,7 @@ fn main() {
     let turbo_parsed = "10".parse::<i32>().unwrap();
 
     let sum = parsed + turbo_parsed;
-    println!{"Sum: {:?}", sum};
+    println!("Sum: {:?}", sum);
 }
 ```
 


### PR DESCRIPTION
This tripped me up when I was reading it. It makes sense now that curly braces work since `println` is a macro but I thought the random switch to curly braces might trip up other people as well.