### PR TITLE
Changed word `function` to `type` in comment of fn area

### DIFF
--- a/src/generics/bounds.md
+++ b/src/generics/bounds.md
@@ -49,7 +49,7 @@ fn print_debug<T: Debug>(t: &T) {
     println!("{:?}", t);
 }
 
-// `T` must implement `HasArea`. Any function which meets
+// `T` must implement `HasArea`. Any type which meets
 // the bound can access `HasArea`'s function `area`.
 fn area<T: HasArea>(t: &T) -> f64 { t.area() }
 


### PR DESCRIPTION
Closes #1130

Function area is taking generic type instead of function,
so word `type` is correct in that scenario as suggested by
@steveklabnik in issue #1130

Signed-off-by: Bart Smykla <bsmykla@vmware.com>