### PR TITLE
Add "literal" to list of macro designators

### DIFF
--- a/src/macros/designators.md
+++ b/src/macros/designators.md
@@ -54,6 +54,7 @@ This is a list of all the designators:
 * `expr` is used for expressions
 * `ident` is used for variable/function names
 * `item`
+* `literal` is used for literal constants
 * `pat` (*pattern*)
 * `path`
 * `stmt` (*statement*)


### PR DESCRIPTION
[`macro_literal_matcher`](https://github.com/rust-lang/rfcs/blob/master/text/1576-macros-literal-matcher.md) is stable, and is in Rust 1.32, but isn't currently documented in Rust By Example.