### PR TITLE
Fix typo

### DIFF
--- a/src/hello/print.md
+++ b/src/hello/print.md
@@ -6,7 +6,7 @@ some of which include:
 * `format!`: write formatted text to [`String`][string]
 * `print!`: same as `format!` but the text is printed to the console (io::stdout).
 * `println!`: same as `print!` but a newline is appended.
-* `eprint!`: same as `format!` but the text is printed to the standard error (io::stderr).
+* `eprint!`: same as `print!` but the text is printed to the standard error (io::stderr).
 * `eprintln!`: same as `eprint!`but a newline is appended.
 
 All parse text in the same fashion. As a plus, Rust checks formatting 


### PR DESCRIPTION
Small typo where `format!` was written instead of `print!`