### PR TITLE
Reword "Flow Control" to "Flow of Control"

### DIFF
--- a/src/SUMMARY.md
+++ b/src/SUMMARY.md
@@ -40,7 +40,7 @@
 
 - [Expressions](expression.md)
 
-- [Flow Control](flow_control.md)
+- [Flow of Control](flow_control.md)
     - [if/else](flow_control/if_else.md)
     - [loop](flow_control/loop.md)
         - [Nesting and labels](flow_control/loop/nested.md)

--- a/src/flow_control.md
+++ b/src/flow_control.md
@@ -1,4 +1,4 @@
-# Flow Control
+# Flow of Control
 
 An essential part of any programming languages are ways to modify control flow:
 `if`/`else`, `for`, and others. Let's talk about them in Rust.

--- a/src/index.md
+++ b/src/index.md
@@ -25,7 +25,7 @@ Now let's begin!
 
 - [Expressions](expression.html)
 
-- [Flow Control](flow_control.html) - `if`/`else`, `for`, and others.
+- [Flow of Control](flow_control.html) - `if`/`else`, `for`, and others.
 
 - [Functions](fn.html) - Learn about Methods, Closures and High Order Functions.
 


### PR DESCRIPTION
It's a bit of a nit, but flow control generally refers to something different. The way it's being used here, it's usually worded as flow *of* control or control flow.

References:
https://en.wikipedia.org/wiki/Flow_control
https://en.wikipedia.org/wiki/Control_flow