### PR TITLE
Upgrade links to match mdbook 0.2

### DIFF
--- a/src/attribute.md
+++ b/src/attribute.md
@@ -33,6 +33,6 @@ Attributes can have multiple values and can be separated over multiple lines, to
             value4, value5)]
 ```
 
-[cfg]: attribute/cfg.html
-[crate]: attribute/crate.html
+[cfg]: attribute/cfg.md
+[crate]: attribute/crate.md
 [lint]: https://en.wikipedia.org/wiki/Lint_%28software%29

--- a/src/attribute/cfg.md
+++ b/src/attribute/cfg.md
@@ -37,5 +37,5 @@ fn main() {
 [the reference][ref], [`cfg!`][cfg], and [macros][macros].
 
 [cfg]: https://doc.rust-lang.org/std/macro.cfg!.html
-[macros]: macros.html
+[macros]: ../macros.md
 [ref]: https://doc.rust-lang.org/reference/attributes.html#conditional-compilation

--- a/src/compatibility.md
+++ b/src/compatibility.md
@@ -4,4 +4,4 @@ The Rust language is fastly evolving, and because of this certain compatibility
 issues can arise, despite efforts to ensure forwards-compatibility wherever
 possible.
 
-* [Raw identifiers](compatibility/raw_identifiers.html)
+* [Raw identifiers](compatibility/raw_identifiers.md)

--- a/src/conversion.md
+++ b/src/conversion.md
@@ -5,6 +5,6 @@ conversions will use the [`From`] and [`Into`] traits. However there are more
 specific ones for the more common cases, in particular when converting to and
 from `String`s.
 
-[traits]: trait.html
+[traits]: trait.md
 [`From`]: https://doc.rust-lang.org/std/convert/trait.From.html
 [`Into`]: https://doc.rust-lang.org/std/convert/trait.Into.html

--- a/src/conversion/string.md
+++ b/src/conversion/string.md
@@ -50,6 +50,6 @@ fn main() {
 
 [`ToString`]: https://doc.rust-lang.org/std/string/trait.ToString.html
 [Display]: https://doc.rust-lang.org/std/fmt/trait.Display.html
-[print]: hello/print.html
+[print]: ../hello/print.md
 [`parse`]: https://doc.rust-lang.org/std/primitive.str.html#method.parse
 [`FromStr`]: https://doc.rust-lang.org/std/str/trait.FromStr.html

--- a/src/crates/lib.md
+++ b/src/crates/lib.md
@@ -28,4 +28,4 @@ Libraries get prefixed with "lib", and by default they get named after their
 crate file, but this default name can be overridden using the [`crate_name`
 attribute][crate-name].
 
-[crate-name]: attribute/crate.html
+[crate-name]: ../attribute/crate.md

--- a/src/custom_types/constants.md
+++ b/src/custom_types/constants.md
@@ -38,5 +38,5 @@ fn main() {
 https://github.com/rust-lang/rfcs/blob/master/text/0246-const-vs-static.md),
 [`'static` lifetime][static]
 
-[static]: scope/lifetime/static_lifetime.html
-[unsafe]: unsafe.html
+[static]: ../scope/lifetime/static_lifetime.md
+[unsafe]: ../unsafe.md

