### PR TITLE
fix 1037: add the TryFrom chapter back in

### DIFF
--- a/src/SUMMARY.md
+++ b/src/SUMMARY.md
@@ -36,6 +36,7 @@
 
 - [Conversion](conversion.md)
     - [`From` and `Into`](conversion/from_into.md)
+    - [`TryFrom` and `TryInto`](conversion/try_from_try_into.md)
     - [To and from `String`s](conversion/string.md)
 
 - [Expressions](expression.md)

--- a/src/conversion/try_from_try_into.md
+++ b/src/conversion/try_from_try_into.md
@@ -1,0 +1,45 @@
+# `TryFrom` and `TryInto`
+
+Similar to [`From` and `Into`][from-into], [`TryFrom`] and [`TryInto`] are
+generic traits for converting between types. Unlike `From`/`Into`, the
+`TryFrom`/`TryInto` traits are used for fallible conversions, and as such,
+return [`Result`]s.
+
+[from-into]: conversion/from_into.html
+[`TryFrom`]: https://doc.rust-lang.org/std/convert/trait.TryFrom.html
+[`TryInto`]: https://doc.rust-lang.org/std/convert/trait.TryInto.html
+[`Result`]: https://doc.rust-lang.org/std/result/enum.Result.html
+
+```rust
+use std::convert::TryFrom;
+use std::convert::TryInto;
+
+#[derive(Debug, PartialEq)]
+struct EvenNumber(i32);
+
+impl TryFrom<i32> for EvenNumber {
+    type Error = ();
+
+    fn try_from(value: i32) -> Result<Self, Self::Error> {
+        if value % 2 == 0 {
+            Ok(EvenNumber(value))
+        } else {
+            Err(())
+        }
+    }
+}
+
+fn main() {
+    // TryFrom
+
+    assert_eq!(EvenNumber::try_from(8), Ok(EvenNumber(8)));
+    assert_eq!(EvenNumber::try_from(5), Err(()));
+
+    // TryInto
+
+    let result: Result<EvenNumber, ()> = 8i32.try_into();
+    assert_eq!(result, Ok(EvenNumber(8)));
+    let result: Result<EvenNumber, ()> = 5i32.try_into();
+    assert_eq!(result, Err(()));
+}
+```


### PR DESCRIPTION
Commit 2a808e6a3d25a26702a4a4a08568904764ae1bea reverted the chapter on TryFrom, because the TryFrom trait was unstabilized. But now it's stabilized again, so we should put the chapter back in. This fixes issue 1037. 