### PR TITLE
panic.md: Fix highlighting

### DIFF
--- a/src/std/panic.md
+++ b/src/std/panic.md
@@ -34,7 +34,7 @@ fn main() {
 
 Let's check that `panic!` doesn't leak memory.
 
-```
+```text
 $ rustc panic.rs && valgrind ./panic
 ==4401== Memcheck, a memory error detector
 ==4401== Copyright (C) 2002-2013, and GNU GPL'd, by Julian Seward et al.

--- a/src/std/panic.md
+++ b/src/std/panic.md
@@ -34,7 +34,7 @@ fn main() {
 
 Let's check that `panic!` doesn't leak memory.
 
-```bash
+```
 $ rustc panic.rs && valgrind ./panic
 ==4401== Memcheck, a memory error detector
 ==4401== Copyright (C) 2002-2013, and GNU GPL'd, by Julian Seward et al.


### PR DESCRIPTION
A "```bash" section is only meant for Bash code, not for transcripts of interactive sessions including command output.