### PR TITLE
Explicit mention of slice range meaning

### DIFF
--- a/src/primitives/array.md
+++ b/src/primitives/array.md
@@ -42,6 +42,9 @@ fn main() {
     analyze_slice(&xs);
 
     // Slices can point to a section of an array
+    // They are of the form [starting_index..ending_index]
+    // starting_index is the first position in the slice
+    // ending_index is one more than the last position in the slice
     println!("borrow a section of the array as a slice");
     analyze_slice(&ys[1 .. 4]);
 


### PR DESCRIPTION
In `&ys[1 .. 4]` i did not understand whether 4 meant the length or the end index. This is to prevent other readers from having the same confusion.