### PR TITLE
Fight the confusion over 'static

### DIFF
--- a/src/scope/lifetime/static_lifetime.md
+++ b/src/scope/lifetime/static_lifetime.md
@@ -1,15 +1,61 @@
 # Static
 
-A `'static` lifetime is the longest possible lifetime, and lasts for 
-the lifetime of the running program. A `'static` lifetime may also be 
-coerced to a shorter lifetime. There are two ways to make a variable 
-with `'static` lifetime, and both are stored in the read-only memory
-of the binary:
+`'static` is one of the reserved lifetime names. It has a special meaning
+in Rust. A __reference__ that has a `'static` lifetime is guaranteed to be 
+valid for the entire lifetime of the running program. 
+
+There are two ways to create data that lives for the entire lifetime of
+a program and both are stored in the read-only memory of the binary:
 
 * Make a constant with the `static` declaration.
 * Make a `string` literal which has type: `&'static str`.
 
-See the following example for a display of each method:
+__Warning__: It's easy to get confused about `'static` because all variable
+bindings that own their data, eg. do not contain references, fulfill a 
+bound on `'static`:
+
+```rust,editable,compile_fail
+use std::fmt::Debug;
+
+fn print_it( input: impl Debug + 'static )
+{
+    println!( "'static value passed in is: {:?}", input );
+}
+
+fn use_it()
+{
+    let i = 5;     // i is owned and contains no references, thus it's 'static
+    print_it( i ); // valid call
+    
+    // oops, &i only has the lifetime defined by the scope of 
+    // use_it(), so it's not 'static
+    print_it( &i ); 
+}
+```
+
+
+The compiler will tell you:
+```ignore
+error[E0597]: `i` does not live long enough
+  --> src/lib.rs:15:15
+   |
+15 |     print_it( &i ); 
+   |     ----------^^--
+   |     |         |
+   |     |         borrowed value does not live long enough
+   |     argument requires that `i` is borrowed for `'static`
+16 | }
+   | - `i` dropped here while still borrowed
+```
+
+A bound on `'static` means that the callee does not have to worry
+about their variable binding becoming invalid after some time.
+They can use it as long as they want. In contrast to a `'static` 
+__reference__, it is unrelated to the runtime of the entire program.
+
+A `'static` lifetime may also be coerced to a shorter lifetime. 
+
+See the following example for uses of `'static`:
 
 ```rust,editable
 // Make a constant with `'static` lifetime.

--- a/src/scope/lifetime/static_lifetime.md
+++ b/src/scope/lifetime/static_lifetime.md
@@ -1,6 +1,6 @@
 # Static
 
-`'static` is one of the reserved lifetime names. It has a special meaning
+`'static` is one of the reserved lifetime specifiers. It has a special meaning
 in Rust. A __reference__ that has a `'static` lifetime is guaranteed to be 
 valid for the entire lifetime of the running program. 
 
@@ -51,7 +51,7 @@ error[E0597]: `i` does not live long enough
 A bound on `'static` means that the callee does not have to worry
 about their variable binding becoming invalid after some time.
 They can use it as long as they want. In contrast to a `'static` 
-__reference__, it is unrelated to the runtime of the entire program.
+__reference__, this is unrelated to the runtime of the entire program.
 
 A `'static` lifetime may also be coerced to a shorter lifetime. 
 


### PR DESCRIPTION
Many people learning Rust are confused by the fact that owned values are `'static`. I feel the description here as well as in _the book_ are in part responsible for that. 

I hope that this change makes things a lot clearer. Note that I have intersected the explanation before the existing example because if It's underneath, it will 
be offscreen without scrolling. I kind of feel this is to important to be hidden offscreen, even if I tried to reformulate the original text to be more accurate.

I would propose we put this explanation in _the book_ as well, in the section about 'static lifetimes.

For an example of what can happen if people are confused about lifetime bounds (and use unsafe): https://github.com/libra/libra/pull/1949

ps: edited on Github, so I didn't run this through mdbook and doctests... but the example was verified on the playground.