### PR TITLE
Fixed wording in the `Seconds` struct description.

### DIFF
--- a/src/generics/assoc_items/types.md
+++ b/src/generics/assoc_items/types.md
@@ -41,7 +41,7 @@ trait Contains {
     type A;
     type B;
 
-    fn contains(&self, &Self::A, &Self::B) -> bool;
+    fn contains(&self, _: &Self::A, _: &Self::B) -> bool;
     fn first(&self) -> i32;
     fn last(&self) -> i32;
 }

--- a/src/trait/derive.md
+++ b/src/trait/derive.md
@@ -30,7 +30,7 @@ impl Inches {
     }
 }
 
-// `Seconds`, a tuple struct no additional attributes
+// `Seconds`, a tuple struct with no additional attributes
 struct Seconds(i32);
 
 fn main() {


### PR DESCRIPTION
I'm willing to be wrong on this one. The original author's intent could have been:
```rust
// `Seconds`, a tuple struct, no additional attributes
```
or
```rust
// `Seconds`, a tuple struct; no additional attributes
```
or maybe
```rust
// `Seconds`, a tuple struct - no additional attributes
```