### PR TITLE
Don't suggest Into implements a reverse conversion

### DIFF
--- a/src/conversion/from_into.md
+++ b/src/conversion/from_into.md
@@ -43,8 +43,8 @@ fn main() {
 ## `Into`
 
 The [`Into`] trait is simply the reciprocal of the `From` trait. That is, if you
-have implemented the `From` trait for your type you get the `Into`
-implementation for free.
+have implemented the `From` trait for your type, `Into` will call it when
+necessary.
 
 Using the `Into` trait will typically require specification of the type to
 convert into as the compiler is unable to determine this most of the time.


### PR DESCRIPTION
Current wording [could be misunderstood](https://users.rust-lang.org/t/confusing-messages-related-to-turbofish-operator/38337/3?u=kornel) as `Into` magically reversing the `From` implementation to add conversion the other way. This change clarifies that it's only a simple function call.


