### PR TITLE
CamelCase -> UpperCamelCase

### DIFF
--- a/src/types/alias.md
+++ b/src/types/alias.md
@@ -1,7 +1,7 @@
 # Aliasing
 
 The `type` statement can be used to give a new name to an existing type. Types
-must have `CamelCase` names, or the compiler will raise a warning. The
+must have `UpperCamelCase` names, or the compiler will raise a warning. The
 exception to this rule are the primitive types: `usize`, `f32`, etc.
 
 ```rust,editable


### PR DESCRIPTION
The compiler will raise a warning unless it is UpperCamelCase. Since the warning is explicit about mentioning "upper", maybe the guide should be aswell?