### PR TITLE
Added two missing full stops

### DIFF
--- a/src/trait/derive.md
+++ b/src/trait/derive.md
@@ -6,9 +6,9 @@ manually implemented if a more complex behavior is required.
 
 The following is a list of derivable traits:
 * Comparison traits:
-  [`Eq`][eq], [`PartialEq`][partial-eq], [`Ord`][ord], [`PartialOrd`][partial-ord]
+  [`Eq`][eq], [`PartialEq`][partial-eq], [`Ord`][ord], [`PartialOrd`][partial-ord].
 * [`Clone`][clone], to create `T` from `&T` via a copy.
-* [`Copy`][copy], to give a type 'copy semantics' instead of 'move semantics'
+* [`Copy`][copy], to give a type 'copy semantics' instead of 'move semantics'.
 * [`Hash`][hash], to compute a hash from `&T`.
 * [`Default`][default], to create an empty instance of a data type.
 * [`Debug`][debug], to format a value using the `{:?}` formatter.


### PR DESCRIPTION
In listing of derivable traits, two of the list items
didn't have full stop at the end, like the other items.

Signed-off-by: Bart Smykla <bsmykla@vmware.com>