### PR TITLE
Fix a typo ("half" -> "halve")

### DIFF
--- a/src/flow_control/if_else.md
+++ b/src/flow_control/if_else.md
@@ -24,7 +24,7 @@ fn main() {
             // This expression returns an `i32`.
             10 * n
         } else {
-            println!(", and is a big number, half the number");
+            println!(", and is a big number, halve the number");
 
             // This expression must return an `i32` as well.
             n / 2


### PR DESCRIPTION
Half mistakenly used as a verb; should be halve.