### PR TITLE
eliminate the warnings

### DIFF
--- a/src/error/multiple_error_types/boxing_errors.md
+++ b/src/error/multiple_error_types/boxing_errors.md
@@ -13,7 +13,7 @@ use std::error;
 use std::fmt;
 
 // Change the alias to `Box<error::Error>`.
-type Result<T> = std::result::Result<T, Box<error::Error>>;
+type Result<T> = std::result::Result<T, Box<dyn error::Error>>;
 
 #[derive(Debug, Clone)]
 struct EmptyVec;
@@ -29,7 +29,7 @@ impl error::Error for EmptyVec {
         "invalid first item to double"
     }
 
-    fn cause(&self) -> Option<&error::Error> {
+    fn cause(&self) -> Option<&(dyn error::Error)> {
         // Generic error, underlying cause isn't tracked.
         None
     }


### PR DESCRIPTION
if there is no `dyn`, there are warnings like this:

>         warning: trait objects without an explicit `dyn` are deprecated
>         --> xxx.rs:5:45
>         |
>         5 | type Result<T> = std::result::Result<T, Box<error::Error>>;
>         |                                             ^^^^^^^^^^^^ help: use `dyn`: `dyn error::Error`
>         |
>         = note: `#[warn(bare_trait_objects)]` on by default
> 
>         warning: trait objects without an explicit `dyn` are deprecated
>         --> xxx.rs:21:32
>         |
>         21 |     fn cause(&self) -> Option<&error::Error> {
>         |                                ^^^^^^^^^^^^ help: use `dyn`: `dyn error::Error`