### PR TITLE
Small improvements to various files

### DIFF
--- a/src/crates/lib.md
+++ b/src/crates/lib.md
@@ -2,7 +2,7 @@
 
 Let's create a library, and then see how to link it to another crate.
 
-```rust,editable
+```rust,ignore
 pub fn public_function() {
     println!("called rary's `public_function()`");
 }

--- a/src/custom_types/enum.md
+++ b/src/custom_types/enum.md
@@ -5,9 +5,6 @@ different variants. Any variant which is valid as a `struct` is also valid as
 an `enum`.
 
 ```rust,editable
-// An attribute to hide warnings for unused code.
-#![allow(dead_code)]
-
 // Create an `enum` to classify a web event. Note how both
 // names and type information together specify the variant:
 // `PageLoad != PageUnload` and `KeyPress(char) != Paste(String)`.
@@ -58,9 +55,8 @@ fn main() {
 
 ### See also:
 
-[`attributes`][attributes], [`match`][match], [`fn`][fn], and [`String`][str]
+[`match`][match], [`fn`][fn], and [`String`][str]
 
-[attributes]: attribute.html
 [c_struct]: https://en.wikipedia.org/wiki/Struct_(C_programming_language)
 [match]: flow_control/match.html
 [fn]: fn.html

--- a/src/flow_control/match/destructuring/destructure_structures.md
+++ b/src/flow_control/match/destructuring/destructure_structures.md
@@ -13,14 +13,14 @@ fn main() {
     let foo = Foo { x: (1, 2), y: 3 };
 
     match foo {
-        Foo { x: (1, b), y } => println!("a = 1, b = {},  y = {} ", b, y),
+        Foo { x: (1, b), y } => println!("First of x is 1, b = {},  y = {} ", b, y),
 
         // you can destructure structs and rename the variables,
         // the order is not important
-        Foo { y: 2, x: i } => println!("i = {:?}, j = 2", i),
+        Foo { y: 2, x: i } => println!("y is 2, i = {:?}", i),
 
         // and you can also ignore some variables:
-        Foo { y, .. } => println!("y = {}", y),
+        Foo { y, .. } => println!("y = {}, we don't care about x", y),
         // this will give an error: pattern does not mention field `x`
         //Foo { y } => println!("y = {}", y);
     }

--- a/src/flow_control/match/destructuring/destructure_structures.md
+++ b/src/flow_control/match/destructuring/destructure_structures.md
@@ -4,26 +4,26 @@ Similarly, a `struct` can be destructured as shown:
 
 ```rust,editable
 fn main() {
-    struct Foo { x: (u32, u32), y: u32 }
+    struct Foo {
+        x: (u32, u32),
+        y: u32,
+    }
 
-    // destructure members of the struct
+    // Try changing the values in the struct to see what happens
     let foo = Foo { x: (1, 2), y: 3 };
-    let Foo { x: (a, b), y } = foo;
 
-    println!("a = {}, b = {},  y = {} ", a, b, y);
+    match foo {
+        Foo { x: (1, b), y } => println!("a = 1, b = {},  y = {} ", b, y),
 
-    // you can destructure structs and rename the variables,
-    // the order is not important
+        // you can destructure structs and rename the variables,
+        // the order is not important
+        Foo { y: 2, x: i } => println!("i = {:?}, j = 2", i),
 
-    let Foo { y: i, x: j } = foo;
-    println!("i = {:?}, j = {:?}", i, j);
-
-    // and you can also ignore some variables:
-    let Foo { y, .. } = foo;
-    println!("y = {}", y);
-
-    // this will give an error: pattern does not mention field `x`
-    // let Foo { y } = foo;
+        // and you can also ignore some variables:
+        Foo { y, .. } => println!("y = {}", y),
+        // this will give an error: pattern does not mention field `x`
+        //Foo { y } => println!("y = {}", y);
+    }
 }
 ```
 

--- a/src/meta/doc.md
+++ b/src/meta/doc.md
@@ -4,7 +4,7 @@ Doc comments are very useful for big projects that require documentation. When
 running [Rustdoc][1], these are the comments that get compiled into
 documentation. They are denoted by a `///`, and support [Markdown][2].
 
-```rust,editable,ignore,mdbook-runnable
+```rust,editable,ignore
 #![crate_name = "doc"]
 
 /// A human being is represented here


### PR DESCRIPTION
Various small fixes to:
11.1: This code will not run as there is no main function, so removed the ability to run it
24.1: This code will not run due to the crate_name being set to something other than playground. Could be changed in a different way, but running the code is not the purpose of this code example so I removed the ability to run it. This could be changed in a different way, open to discussion if this isn't the best.

3.2: Removed an unneeded attribute of allow(dead_code) as there isn't any dead code

8.5.1.4: Changed example to actually use match as all the other destructuring examples do. This is the biggest change so can be moved into its own pull request, but didn't want to split these issues so finely as they are all quite small.

Can split all of these into separate pull requests but wasn't sure if spamming the pull requests would be best.
Alex