### PR TITLE
19.2 Vectors Error in Code Example

### DIFF
--- a/src/std/vec.md
+++ b/src/std/vec.md
@@ -10,7 +10,7 @@ be surpassed, the vector is reallocated with a larger capacity.
 ```rust,editable,ignore,mdbook-runnable
 fn main() {
     // Iterators can be collected into vectors
-    let collected_iterator: Vec<i32> = (0..10).collect();
+    let mut collected_iterator: Vec<i32> = (0..10).collect();
     println!("Collected (0..10) into: {:?}", collected_iterator);
 
     // The `vec!` macro can be used to initialize a vector


### PR DESCRIPTION
https://doc.rust-lang.org/1.29.2/rust-by-example/std/vec.html

Code contain an error in the following places:

Line number 3: let collected_iterator: Vec = (0..10).collect();
Should be: let mut collected_iterator: Vec = (0..10).collect();
Or else Line number16 can't borrow mutably