### PR TITLE
freeze.md: Incorrect example

### DIFF
--- a/src/scope/borrow/freeze.md
+++ b/src/scope/borrow/freeze.md
@@ -17,7 +17,7 @@ fn main() {
 
         println!("Immutably borrowed {}", large_integer);
 
-        // `_large_integer` goes out of scope
+        // `large_integer` goes out of scope
     }
 
     // Ok! `_mutable_integer` is not frozen in this scope

--- a/src/scope/borrow/freeze.md
+++ b/src/scope/borrow/freeze.md
@@ -9,11 +9,13 @@ fn main() {
 
     {
         // Borrow `_mutable_integer`
-        let _large_integer = &_mutable_integer;
+        let large_integer = &_mutable_integer;
 
         // Error! `_mutable_integer` is frozen in this scope
         _mutable_integer = 50;
         // FIXME ^ Comment out this line
+
+        println!("Immutably borrowed {}", large_integer);
 
         // `_large_integer` goes out of scope
     }


### PR DESCRIPTION
The freeze example is meant to show that a value cannot be immutably borrowed
while the original value is modified within the same scope.

However, as the immutably borrowed value is not used after the mutation, the
borrow checker allows the example to be compiled successfully, contrary to what
we intend to demonstrate.

See #1217 for discussion.

Solution: Use the immutably borrowed value after original value is modified.