### PR TITLE
Update `macro_rules!` formatting.

### DIFF
--- a/src/macros.md
+++ b/src/macros.md
@@ -14,10 +14,10 @@ Macros are created using the `macro_rules!` macro.
 // This is a simple macro named `say_hello`.
 macro_rules! say_hello {
     // `()` indicates that the macro takes no argument.
-    () => (
+    () => {
         // The macro will expand into the contents of this block.
         println!("Hello!");
-    )
+    };
 }
 
 fn main() {

--- a/src/macros/designators.md
+++ b/src/macros/designators.md
@@ -8,13 +8,13 @@ macro_rules! create_function {
     // This macro takes an argument of designator `ident` and
     // creates a function named `$func_name`.
     // The `ident` designator is used for variable/function names.
-    ($func_name:ident) => (
+    ($func_name:ident) => {
         fn $func_name() {
             // The `stringify!` macro converts an `ident` into a string.
             println!("You called {:?}()",
                      stringify!($func_name));
         }
-    )
+    };
 }
 
 // Create functions named `foo` and `bar` with the above macro.
@@ -25,12 +25,12 @@ macro_rules! print_result {
     // This macro takes an expression of type `expr` and prints
     // it as a string along with its result.
     // The `expr` designator is used for expressions.
-    ($expression:expr) => (
+    ($expression:expr) => {
         // `stringify!` will convert the expression *as it is* into a string.
         println!("{:?} = {:?}",
                  stringify!($expression),
                  $expression);
-    )
+    };
 }
 
 fn main() {

--- a/src/macros/dry.md
+++ b/src/macros/dry.md
@@ -10,18 +10,18 @@ use std::ops::{Add, Mul, Sub};
 macro_rules! assert_equal_len {
     // The `tt` (token tree) designator is used for
     // operators and tokens.
-    ($a:ident, $b:ident, $func:ident, $op:tt) => (
+    ($a:ident, $b:ident, $func:ident, $op:tt) => {
         assert!($a.len() == $b.len(),
                 "{:?}: dimension mismatch: {:?} {:?} {:?}",
                 stringify!($func),
                 ($a.len(),),
                 stringify!($op),
                 ($b.len(),));
-    )
+    };
 }
 
 macro_rules! op {
-    ($func:ident, $bound:ident, $op:tt, $method:ident) => (
+    ($func:ident, $bound:ident, $op:tt, $method:ident) => {
         fn $func<T: $bound<T, Output=T> + Copy>(xs: &mut Vec<T>, ys: &Vec<T>) {
             assert_equal_len!(xs, ys, $func, $op);
 
@@ -30,7 +30,7 @@ macro_rules! op {
                 // *x = x.$method(*y);
             }
         }
-    )
+    };
 }
 
 // Implement `add_assign`, `mul_assign`, and `sub_assign` functions.
@@ -54,7 +54,7 @@ mod test {
                     assert_eq!(x, z);
                 }
             }
-        }
+        };
     }
 
     // Test `add_assign`, `mul_assign`, and `sub_assign`.

--- a/src/macros/overload.md
+++ b/src/macros/overload.md
@@ -9,19 +9,19 @@ In that regard, `macro_rules!` can work similarly to a match block:
 macro_rules! test {
     // Arguments don't need to be separated by a comma.
     // Any template can be used!
-    ($left:expr; and $right:expr) => (
+    ($left:expr; and $right:expr) => {
         println!("{:?} and {:?} is {:?}",
                  stringify!($left),
                  stringify!($right),
                  $left && $right)
-    );
+    };
     // ^ each arm must end with a semicolon.
-    ($left:expr; or $right:expr) => (
+    ($left:expr; or $right:expr) => {
         println!("{:?} or {:?} is {:?}",
                  stringify!($left),
                  stringify!($right),
                  $left || $right)
-    );
+    };
 }
 
 fn main() {

--- a/src/macros/repeat.md
+++ b/src/macros/repeat.md
@@ -22,7 +22,7 @@ macro_rules! find_min {
 
 fn main() {
     println!("{}", find_min!(1u32));
-    println!("{}", find_min!(1u32 + 2 , 2u32));
+    println!("{}", find_min!(1u32 + 2, 2u32));
     println!("{}", find_min!(5u32, 2u32 * 3, 4u32));
 }
 ```


### PR DESCRIPTION
In accordance to the default behavior of `rust-fmt`, most of plain parentheses used in `macro_rules!` definitions, have been replaced by curly braces.