### PR TITLE
Added two missing backticks in generics/multi_bounds

### DIFF
--- a/src/generics/multi_bounds.md
+++ b/src/generics/multi_bounds.md
@@ -12,8 +12,8 @@ fn compare_prints<T: Debug + Display>(t: &T) {
 }
 
 fn compare_types<T: Debug, U: Debug>(t: &T, u: &U) {
-    println!("t: `{:?}", t);
-    println!("u: `{:?}", u);
+    println!("t: `{:?}`", t);
+    println!("u: `{:?}`", u);
 }
 
 fn main() {


### PR DESCRIPTION
Just small fix, adding two missing backticks in
generics/multi_bounds

Signed-off-by: Bart Smykla <bsmykla@vmware.com>