### PR TITLE
Changed mutable collected_iterator into immutable

### DIFF
--- a/src/std/vec.md
+++ b/src/std/vec.md
@@ -10,7 +10,7 @@ be surpassed, the vector is reallocated with a larger capacity.
 ```rust,editable,ignore,mdbook-runnable
 fn main() {
     // Iterators can be collected into vectors
-    let mut collected_iterator: Vec<i32> = (0..10).collect();
+    let collected_iterator: Vec<i32> = (0..10).collect();
     println!("Collected (0..10) into: {:?}", collected_iterator);
 
     // The `vec!` macro can be used to initialize a vector


### PR DESCRIPTION
`collected_iterator` should be immutable in order for `collected_iterator.push(0)` to produce error.