### PR TITLE
flow_control/match/binding.md: `...' -> `..='

### DIFF
--- a/src/flow_control/match/binding.md
+++ b/src/flow_control/match/binding.md
@@ -18,8 +18,8 @@ fn main() {
         // Could `match` 1 ... 12 directly but then what age
         // would the child be? Instead, bind to `n` for the
         // sequence of 1 .. 12. Now the age can be reported.
-        n @ 1  ... 12 => println!("I'm a child of age {:?}", n),
-        n @ 13 ... 19 => println!("I'm a teen of age {:?}", n),
+        n @ 1  ..= 12 => println!("I'm a child of age {:?}", n),
+        n @ 13 ..= 19 => println!("I'm a teen of age {:?}", n),
         // Nothing bound. Return the result.
         n             => println!("I'm an old person of age {:?}", n),
     }


### PR DESCRIPTION
`...` range patterns are deprecated and only kept for backward compatibility (https://doc.rust-lang.org/reference/patterns.html#range-patterns) so they souldn't be used in new code or when you learn rust.

To get compiler warnings compile local with:
`rustc --edition=2018 -W ellipsis-inclusive-range-patterns match.rs` or
`cargo rustc -- --warn  ellipsis-inclusive-range-patterns `