### PR TITLE
Add missing `dyn` in code sample

### DIFF
--- a/src/error/multiple_error_types/reenter_question_mark.md
+++ b/src/error/multiple_error_types/reenter_question_mark.md
@@ -26,8 +26,8 @@ Here, we rewrite the previous example using `?`. As a result, the
 use std::error;
 use std::fmt;
 
-// Change the alias to `Box<error::Error>`.
-type Result<T> = std::result::Result<T, Box<error::Error>>;
+// Change the alias to `Box<dyn error::Error>`.
+type Result<T> = std::result::Result<T, Box<dyn error::Error>>;
 
 #[derive(Debug)]
 struct EmptyVec;


### PR DESCRIPTION
Hi, 

I recently read this book, and found it very useful. Thanks for writing it.

This PR fixes a warning by the compiler. I'm mostly submitting it as I found the missing `dyn` confusing when reading the book. Luckily the compiler complained about the exact same thing that confused me :)