### PR TITLE
Update syntax for 2018 Edition

### DIFF
--- a/src/custom_types/enum/enum_use.md
+++ b/src/custom_types/enum/enum_use.md
@@ -19,9 +19,9 @@ enum Work {
 fn main() {
     // Explicitly `use` each name so they are available without
     // manual scoping.
-    use Status::{Poor, Rich};
+    use crate::Status::{Poor, Rich};
     // Automatically `use` each name inside `Work`.
-    use Work::*;
+    use crate::Work::*;
 
     // Equivalent to `Status::Poor`.
     let status = Poor;

--- a/src/custom_types/enum/testcase_linked_list.md
+++ b/src/custom_types/enum/testcase_linked_list.md
@@ -3,7 +3,7 @@
 A common use for `enums` is to create a linked-list:
 
 ```rust,editable
-crate::use List::*;
+use crate::List::*;
 
 enum List {
     // Cons: Tuple struct that wraps an element and a pointer to the next node

--- a/src/custom_types/enum/testcase_linked_list.md
+++ b/src/custom_types/enum/testcase_linked_list.md
@@ -3,7 +3,7 @@
 A common use for `enums` is to create a linked-list:
 
 ```rust,editable
-use List::*;
+crate::use List::*;
 
 enum List {
     // Cons: Tuple struct that wraps an element and a pointer to the next node

--- a/src/mod/super.md
+++ b/src/mod/super.md
@@ -44,7 +44,7 @@ mod my {
         // This will bind to the `cool::function` in the *crate* scope.
         // In this case the crate scope is the outermost scope.
         {
-            use cool::function as root_function;
+            use crate::cool::function as root_function;
             root_function();
         }
     }

--- a/src/mod/use.md
+++ b/src/mod/use.md
@@ -6,7 +6,7 @@ access. It is often used like this:
 ```rust,editable,ignore
 // extern crate deeply; // normally, this would exist and not be commented out!
 
-use deeply::nested::{
+use crate::deeply::nested::{
     my_first_function,
     my_second_function,
     AndATraitType
@@ -43,7 +43,7 @@ fn main() {
     {
         // This is equivalent to `use deeply::nested::function as function`.
         // This `function()` will shadow the outer one.
-        use deeply::nested::function;
+        use crate::deeply::nested::function;
         function();
 
         // `use` bindings have a local scope. In this case, the

--- a/src/mod/visibility.md
+++ b/src/mod/visibility.md
@@ -37,7 +37,7 @@ mod my_mod {
 
         // Functions declared using `pub(in path)` syntax are only visible
         // within the given path. `path` must be a parent or ancestor module
-        pub(in my_mod) fn public_function_in_my_mod() {
+        pub(in crate::my_mod) fn public_function_in_my_mod() {
             print!("called `my_mod::nested::public_function_in_my_mod()`, that\n > ");
             public_function_in_nested()
         }


### PR DESCRIPTION
Under the 2018 Edition, the `crate::` namespace is required when `use` is employed to reference a structure created in the current module. Without `crate::` this example will not compile under the 2018 Edition; with this change, the example complies again.

This PR fixes issue #1134.