### PR TITLE
Fix match range pattern usage

### DIFF
--- a/src/flow_control/match.md
+++ b/src/flow_control/match.md
@@ -15,7 +15,7 @@ fn main() {
         // Match several values
         2 | 3 | 5 | 7 | 11 => println!("This is a prime"),
         // Match an inclusive range
-        13...19 => println!("A teen"),
+        13..=19 => println!("A teen"),
         // Handle the rest of cases
         _ => println!("Ain't special"),
     }


### PR DESCRIPTION
I was working through the [match example](https://doc.rust-lang.org/rust-by-example/flow_control/match.html) and received this compiler warning:

```
warning: `...` range patterns are deprecated
  --> src/main.rs:12:11
   |
12 |         13...19 => println!("A teen"),
   |           ^^^ help: use `..=` for an inclusive range
   |
   = note: #[warn(ellipsis_inclusive_range_patterns)] on by default
```