### PR TITLE
Chapter 9.2.5: impl FnOnce() works in 1.35

### DIFF
--- a/src/fn/closures/output_parameters.md
+++ b/src/fn/closures/output_parameters.md
@@ -5,13 +5,11 @@ output parameters should also be possible. However, anonymous
 closure types are, by definition, unknown, so we have to use
 `impl Trait` to return them.
 
-The valid traits for returns are slightly different than before:
+The valid traits for returning a closure are:
 
-* `Fn`: normal
-* `FnMut`: normal
-* `FnOnce`: There are some unusual things at play here, so the [`FnBox`][fnbox]
-  type is currently needed, and is unstable. This is expected to change in
-  the future.
+* `Fn`
+* `FnMut`
+* `FnOnce`
 
 Beyond this, the `move` keyword must be used, which signals that all captures
 occur by value. This is required because any captures by reference would be
@@ -31,12 +29,20 @@ fn create_fnmut() -> impl FnMut() {
     move || println!("This is a: {}", text)
 }
 
+fn create_fnonce() -> impl FnOnce() {
+    let text = "FnOnce".to_owned();
+
+    move || println!("This is a: {}", text)
+}
+
 fn main() {
     let fn_plain = create_fn();
     let mut fn_mut = create_fnmut();
+    let fn_once = create_fnonce();
 
     fn_plain();
     fn_mut();
+    fn_once();
 }
 ```
 
@@ -46,6 +52,5 @@ fn main() {
 
 [fn]: https://doc.rust-lang.org/std/ops/trait.Fn.html
 [fnmut]: https://doc.rust-lang.org/std/ops/trait.FnMut.html
-[fnbox]: https://doc.rust-lang.org/std/boxed/trait.FnBox.html
 [generics]: ../../generics.md
 [impltrait]: ../../trait/impl_trait.md


### PR DESCRIPTION
Update to remove references to the deprecated `FnBox`, and add an example of `impl FnOnce`.

Fixes #1244