### PR TITLE
Add link to Cargo chapter in the index page

### DIFF
--- a/src/index.md
+++ b/src/index.md
@@ -33,6 +33,8 @@ Now let's begin!
 
 - [Crates](crates.html) - A crate is a compilation unit in Rust. Learn to create a library.
 
+- [Cargo](cargo.html) - Go through some basic features of the official Rust package management tool.
+
 - [Attributes](attribute.html) - An attribute is metadata applied to some module, crate or item.
 
 - [Generics](generics.html) - Learn about writing a function or data type which can work for multiple types of arguments.


### PR DESCRIPTION
Fixes #1158

The change simply updates the Introduction/Homepage/index page to add a link to the Cargo chapter (between Crates and Attributes in the list) along with a basic description.

Please advise if you have a better description that I should use for Cargo so I can update the PR.
