### PR TITLE
Rename variable names for consistent in iter_result.md

### DIFF
--- a/src/error/iter_result.md
+++ b/src/error/iter_result.md
@@ -5,11 +5,11 @@ An `Iter::map` operation might fail, for example:
 ```rust,editable
 fn main() {
     let strings = vec!["tofu", "93", "18"];
-    let possible_numbers: Vec<_> = strings
+    let numbers: Vec<_> = strings
         .into_iter()
         .map(|s| s.parse::<i32>())
         .collect();
-    println!("Results: {:?}", possible_numbers);
+    println!("Results: {:?}", numbers);
 }
 ```
 


### PR DESCRIPTION
Rename `possible_numbers` in first example to `number` like in other examples.