### PR TITLE
Update new_types.md to clarify conversion to base type

### DIFF
--- a/src/generics/new_types.md
+++ b/src/generics/new_types.md
@@ -40,6 +40,16 @@ fn main() {
 
 Uncomment the last print statement to observe that the type supplied must be `Years`.
 
+To obtain the `newtype`'s value as the base type, you may use tuple syntax like so:
+```rust, editable
+struct Years(i64);
+
+fn main() {
+    let years = Years(42);
+    let years_as_primitive: i64 = years.0;
+}
+```
+
 ### See also:
 
 [`structs`][struct]


### PR DESCRIPTION
As someone new to the language, I struggled for a little while trying to figure out how to make use of the `newtype` idiom. I needed to convert my custom type back to the base type, and the documentation did not make it obvious. 

I tried using `as`, I tried using `From`, and neither worked. 

I wasn't aware of the differences/similarities between structs, struct tuples, and tuples, and I think this deserves more documentation as well. 