### PR TITLE
Add colon after "See Also"

### DIFF
--- a/src/flow_control/for.md
+++ b/src/flow_control/for.md
@@ -113,7 +113,7 @@ In the above snippets note the type of `match` branch, that is the key
 difference in the types of iteration. The difference in type then of course
 implies differing actions that are able to be performed.
 
-### See also
+### See also:
 
 [Iterator][iter]
 

--- a/src/hello/print.md
+++ b/src/hello/print.md
@@ -80,7 +80,7 @@ Implementing the `fmt::Display` trait automatically implements the
    check the [`std::fmt`][fmt] documentation for setting the number of
    decimals to display)
 
-### See also
+### See also:
 
 [`std::fmt`][fmt], [`macros`][macros], [`struct`][structs],
 and [`traits`][traits]

--- a/src/hello/print/fmt.md
+++ b/src/hello/print/fmt.md
@@ -82,7 +82,7 @@ Two hints if you get stuck:
  * You [may need to list each color more than once][named_parameters],
  * You can [pad with zeros to a width of 2][fmt_width] with `:02`.
 
-### See also
+### See also:
 
 [`std::fmt`][fmt]
 

--- a/src/hello/print/print_debug.md
+++ b/src/hello/print/print_debug.md
@@ -72,7 +72,7 @@ fn main() {
 
 One can manually implement `fmt::Display` to control the display.
 
-### See also
+### See also:
 
 [attributes][attributes], [`derive`][derive], [`std::fmt`][fmt],
 and [`struct`][structs]

--- a/src/hello/print/print_display.md
+++ b/src/hello/print/print_display.md
@@ -116,7 +116,7 @@ Display: 3.3 + 7.2i
 Debug: Complex { real: 3.3, imag: 7.2 }
 ```
 
-### See also
+### See also:
 
 [`derive`][derive], [`std::fmt`][fmt], [macros], [`struct`][structs],
 [`trait`][traits], and [use][use]

--- a/src/hello/print/print_display/testcase_list.md
+++ b/src/hello/print/print_display/testcase_list.md
@@ -66,7 +66,7 @@ Try changing the program so that the index of each element in the vector is also
 [0: 1, 1: 2, 2: 3]
 ```
 
-### See also
+### See also:
 
 [`for`][for], [`ref`][ref], [`Result`][result], [`struct`][struct],
 [`?`][q_mark], and [`vec!`][vec]

--- a/src/std/rc.md
+++ b/src/std/rc.md
@@ -46,7 +46,7 @@ fn main() {
 }
 ```
 
-### See also
+### See also:
 
 [std::rc][1] and [Arc][2].
 

--- a/src/std_misc/path.md
+++ b/src/std_misc/path.md
@@ -38,7 +38,7 @@ fn main() {
 Be sure to check at other `Path` methods (`posix::Path` or `windows::Path`) and
 the `Metadata` struct.
 
-### See also
+### See also:
 
 [OsStr][1] and [Metadata][2].
 


### PR DESCRIPTION
In many files after "See Also" placed colon, but some files don't have this colon.