### PR TITLE
Enable section-folding of table of content

### DIFF
--- a/book.toml
+++ b/book.toml
@@ -6,3 +6,6 @@ author = "The Rust Community"
 [output.html.playpen]
 editable = true
 editor = "ace"
+
+[output.html.fold]
+enable = true


### PR DESCRIPTION
The section-folding configuration has landed in [mdBook v0.3.2](https://github.com/rust-lang/mdBook/blob/master/CHANGELOG.md#mdbook-032). Enable this would make sidebar a little bit clear.

This is just an enhancement. Feel free to close this PR if not it's not suitable.

![image](https://user-images.githubusercontent.com/14314532/68522059-21e60600-029f-11ea-93f1-59925e363e56.png)
