### PR TITLE
Removed unnecessary spaces before macro designators in macros/dry

### DIFF
--- a/src/macros/dry.md
+++ b/src/macros/dry.md
@@ -10,7 +10,7 @@ use std::ops::{Add, Mul, Sub};
 macro_rules! assert_equal_len {
     // The `tt` (token tree) designator is used for
     // operators and tokens.
-    ($a:ident, $b: ident, $func:ident, $op:tt) => (
+    ($a:ident, $b:ident, $func:ident, $op:tt) => (
         assert!($a.len() == $b.len(),
                 "{:?}: dimension mismatch: {:?} {:?} {:?}",
                 stringify!($func),
@@ -41,7 +41,7 @@ op!(sub_assign, Sub, -=, sub);
 mod test {
     use std::iter;
     macro_rules! test {
-        ($func: ident, $x:expr, $y:expr, $z:expr) => {
+        ($func:ident, $x:expr, $y:expr, $z:expr) => {
             #[test]
             fn $func() {
                 for size in 0usize..10 {


### PR DESCRIPTION
In other places there is no space before designators so I removed
unnecessary spaces in two places to make it more consistent.

Signed-off-by: Bart Smykla <bsmykla@vmware.com>