### PR TITLE
Fix minor formatting inconsistencies

### DIFF
--- a/src/mod/visibility.md
+++ b/src/mod/visibility.md
@@ -38,20 +38,20 @@ mod my_mod {
         // Functions declared using `pub(in path)` syntax are only visible
         // within the given path. `path` must be a parent or ancestor module
         pub(in crate::my_mod) fn public_function_in_my_mod() {
-            print!("called `my_mod::nested::public_function_in_my_mod()`, that\n > ");
-            public_function_in_nested()
+            print!("called `my_mod::nested::public_function_in_my_mod()`, that\n> ");
+            public_function_in_nested();
         }
 
         // Functions declared using `pub(self)` syntax are only visible within
         // the current module, which is the same as leaving them private
         pub(self) fn public_function_in_nested() {
-            println!("called `my_mod::nested::public_function_in_nested");
+            println!("called `my_mod::nested::public_function_in_nested()`");
         }
 
         // Functions declared using `pub(super)` syntax are only visible within
         // the parent module
         pub(super) fn public_function_in_super_mod() {
-            println!("called my_mod::nested::public_function_in_super_mod");
+            println!("called `my_mod::nested::public_function_in_super_mod()`");
         }
     }
 
@@ -64,7 +64,7 @@ mod my_mod {
 
     // pub(crate) makes functions visible only within the current crate
     pub(crate) fn public_function_in_crate() {
-        println!("called `my_mod::public_function_in_crate()");
+        println!("called `my_mod::public_function_in_crate()`");
     }
 
     // Nested modules follow the same rules for visibility


### PR DESCRIPTION
Fixes minor formatting inconsistencies.

Example:
`println!("called my_mod::nested::public_function_in_super_mod");`
deviates from the precedent
``println!("called `my_mod::nested::public_function_in_super_mod()`");``