### PR TITLE
Change initial parameters in `fibonacci()` call.

### DIFF
--- a/src/trait/iter.md
+++ b/src/trait/iter.md
@@ -38,7 +38,7 @@ impl Iterator for Fibonacci {
 
 // Returns a Fibonacci sequence generator
 fn fibonacci() -> Fibonacci {
-    Fibonacci { curr: 1, next: 1 }
+    Fibonacci { curr: 0, next: 1 }
 }
 
 fn main() {


### PR DESCRIPTION
Fixes #1240