### PR TITLE
crates: fix suggested value for --crate-type flag

### DIFF
--- a/src/crates.md
+++ b/src/crates.md
@@ -9,4 +9,4 @@ individually, only crates get compiled.
 
 A crate can be compiled into a binary or into a library. By default, `rustc`
 will produce a binary from a crate. This behavior can be overridden by passing
-the `--crate-type` flag to `rustc`.
+the `--crate-type` flag to `lib`.


### PR DESCRIPTION
In order to compile to a library, suggest using `lib` instead of `rustc`, which is not a valid `--crate-type` value.