### PR TITLE
Make `use` example runnable

### DIFF
--- a/src/mod/use.md
+++ b/src/mod/use.md
@@ -19,7 +19,7 @@ fn main() {
 
 You can use the `as` keyword to bind imports to a different name:
 
-```rust,editable,ignore
+```rust,editable
 // Bind the `deeply::nested::function` path to `other_function`.
 use deeply::nested::function as other_function;
 


### PR DESCRIPTION
The `ignore` was added in #1097, but the example was runnable until then.