### PR TITLE
Replace lvalue and rvalue with place and value

### DIFF
--- a/src/expression.md
+++ b/src/expression.md
@@ -25,9 +25,9 @@ fn main() {
 }
 ```
 
-Blocks are expressions too, so they can be used as [r-values][rvalue] in
+Blocks are expressions too, so they can be used as values in
 assignments. The last expression in the block will be assigned to the
-[l-value][lvalue]. However, if the last expression of the block ends with a
+place expression such as a local variable. However, if the last expression of the block ends with a
 semicolon, the return value will be `()`.
 
 ```rust,editable
@@ -52,6 +52,3 @@ fn main() {
     println!("z is {:?}", z);
 }
 ```
-
-[rvalue]: https://en.wikipedia.org/wiki/Value_%28computer_science%29#lrvalue
-[lvalue]: https://en.wikipedia.org/wiki/Value_%28computer_science%29#lrvalue

--- a/src/types/inference.md
+++ b/src/types/inference.md
@@ -1,8 +1,7 @@
 # Inference
 
 The type inference engine is pretty smart. It does more than looking at the
-type of the
-[r-value][rvalue]
+type of the value expression
 during an initialization. It also looks at how the variable is used afterwards 
 to infer its type. Here's an advanced example of type inference:
 
@@ -27,5 +26,3 @@ fn main() {
 
 No type annotation of variables was needed, the compiler is happy and so is the
 programmer!
-
-[rvalue]: https://en.wikipedia.org/wiki/Value_%28computer_science%29#lrvalue


### PR DESCRIPTION
Fixes #988

I didn't perform a simple find and replace. For rvalue, in one instance I simply replaced it with _"value"_, but in another, I used the phrase _"value expression"_. For lvalue, I replaced it with _"place expression such as a local variable"_ to make it easier to understand in the given context.

I'm open to suggestions to improve the changes.
