### PR TITLE
Fix for loop description in list print example

### DIFF
--- a/src/hello/print/print_display/testcase_list.md
+++ b/src/hello/print/print_display/testcase_list.md
@@ -38,7 +38,7 @@ impl fmt::Display for List {
 
         write!(f, "[")?;
 
-        // Iterate over `vec` in `v` while enumerating the iteration
+        // Iterate over `v` in `vec` while enumerating the iteration
         // count in `count`.
         for (count, v) in vec.iter().enumerate() {
             // For every element except the first, add a comma.


### PR DESCRIPTION
This comment confused me since the loop is defined as `for v in vec`. I'm new to Rust though, so please feel free to let me know if I am mistaken!