### PR TITLE
Some fix to three files

### DIFF
--- a/src/error/result.md
+++ b/src/error/result.md
@@ -5,8 +5,8 @@ describes possible *error* instead of possible *absence*.
 
 That is, `Result<T, E>` could have one of two outcomes:
 
-* `Ok<T>`: An element `T` was found
-* `Err<E>`: An error was found with element `E`
+* `Ok(T)`: An element `T` was found
+* `Err(E)`: An error was found with element `E`
 
 By convention, the expected outcome is `Ok` while the unexpected outcome is `Err`.
 

--- a/src/flow_control/match/binding.md
+++ b/src/flow_control/match/binding.md
@@ -15,9 +15,9 @@ fn main() {
 
     match age() {
         0             => println!("I'm not born yet I guess"),
-        // Could `match` 1 ... 12 directly but then what age
+        // Could `match` 1 ..= 12 directly but then what age
         // would the child be? Instead, bind to `n` for the
-        // sequence of 1 .. 12. Now the age can be reported.
+        // sequence of 1 ..= 12. Now the age can be reported.
         n @ 1  ..= 12 => println!("I'm a child of age {:?}", n),
         n @ 13 ..= 19 => println!("I'm a teen of age {:?}", n),
         // Nothing bound. Return the result.

--- a/src/macros/dry.md
+++ b/src/macros/dry.md
@@ -10,7 +10,7 @@ use std::ops::{Add, Mul, Sub};
 macro_rules! assert_equal_len {
     // The `tt` (token tree) designator is used for
     // operators and tokens.
-    ($a:ident, $b:ident, $func:ident, $op:tt) => {
+    ($a:expr, $b:expr, $func:ident, $op:tt) => {
         assert!($a.len() == $b.len(),
                 "{:?}: dimension mismatch: {:?} {:?} {:?}",
                 stringify!($func),


### PR DESCRIPTION
#### 1. `...` range patterns are deprecated:
> Fix in comment.

#### 2. Change misleading `ident` to `expr`:
> If marked as `ident`, `$a.len()` and `$b.len()` are confusing.
Actually, `xs` and `ys` are expressions, too.

#### 3. `Ok<T>` -> `Ok(T)` and `Err<E>` -> `Ok(T)`:
```rust
pub enum Result<T, E> {
    Ok(T),
    Err(E),
}
```