### PR TITLE
Improve grammar in example of 'in let' section

### DIFF
--- a/src/flow_control/if_let.md
+++ b/src/flow_control/if_let.md
@@ -104,7 +104,7 @@ Another benefit is that `if let` allows us to match non-parameterized enum varia
 Would you like a challenge? Fix the following example to use `if let`:
 
 ```rust,editable,ignore,mdbook-runnable
-// This enum purposely neither implements nor derives PartialEq).
+// This enum purposely neither implements nor derives PartialEq.
 // That is why comparing Foo::Bar == a fails below.
 enum Foo {Bar}
 

--- a/src/flow_control/if_let.md
+++ b/src/flow_control/if_let.md
@@ -104,8 +104,8 @@ Another benefit is that `if let` allows us to match non-parameterized enum varia
 Would you like a challenge? Fix the following example to use `if let`:
 
 ```rust,editable,ignore,mdbook-runnable
-// This enum purposely doesn't #[derive(PartialEq)],
-// neither we implement PartialEq for it. That's why comparing Foo::Bar==a fails below.
+// This enum purposely neither implements nor derives PartialEq).
+// That is why comparing Foo::Bar == a fails below.
 enum Foo {Bar}
 
 fn main() {


### PR DESCRIPTION
Extends work done in #1305 to comments in the example code.