### PR TITLE
Add Cargo comment to the `try!` macro example.

### DIFF
--- a/src/error/multiple_error_types/reenter_question_mark.md
+++ b/src/error/multiple_error_types/reenter_question_mark.md
@@ -25,7 +25,6 @@ Here, we rewrite the previous example using `?`. As a result, the
 ```rust,editable
 use std::error;
 use std::fmt;
-use std::num::ParseIntError;
 
 // Change the alias to `Box<error::Error>`.
 type Result<T> = std::result::Result<T, Box<error::Error>>;

--- a/src/error/result/enter_question_mark.md
+++ b/src/error/result/enter_question_mark.md
@@ -44,6 +44,9 @@ at older code. The same `multiply` function from the previous example
 would look like this using `try!`:
 
 ```rust,editable
+// To compile and run this example without errors, while using Cargo, change the value 
+// of the `edition` field, in the `[package]` section of the `Cargo.toml` file, to "2015".
+
 use std::num::ParseIntError;
 
 fn multiply(first_number_str: &str, second_number_str: &str) -> Result<i32, ParseIntError> {


### PR DESCRIPTION
In Rust "2018", `try!` macro is deprecated, and `try` is a reserved keyword. If you're using Cargo to compile the code using this syntax, you'll get an error message. To fix it, you need to change the value of the `edition` field in the `Cargo.toml` file back to "2015".