### PR TITLE
shows destructing struct within pattern matching statement

### DIFF
--- a/src/flow_control/match/destructuring/destructure_structures.md
+++ b/src/flow_control/match/destructuring/destructure_structures.md
@@ -8,22 +8,12 @@ fn main() {
 
     // destructure members of the struct
     let foo = Foo { x: (1, 2), y: 3 };
-    let Foo { x: (a, b), y } = foo;
 
-    println!("a = {}, b = {},  y = {} ", a, b, y);
-
-    // you can destructure structs and rename the variables,
-    // the order is not important
-
-    let Foo { y: i, x: j } = foo;
-    println!("i = {:?}, j = {:?}", i, j);
-
-    // and you can also ignore some variables:
-    let Foo { y, .. } = foo;
-    println!("y = {}", y);
-
-    // this will give an error: pattern does not mention field `x`
-    // let Foo { y } = foo;
+    #[allow(unreachable_patterns)]
+    match foo{
+        Foo{x:first,y:second} => println!("The first field is {:?} and the second is {}",first,second),
+        _ => println!("impossible")
+    }
 }
 ```
 


### PR DESCRIPTION
previous example shows how to  destruct **struct** but it's somewhat irrelevant to this section