### PR TITLE
Remove unnecessary lifetime annotation

### DIFF
--- a/src/trait/impl_trait.md
+++ b/src/trait/impl_trait.md
@@ -9,7 +9,7 @@ use std::vec::IntoIter;
 
 // This function combines two `Vec<i32>` and returns an iterator over it.
 // Look how complicated its return type is!
-fn combine_vecs_explicit_return_type<'a>(
+fn combine_vecs_explicit_return_type(
     v: Vec<i32>,
     u: Vec<i32>,
 ) -> iter::Cycle<iter::Chain<IntoIter<i32>, IntoIter<i32>>> {
@@ -18,11 +18,23 @@ fn combine_vecs_explicit_return_type<'a>(
 
 // This is the exact same function, but its return type uses `impl Trait`.
 // Look how much simpler it is!
-fn combine_vecs<'a>(
+fn combine_vecs(
     v: Vec<i32>,
     u: Vec<i32>,
 ) -> impl Iterator<Item=i32> {
     v.into_iter().chain(u.into_iter()).cycle()
+}
+
+fn main() {
+    let v1 = vec![1, 2, 3];
+    let v2 = vec![4, 5];
+    let mut v3 = combine_vecs(v1, v2);
+    assert_eq!(Some(1), v3.next());
+    assert_eq!(Some(2), v3.next());
+    assert_eq!(Some(3), v3.next());
+    assert_eq!(Some(4), v3.next());
+    assert_eq!(Some(5), v3.next());
+    println!("all done");
 }
 ```
 


### PR DESCRIPTION
The lifetime annotations aren't needed for these 2 functions. 

I tested the change by doing the following:

1. I ran `mdbook test`and all the tests passed
2. I ran `mdbook serve`, ran the code in the browser, and it worked well