--- a/src/custom_types/enum.md
+++ b/src/custom_types/enum.md
@@ -58,6 +58,6 @@ fn main() {
 [`match`][match], [`fn`][fn], and [`String`][str]
 
 [c_struct]: https://en.wikipedia.org/wiki/Struct_(C_programming_language)
-[match]: flow_control/match.html
-[fn]: fn.html
-[str]: std/str.html
+[match]: ../flow_control/match.md
+[fn]: ../fn.md
+[str]: ../std/str.md

--- a/src/custom_types/enum/c_like.md
+++ b/src/custom_types/enum/c_like.md
@@ -34,4 +34,4 @@ fn main() {
 
 [casting][cast]
 
-[cast]: types/cast.html
+[cast]: ../../types/cast.md

--- a/src/custom_types/enum/enum_use.md
+++ b/src/custom_types/enum/enum_use.md
@@ -46,5 +46,5 @@ fn main() {
 
 [`match`][match] and [`use`][use] 
 
-[use]: mod/use.html
-[match]: flow_control/match.html
+[use]: ../../mod/use.md
+[match]: ../../flow_control/match.md

--- a/src/custom_types/enum/testcase_linked_list.md
+++ b/src/custom_types/enum/testcase_linked_list.md
@@ -75,5 +75,5 @@ fn main() {
 
 [`Box`][box] and [methods][methods]
 
-[box]: std/box.html
-[methods]: fn/methods.html
+[box]: ../../std/box.md
+[methods]: ../../fn/methods.md

--- a/src/custom_types/structs.md
+++ b/src/custom_types/structs.md
@@ -89,6 +89,6 @@ fn main() {
 
 [`attributes`][attributes] and [destructuring][destructuring]
 
-[attributes]: attribute.html
+[attributes]: ../attribute.md
 [c_struct]: https://en.wikipedia.org/wiki/Struct_(C_programming_language)
-[destructuring]: flow_control/match/destructuring.html
+[destructuring]: ../flow_control/match/destructuring.md

--- a/src/error/multiple_error_types/option_result.md
+++ b/src/error/multiple_error_types/option_result.md
@@ -55,4 +55,4 @@ fn main() {
 }
 ```
 
-[enter_question_mark]: error/result/enter_question_mark.html
+[enter_question_mark]: ../result/enter_question_mark.md

--- a/src/error/multiple_error_types/wrap_error.md
+++ b/src/error/multiple_error_types/wrap_error.md
@@ -83,4 +83,4 @@ for you.
 [`From::from`][from] and [`Enums`][enums]
 
 [from]: https://doc.rust-lang.org/std/convert/trait.From.html
-[enums]: custom_types/enum.html
+[enums]: ../../custom_types/enum.md

--- a/src/error/option_unwrap/and_then.md
+++ b/src/error/option_unwrap/and_then.md
@@ -71,6 +71,6 @@ fn main() {
 
 [closures][closures], [`Option`][option], and [`Option::and_then()`][and_then]
 
-[closures]: fn/closures.html
+[closures]: ../../fn/closures.md
 [option]: https://doc.rust-lang.org/std/option/enum.Option.html
 [and_then]: https://doc.rust-lang.org/std/option/enum.Option.html#method.and_then

--- a/src/error/option_unwrap/map.md
+++ b/src/error/option_unwrap/map.md
@@ -81,6 +81,6 @@ fn main() {
 [closures][closures], [`Option`][option], [`Option::map()`][map]
 
 [combinators]: https://doc.rust-lang.org/book/glossary.html#combinators
-[closures]: fn/closures.html
+[closures]: ../../fn/closures.md
 [option]: https://doc.rust-lang.org/std/option/enum.Option.html
 [map]: https://doc.rust-lang.org/std/option/enum.Option.html#method.map

--- a/src/error/result.md
+++ b/src/error/result.md
@@ -80,4 +80,4 @@ fn main() -> Result<(), ParseIntError> {
 [result]: https://doc.rust-lang.org/std/result/enum.Result.html
 [parse]: https://doc.rust-lang.org/std/primitive.str.html#method.parse
 [`Debug`]: https://doc.rust-lang.org/std/fmt/trait.Debug.html
-[the following section]: error/result/early_returns.html
+[the following section]: result/early_returns.md

--- a/src/error/result/enter_question_mark.md
+++ b/src/error/result/enter_question_mark.md
@@ -69,4 +69,4 @@ fn main() {
 
 [^†]: See [re-enter ?][re_enter_?] for more details.
 
-[re_enter_?]: error/multiple_error_types/reenter_question_mark.html
+[re_enter_?]: ../multiple_error_types/reenter_question_mark.md

--- a/src/error/result/result_alias.md
+++ b/src/error/result/result_alias.md
@@ -42,5 +42,5 @@ fn main() {
 
 [`io::Result`][io_result]
 
-[typealias]: types/alias.html
+[typealias]: ../../types/alias.md
 [io_result]: https://doc.rust-lang.org/std/io/type.Result.html

--- a/src/flow_control/for.md
+++ b/src/flow_control/for.md
@@ -117,4 +117,4 @@ implies differing actions that are able to be performed.
 
 [Iterator][iter]
 
-[iter]: trait/iter.html
+[iter]: ../trait/iter.md

--- a/src/flow_control/if_let.md
+++ b/src/flow_control/if_let.md
@@ -118,6 +118,6 @@ fn main() {
 
 [`enum`][enum], [`Option`][option], and the [RFC][if_let_rfc]
 
-[enum]: custom_types/enum.html
+[enum]: ../custom_types/enum.md
 [if_let_rfc]: https://github.com/rust-lang/rfcs/pull/160
-[option]: std/option.html
+[option]: ../std/option.md

--- a/src/flow_control/match/binding.md
+++ b/src/flow_control/match/binding.md
@@ -29,4 +29,4 @@ fn main() {
 ### See also:
 [functions]
 
-[functions]: fn.html
+[functions]: ../../fn.md

--- a/src/flow_control/match/destructuring.md
+++ b/src/flow_control/match/destructuring.md
@@ -8,7 +8,7 @@ A `match` block can destructure items in a variety of ways.
 * [Destructuring Tuples][tuple]
 
 
-[enum]: flow_control/match/destructuring/destructure_enum.html
-[refs]: flow_control/match/destructuring/destructure_pointers.html
-[struct]: flow_control/match/destructuring/destructure_structures.html
-[tuple]: flow_control/match/destructuring/destructure_tuple.html
+[enum]: destructuring/destructure_enum.md
+[refs]: destructuring/destructure_pointers.md
+[struct]: destructuring/destructure_structures.md
+[tuple]: destructuring/destructure_tuple.md

--- a/src/flow_control/match/destructuring/destructure_enum.md
+++ b/src/flow_control/match/destructuring/destructure_enum.md
@@ -49,6 +49,6 @@ fn main() {
 
 [`#[allow(...)]`][allow], [color models][color_models] and [`enum`][enum]
 
-[allow]: attribute/unused.html
+[allow]: ../../../attribute/unused.md
 [color_models]: https://en.wikipedia.org/wiki/Color_model
-[enum]: custom_types/enum.html
+[enum]: ../../../custom_types/enum.md

--- a/src/flow_control/match/destructuring/destructure_structures.md
+++ b/src/flow_control/match/destructuring/destructure_structures.md
@@ -29,4 +29,4 @@ fn main() {
 
 ### See also:
 
-[Structs](custom_types/structs.html), [The ref pattern](scope/borrow/ref.html)
+[Structs](../../../custom_types/structs.md), [The ref pattern](../../../scope/borrow/ref.md)

--- a/src/flow_control/match/destructuring/destructure_tuple.md
+++ b/src/flow_control/match/destructuring/destructure_tuple.md
@@ -21,4 +21,4 @@ fn main() {
 
 ### See also:
 
-[Tuples](primitives/tuples.html)
+[Tuples](../../../primitives/tuples.md)

--- a/src/flow_control/match/guard.md
+++ b/src/flow_control/match/guard.md
@@ -20,4 +20,4 @@ fn main() {
 
 ### See also:
 
-[Tuples](primitives/tuples.html)
+[Tuples](../../primitives/tuples.md)

--- a/src/flow_control/while_let.md
+++ b/src/flow_control/while_let.md
@@ -57,6 +57,6 @@ fn main() {
 
 [`enum`][enum], [`Option`][option], and the [RFC][while_let_rfc]
 
-[enum]: custom_types/enum.html
-[option]: std/option.html
+[enum]: ../custom_types/enum.md
+[option]: ../std/option.md
 [while_let_rfc]: https://github.com/rust-lang/rfcs/pull/214

--- a/src/fn/closures/anonymity.md
+++ b/src/fn/closures/anonymity.md
@@ -49,7 +49,7 @@ fn main() {
 [A thorough analysis][thorough_analysis], [`Fn`][fn], [`FnMut`][fn_mut],
 and [`FnOnce`][fn_once]
 
-[generics]: generics.html
+[generics]: ../../generics.md
 [fn]: https://doc.rust-lang.org/std/ops/trait.Fn.html
 [fn_mut]: https://doc.rust-lang.org/std/ops/trait.FnMut.html
 [fn_once]: https://doc.rust-lang.org/std/ops/trait.FnOnce.html

--- a/src/fn/closures/capture.md
+++ b/src/fn/closures/capture.md
@@ -97,5 +97,5 @@ fn main() {
 
 [`Box`][box] and [`std::mem::drop`][drop]
 
-[box]: std/box.html
+[box]: ../../std/box.md
 [drop]: https://doc.rust-lang.org/std/mem/fn.drop.html

--- a/src/fn/closures/output_parameters.md
+++ b/src/fn/closures/output_parameters.md
@@ -46,8 +46,8 @@ fn main() {
 
 [Boxing][box], [`Fn`][fn], [`FnMut`][fnmut], and [Generics][generics].
 
-[box]: std/box.html
+[box]: ../../std/box.md
 [fn]: https://doc.rust-lang.org/std/ops/trait.Fn.html
 [fnmut]: https://doc.rust-lang.org/std/ops/trait.FnMut.html
 [fnbox]: https://doc.rust-lang.org/std/boxed/trait.FnBox.html 
-[generics]: generics.html
+[generics]: ../../generics.md

--- a/src/generics.md
+++ b/src/generics.md
@@ -60,5 +60,5 @@ fn main() {
 
 [`struct`s][structs]
 
-[structs]: custom_types/structs.html
+[structs]: custom_types/structs.md
 [camelcase]: https://en.wikipedia.org/wiki/CamelCase

--- a/src/generics/assoc_items/the_problem.md
+++ b/src/generics/assoc_items/the_problem.md
@@ -63,5 +63,5 @@ fn main() {
 
 [`struct`s][structs], and [`trait`s][traits]
 
-[structs]: custom_types/structs.html
-[traits]: trait.html
+[structs]: ../../custom_types/structs.md
+[traits]: ../../trait.md

--- a/src/generics/bounds.md
+++ b/src/generics/bounds.md
@@ -74,8 +74,8 @@ some cases to be more expressive.
 
 [`std::fmt`][fmt], [`struct`s][structs], and [`trait`s][traits]
 
-[fmt]: hello/print.html
-[methods]: fn/methods.html
-[structs]: custom_types/structs.html
-[traits]: trait.html
-[where]: generics/where.html
+[fmt]: ../hello/print.md
+[methods]: ../fn/methods.md
+[structs]: ../custom_types/structs.md
+[traits]: ../trait.md
+[where]: ../generics/where.md

--- a/src/generics/bounds/testcase_empty.md
+++ b/src/generics/bounds/testcase_empty.md
@@ -40,4 +40,4 @@ fn main() {
 
 [eq]: https://doc.rust-lang.org/std/cmp/trait.Eq.html
 [ord]: https://doc.rust-lang.org/std/cmp/trait.Ord.html
-[traits]: trait.html
+[traits]: ../../trait.md

--- a/src/generics/gen_fn.md
+++ b/src/generics/gen_fn.md
@@ -55,5 +55,5 @@ fn main() {
 
 [functions][fn] and [`struct`s][structs]
 
-[fn]: fn.html
-[structs]: custom_types/structs.html
+[fn]: ../fn.md
+[structs]: ../custom_types/structs.md

--- a/src/generics/gen_trait.md
+++ b/src/generics/gen_trait.md
@@ -41,5 +41,5 @@ fn main() {
 [`Drop`][Drop], [`struct`][structs], and [`trait`][traits]
 
 [Drop]: https://doc.rust-lang.org/std/ops/trait.Drop.html
-[structs]: custom_types/structs.html
-[traits]: trait.html
+[structs]: ../custom_types/structs.md
+[traits]: ../trait.md

--- a/src/generics/impl.md
+++ b/src/generics/impl.md
@@ -46,7 +46,7 @@ fn main() {
 [functions returning references][fn], [`impl`][methods], and [`struct`][structs]
 
 
-[fn]: scope/lifetime/fn.html
-[methods]: fn/methods.html
+[fn]: ../scope/lifetime/fn.md
+[methods]: ../fn/methods.md
 [specialization_plans]: https://blog.rust-lang.org/2015/05/11/traits.html#the-future
-[structs]: custom_types/structs.html
+[structs]: ../custom_types/structs.md

--- a/src/generics/multi_bounds.md
+++ b/src/generics/multi_bounds.md
@@ -33,5 +33,5 @@ fn main() {
 
 [`std::fmt`][fmt] and [`trait`s][traits]
 
-[fmt]: hello/print.html
-[traits]: trait.html
+[fmt]: ../hello/print.md
+[traits]: ../trait.md

--- a/src/generics/new_types.md
+++ b/src/generics/new_types.md
@@ -54,5 +54,5 @@ fn main() {
 
 [`structs`][struct]
 
-[struct]: custom_types/structs.html
+[struct]: ../custom_types/structs.md
 

--- a/src/generics/phantom.md
+++ b/src/generics/phantom.md
@@ -57,7 +57,7 @@ fn main() {
 
 [Derive], [struct], and [TupleStructs]
 
-[Derive]: trait/derive.html
-[struct]: custom_types/structs.html
-[TupleStructs]: custom_types/structs.html
+[Derive]: ../trait/derive.md
+[struct]: ../custom_types/structs.md
+[TupleStructs]: ../custom_types/structs.md
 [std::marker::PhantomData]: https://doc.rust-lang.org/std/marker/struct.PhantomData.html

--- a/src/generics/phantom/testcase_units.md
+++ b/src/generics/phantom/testcase_units.md
@@ -77,12 +77,12 @@ fn main() {
 [Borrowing (`&`)], [Bounds (`X: Y`)], [enum], [impl & self],
 [Overloading], [ref], [Traits (`X for Y`)], and [TupleStructs].
 
-[Borrowing (`&`)]: scope/borrow.html
-[Bounds (`X: Y`)]: generics/bounds.html
-[enum]: custom_types/enum.html
-[impl & self]: fn/methods.html
-[Overloading]: trait/ops.html
-[ref]: scope/borrow/ref.html
-[Traits (`X for Y`)]: trait.html
-[TupleStructs]: custom_types/structs.html
+[Borrowing (`&`)]: ../../scope/borrow.md
+[Bounds (`X: Y`)]: ../../generics/bounds.md
+[enum]: ../../custom_types/enum.md
+[impl & self]: ../../fn/methods.md
+[Overloading]: ../../trait/ops.md
+[ref]: ../../scope/borrow/ref.md
+[Traits (`X for Y`)]: ../../trait.md
+[TupleStructs]: ../../custom_types/structs.md
 [std::marker::PhantomData]: https://doc.rust-lang.org/std/marker/struct.PhantomData.html

--- a/src/generics/where.md
+++ b/src/generics/where.md
@@ -50,6 +50,6 @@ fn main() {
 
 [RFC][where], [`struct`][struct], and [`trait`][trait]
 
-[struct]: custom_types/structs.html
-[trait]: trait.html
+[struct]: ../custom_types/structs.md
+[trait]: ../trait.md
 [where]: https://github.com/rust-lang/rfcs/blob/master/text/0135-where.md

--- a/src/hello.md
+++ b/src/hello.md
@@ -46,4 +46,4 @@ Hello World!
 I'm a Rustacean!
 ```
 
-[macros]: macros.html
+[macros]: macros.md

--- a/src/hello/comment.md
+++ b/src/hello/comment.md
@@ -48,4 +48,4 @@ fn main() {
 
 [Library documentation][docs]
 
-[docs]: meta/doc.html
+[docs]: ../meta/doc.md

--- a/src/hello/print.md
+++ b/src/hello/print.md
@@ -86,9 +86,9 @@ Implementing the `fmt::Display` trait automagically implements the
 and [`traits`][traits]
 
 [fmt]: https://doc.rust-lang.org/std/fmt/
-[macros]: macros.html
-[string]: std/str.html
-[structs]: custom_types/structs.html
-[traits]: trait.html
+[macros]: ../macros.md
+[string]: ../std/str.md
+[structs]: ../custom_types/structs.md
+[traits]: ../trait.md
 [`ToString`]: https://doc.rust-lang.org/std/string/trait.ToString.html
-[convert]: conversion/string.html
+[convert]: ../conversion/string.md

--- a/src/hello/print/print_debug.md
+++ b/src/hello/print/print_debug.md
@@ -78,7 +78,7 @@ One can manually implement `fmt::Display` to control the display.
 and [`struct`][structs]
 
 [attributes]: https://doc.rust-lang.org/reference/attributes.html
-[derive]: trait/derive.html
+[derive]: ../../trait/derive.md
 [fmt]: https://doc.rust-lang.org/std/fmt/
-[structs]: custom_types/structs.html
+[structs]: ../../custom_types/structs.md
 

--- a/src/hello/print/print_display.md
+++ b/src/hello/print/print_display.md
@@ -121,9 +121,9 @@ Debug: Complex { real: 3.3, imag: 7.2 }
 [`derive`][derive], [`std::fmt`][fmt], [macros], [`struct`][structs],
 [`trait`][traits], and [use][use]
 
-[derive]: trait/derive.html
+[derive]: ../../trait/derive.md
 [fmt]: https://doc.rust-lang.org/std/fmt/
-[macros]: macros.html
-[structs]: custom_types/structs.html
-[traits]: trait.html
-[use]: mod/use.html
+[macros]: ../../macros.md
+[structs]: ../../custom_types/structs.md
+[traits]: ../../trait.md
+[use]: ../../mod/use.md

--- a/src/hello/print/print_display/testcase_list.md
+++ b/src/hello/print/print_display/testcase_list.md
@@ -71,9 +71,9 @@ Try changing the program so that the index of each element in the vector is also
 [`for`][for], [`ref`][ref], [`Result`][result], [`struct`][struct],
 [`?`][q_mark], and [`vec!`][vec]
 
-[for]: flow_control/for.html
-[result]: std/result.html
-[ref]: scope/borrow/ref.html
-[struct]: custom_types/structs.html
-[q_mark]: std/result/question_mark.html
-[vec]: std/vec.html
+[for]: ../../../flow_control/for.md
+[result]: ../../../std/result.md
+[ref]: ../../../scope/borrow/ref.md
+[struct]: ../../../custom_types/structs.md
+[q_mark]: ../../../std/result/question_mark.md
+[vec]: ../../../std/vec.md

--- a/src/index.md
+++ b/src/index.md
@@ -11,53 +11,53 @@ Additionally for the curious, you can also [check out the source code for this s
 
 Now let's begin!
 
-- [Hello World](hello.html) - Start with a traditional Hello World program.
+- [Hello World](hello.md) - Start with a traditional Hello World program.
 
-- [Primitives](primitives.html) - Learn about signed integers, unsigned integers and other primitives.
+- [Primitives](primitives.md) - Learn about signed integers, unsigned integers and other primitives.
 
-- [Custom Types](custom_types.html) - `struct` and `enum`.
+- [Custom Types](custom_types.md) - `struct` and `enum`.
 
-- [Variable Bindings](variable_bindings.html) - mutable bindings, scope, shadowing.
+- [Variable Bindings](variable_bindings.md) - mutable bindings, scope, shadowing.
 
-- [Types](types.html) - Learn about changing and defining types.
+- [Types](types.md) - Learn about changing and defining types.
 
-- [Conversion](conversion.html)
+- [Conversion](conversion.md)
 
-- [Expressions](expression.html)
+- [Expressions](expression.md)
 
-- [Flow of Control](flow_control.html) - `if`/`else`, `for`, and others.
+- [Flow of Control](flow_control.md) - `if`/`else`, `for`, and others.
 
-- [Functions](fn.html) - Learn about Methods, Closures and High Order Functions.
+- [Functions](fn.md) - Learn about Methods, Closures and High Order Functions.
 
-- [Modules](mod.html) - Organize code using modules
+- [Modules](mod.md) - Organize code using modules
 
-- [Crates](crates.html) - A crate is a compilation unit in Rust. Learn to create a library.
+- [Crates](crates.md) - A crate is a compilation unit in Rust. Learn to create a library.
 
-- [Cargo](cargo.html) - Go through some basic features of the official Rust package management tool.
+- [Cargo](cargo.md) - Go through some basic features of the official Rust package management tool.
 
-- [Attributes](attribute.html) - An attribute is metadata applied to some module, crate or item.
+- [Attributes](attribute.md) - An attribute is metadata applied to some module, crate or item.
 
-- [Generics](generics.html) - Learn about writing a function or data type which can work for multiple types of arguments.
+- [Generics](generics.md) - Learn about writing a function or data type which can work for multiple types of arguments.
 
-- [Scoping rules](scope.html) - Scopes play an important part in ownership, borrowing, and lifetimes.
+- [Scoping rules](scope.md) - Scopes play an important part in ownership, borrowing, and lifetimes.
 
-- [Traits](trait.html) - A trait is a collection of methods defined for an unknown type: `Self`
+- [Traits](trait.md) - A trait is a collection of methods defined for an unknown type: `Self`
 
-- [Macros](macros.html)
+- [Macros](macros.md)
 
-- [Error handling](error.html) - Learn Rust way of handling failures.
+- [Error handling](error.md) - Learn Rust way of handling failures.
 
-- [Std library types](std.html) - Learn about some custom types provided by `std` library.
+- [Std library types](std.md) - Learn about some custom types provided by `std` library.
 
-- [Std misc](std_misc.html) - More custom types for file handling, threads.
+- [Std misc](std_misc.md) - More custom types for file handling, threads.
 
-- [Testing](testing.html) - All sorts of testing in Rust.
+- [Testing](testing.md) - All sorts of testing in Rust.
 
-- [Unsafe Operations](unsafe.html)
+- [Unsafe Operations](unsafe.md)
 
-- [Compatibility](compatibility.html)
+- [Compatibility](compatibility.md)
 
-- [Meta](meta.html) - Documentation, Benchmarking.
+- [Meta](meta.md) - Documentation, Benchmarking.
 
 
 [rust]: https://www.rust-lang.org/

--- a/src/macros/syntax.md
+++ b/src/macros/syntax.md
@@ -7,6 +7,6 @@ There are three basic ideas:
 - [Overloading][overloading]
 - [Repetition][repetition]
 
-[designators]: macros/designators.html
-[overloading]: macros/overload.html
-[repetition]: macros/repeat.html
+[designators]: designators.md
+[overloading]: overload.md
+[repetition]: repeat.md

--- a/src/mod/split.md
+++ b/src/mod/split.md
@@ -93,4 +93,4 @@ called `my::indirect_access()`, that
 called `my::nested::function()`
 ```
 
-[visibility]: mod/visibility.html
+[visibility]: visibility.md

--- a/src/mod/struct_visibility.md
+++ b/src/mod/struct_visibility.md
@@ -55,5 +55,5 @@ fn main() {
 
 [generics][generics] and [methods][methods]
 
-[generics]: generics.html
-[methods]: fn/methods.html
+[generics]: ../generics.md
+[methods]: ../fn/methods.md

--- a/src/primitives.md
+++ b/src/primitives.md
@@ -58,6 +58,6 @@ fn main() {
 [the `std` library][std], [`mut`][mut], [inference], and [shadowing]
 
 [std]: https://doc.rust-lang.org/std/
-[mut]: variable_bindings/mut.html
-[inference]: types/inference.html
-[shadowing]: variable_bindings/scope.html
+[mut]: variable_bindings/mut.md
+[inference]: types/inference.md
+[shadowing]: variable_bindings/scope.md

--- a/src/primitives/tuples.md
+++ b/src/primitives/tuples.md
@@ -94,4 +94,4 @@ fn main() {
     ( 1.2 2.2 )
     ```
 
-[print_display]: hello/print/print_display.html
+[print_display]: ../hello/print/print_display.md

--- a/src/scope/borrow/mut.md
+++ b/src/scope/borrow/mut.md
@@ -56,4 +56,4 @@ fn main() {
 ### See also:
 [`static`][static]
 
-[static]: scope/lifetime/static_lifetime.html
+[static]: ../lifetime/static_lifetime.md

--- a/src/scope/lifetime/explicit.md
+++ b/src/scope/lifetime/explicit.md
@@ -69,7 +69,7 @@ fn main() {
 
 [generics][generics] and [closures][closures]
 
-[anonymity]: fn/closures/anonymity.html
-[closures]: fn/closures.html
-[elision]: scope/lifetime/elision.html
-[generics]: generics.html
+[anonymity]: ../../fn/closures/anonymity.md
+[closures]: ../../fn/closures.md
+[elision]: elision.md
+[generics]: ../../generics.md

--- a/src/scope/lifetime/fn.md
+++ b/src/scope/lifetime/fn.md
@@ -59,5 +59,5 @@ fn main() {
 
 [functions][fn]
 
-[elision]: scope/lifetime/elision.html
-[fn]: fn.html
+[elision]: elision.md
+[fn]: fn.md

--- a/src/scope/lifetime/lifetime_bounds.md
+++ b/src/scope/lifetime/lifetime_bounds.md
@@ -48,6 +48,6 @@ fn main() {
 [generics][generics], [bounds in generics][bounds], and 
 [multiple bounds in generics][multibounds]
 
-[generics]: generics.html
-[bounds]: generics/bounds.html
-[multibounds]: generics/multi_bounds.html
+[generics]: ../../generics.md
+[bounds]: ../../generics/bounds.md
+[multibounds]: ../../generics/multi_bounds.md

--- a/src/scope/lifetime/methods.md
+++ b/src/scope/lifetime/methods.md
@@ -25,4 +25,4 @@ fn main() {
 
 [methods]
 
-[methods]: fn/methods.html
+[methods]: ../../fn/methods.md

--- a/src/scope/lifetime/static_lifetime.md
+++ b/src/scope/lifetime/static_lifetime.md
@@ -49,4 +49,4 @@ fn main() {
 
 [`'static` constants][static_const]
 
-[static_const]: custom_types/constants.html
+[static_const]: ../../custom_types/constants.md

--- a/src/scope/lifetime/struct.md
+++ b/src/scope/lifetime/struct.md
@@ -43,4 +43,4 @@ fn main() {
 [`struct`s][structs]
 
 
-[structs]: custom_types/structs.html
+[structs]: ../../custom_types/structs.md

--- a/src/scope/lifetime/trait.md
+++ b/src/scope/lifetime/trait.md
@@ -30,4 +30,4 @@ fn main() {
 [`trait`s][trait]
 
 
-[trait]: trait.html
+[trait]: ../../trait.md

--- a/src/scope/move.md
+++ b/src/scope/move.md
@@ -57,4 +57,4 @@ fn main() {
 }
 ```
 
-[references]: flow_control/match/destructuring/destructure_pointers.html
+[references]: ../flow_control/match/destructuring/destructure_pointers.md

--- a/src/scope/raii.md
+++ b/src/scope/raii.md
@@ -91,6 +91,6 @@ fn main() {
 [Box][box]
 
 [raii]: https://en.wikipedia.org/wiki/Resource_Acquisition_Is_Initialization
-[box]: std/box.html
+[box]: ../std/box.md
 [valgrind]: http://valgrind.org/info/
 [`Drop`]: https://doc.rust-lang.org/std/ops/trait.Drop.html

--- a/src/std.md
+++ b/src/std.md
@@ -13,5 +13,5 @@ the `primitives`. Some of these include:
 
 [primitives] and [the std library][std]
 
-[primitives]: primitives.html
+[primitives]: primitives.md
 [std]: https://doc.rust-lang.org/std/

--- a/src/std_misc.md
+++ b/src/std_misc.md
@@ -13,5 +13,5 @@ These expand beyond what the [primitives] provide.
 
 [primitives] and [the std library][std]
 
-[primitives]: primitives.html
+[primitives]: primitives.md
 [std]: https://doc.rust-lang.org/std/

--- a/src/std_misc/fs.md
+++ b/src/std_misc/fs.md
@@ -143,4 +143,4 @@ fn cat(path: &Path) -> io::Result<String> {
 
 [`cfg!`][cfg]
 
-[cfg]: attribute/cfg.html
+[cfg]: ../attribute/cfg.md

--- a/src/std_misc/threads/testcase_mapreduce.md
+++ b/src/std_misc/threads/testcase_mapreduce.md
@@ -140,13 +140,13 @@ defined by a static constant at the beginning of the program.
 * [unwrap vs. expect][unwrap]
 * [enumerate][enumerate]
 
-[thread]: std_misc/threads.html
-[vectors]: std/vec.html
-[iterators]: trait/iter.html
+[thread]: ../threads.md
+[vectors]: ../../std/vec.md
+[iterators]: ../../trait/iter.md
 [destructuring]: https://doc.rust-lang.org/book/ch18-03-pattern-syntax.html#destructuring-to-break-apart-values
-[closures]: fn/closures.html
-[move]: scope/move.html
+[closures]: ../../fn/closures.md
+[move]: ../../scope/move.md
 [move_closure]: https://doc.rust-lang.org/book/ch13-01-closures.html#closures-can-capture-their-environment
 [turbofish]: https://doc.rust-lang.org/std/iter/trait.Iterator.html#method.collect
-[unwrap]: error/option_unwrap.html
+[unwrap]: ../../error/option_unwrap.md
 [enumerate]: https://doc.rust-lang.org/book/loops.html#enumerate

--- a/src/testing.md
+++ b/src/testing.md
@@ -18,9 +18,9 @@ Also Rust has support for specifying additional dependencies for tests:
 * [The Book][doc-testing] chapter on testing
 * [API Guidelines][doc-nursery] on doc-testing
 
-[unit]: testing/unit_testing.html
-[doc]: testing/doc_testing.html
-[integration]: testing/integration_testing.html
-[dev-dependencies]: testing/dev_dependencies.html
+[unit]: testing/unit_testing.md
+[doc]: testing/doc_testing.md
+[integration]: testing/integration_testing.md
+[dev-dependencies]: testing/dev_dependencies.md
 [doc-testing]: https://doc.rust-lang.org/book/ch11-00-testing.html
 [doc-nursery]: https://rust-lang-nursery.github.io/api-guidelines/documentation.html

--- a/src/testing/integration_testing.md
+++ b/src/testing/integration_testing.md
@@ -83,5 +83,5 @@ fn test_add() {
 Modules with common code follow the ordinary [modules][mod] rules, so it's ok to
 create common module as `tests/common/mod.rs`.
 
-[unit]: testing/unit_testing.html
-[mod]: mod.html
+[unit]: unit_testing.md
+[mod]: ../mod.md

--- a/src/testing/unit_testing.md
+++ b/src/testing/unit_testing.md
@@ -224,7 +224,7 @@ running 0 tests
 test result: ok. 0 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out
 ```
 
-[attribute]: attribute.html
-[panic]: std/panic.html
-[macros]: macros.html
-[mod]: mod.html
+[attribute]: ../attribute.md
+[panic]: ../std/panic.md
+[macros]: ../macros.md
+[mod]: ../mod.md

--- a/src/trait/derive.md
+++ b/src/trait/derive.md
@@ -64,7 +64,7 @@ fn main() {
 ### See also:
 [`derive`][derive]
 
-[attribute]: attribute.html
+[attribute]: ../attribute.md
 [eq]: https://doc.rust-lang.org/std/cmp/trait.Eq.html
 [partial-eq]: https://doc.rust-lang.org/std/cmp/trait.PartialEq.html
 [ord]: https://doc.rust-lang.org/std/cmp/trait.Ord.html

--- a/src/types.md
+++ b/src/types.md
@@ -7,7 +7,7 @@ user defined types. The following sections cover:
 * Using [type inference]
 * [Aliasing] types
 
-[Casting]: types/cast.html
-[literals]: types/literals.html
-[type inference]: types/inference.html
-[Aliasing]: types/alias.html
+[Casting]: types/cast.md
+[literals]: types/literals.md
+[type inference]: types/inference.md
+[Aliasing]: types/alias.md

--- a/src/types/alias.md
+++ b/src/types/alias.md
@@ -33,4 +33,4 @@ is an alias for the `Result<T, IoError>` type.
 
 ### See also:
 
-[Attributes](attribute.html)
+[Attributes](../attribute.md)

--- a/src/types/literals.md
+++ b/src/types/literals.md
@@ -38,6 +38,6 @@ yet, here's a brief explanation for the impatient readers:
   is defined in the `std` *crate*. For more details, see
   [modules][mod] and [crates][crate].
 
-[borrow]: scope/borrow.html
-[mod]: mod.html
-[crate]: crates.html
+[borrow]: ../scope/borrow.md
+[mod]: ../mod.md
+[crate]: ../crates.md

--- a/src/unsafe.md
+++ b/src/unsafe.md
@@ -8,7 +8,7 @@ things that unsafe is used for:
 
 * dereferencing raw pointers
 * calling functions or methods which are `unsafe` (including calling a function
-  over FFI, see [a previous chapter](std_misc/ffi.html) of the book) 
+  over FFI, see [a previous chapter](std_misc/ffi.md) of the book) 
 * accessing or modifying static mutable variables
 * implementing unsafe traits
 


### PR DESCRIPTION
Part of ongoing effort to remove old `mdbook 0.1` from Rust: https://github.com/rust-lang/rust/pull/61372.