### PR TITLE
Do not use deprecated functions from `std::error::Error` trait

### DIFF
--- a/src/error/multiple_error_types/define_error_type.md
+++ b/src/error/multiple_error_types/define_error_type.md
@@ -40,11 +40,7 @@ impl fmt::Display for DoubleError {
 
 // This is important for other errors to wrap this one.
 impl error::Error for DoubleError {
-    fn description(&self) -> &str {
-        "invalid first item to double"
-    }
-
-    fn cause(&self) -> Option<&error::Error> {
+    fn source(&self) -> Option<&(dyn error::Error + 'static)> {
         // Generic error, underlying cause isn't tracked.
         None
     }

--- a/src/error/multiple_error_types/wrap_error.md
+++ b/src/error/multiple_error_types/wrap_error.md
@@ -29,7 +29,7 @@ impl fmt::Display for DoubleError {
 }
 
 impl error::Error for DoubleError {
-    fn cause(&self) -> Option<&error::Error> {
+    fn source(&self) -> Option<&(dyn error::Error + 'static)> {
         match *self {
             DoubleError::EmptyVec => None,
             // The cause is the underlying implementation error type. Is implicitly

--- a/src/error/multiple_error_types/wrap_error.md
+++ b/src/error/multiple_error_types/wrap_error.md
@@ -29,14 +29,6 @@ impl fmt::Display for DoubleError {
 }
 
 impl error::Error for DoubleError {
-    fn description(&self) -> &str {
-        match *self {
-            DoubleError::EmptyVec => "empty vectors not allowed",
-            // This already impls `Error`, so defer to its own implementation.
-            DoubleError::Parse(ref e) => e.description(),
-        }
-    }
-
     fn cause(&self) -> Option<&error::Error> {
         match *self {
             DoubleError::EmptyVec => None,


### PR DESCRIPTION
According to https://doc.rust-lang.org/std/error/trait.Error.html, `fn description` is deprecated in favor of `Display` trait and `fn cause` will be deprecated starting from 1.33 in favor of `fn source` (which is already available on stable from 1.30).

I updated the examples accordingly.