### PR TITLE
Reorder links in destructuring.md

### DIFF
--- a/src/flow_control/match/destructuring.md
+++ b/src/flow_control/match/destructuring.md
@@ -2,10 +2,10 @@
 
 A `match` block can destructure items in a variety of ways.
 
+* [Destructuring Tuples][tuple]
 * [Destructuring Enums][enum]
 * [Destructuring Pointers][refs]
 * [Destructuring Structures][struct]
-* [Destructuring Tuples][tuple]
 
 
 [enum]: destructuring/destructure_enum.md


### PR DESCRIPTION
Move "Destructuring Tuples" to start of list, like in Summary