### PR TITLE
Remove deprecated `std::error::Error` functions and other minor changes

### DIFF
--- a/src/error/multiple_error_types/boxing_errors.md
+++ b/src/error/multiple_error_types/boxing_errors.md
@@ -24,16 +24,7 @@ impl fmt::Display for EmptyVec {
     }
 }
 
-impl error::Error for EmptyVec {
-    fn description(&self) -> &str {
-        "invalid first item to double"
-    }
-
-    fn cause(&self) -> Option<&(dyn error::Error)> {
-        // Generic error, underlying cause isn't tracked.
-        None
-    }
-}
+impl error::Error for EmptyVec {}
 
 fn double_first(vec: Vec<&str>) -> Result<i32> {
     vec.first()

--- a/src/error/multiple_error_types/define_error_type.md
+++ b/src/error/multiple_error_types/define_error_type.md
@@ -16,7 +16,6 @@ Rust allows us to define our own error types. In general, a "good" error type:
 * Composes well with other errors
 
 ```rust,editable
-use std::error;
 use std::fmt;
 
 type Result<T> = std::result::Result<T, DoubleError>;
@@ -35,14 +34,6 @@ struct DoubleError;
 impl fmt::Display for DoubleError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         write!(f, "invalid first item to double")
-    }
-}
-
-// This is important for other errors to wrap this one.
-impl error::Error for DoubleError {
-    fn source(&self) -> Option<&(dyn error::Error + 'static)> {
-        // Generic error, underlying cause isn't tracked.
-        None
     }
 }
 

--- a/src/error/multiple_error_types/reenter_question_mark.md
+++ b/src/error/multiple_error_types/reenter_question_mark.md
@@ -38,16 +38,7 @@ impl fmt::Display for EmptyVec {
     }
 }
 
-impl error::Error for EmptyVec {
-    fn description(&self) -> &str {
-        "invalid first item to double"
-    }
-
-    fn cause(&self) -> Option<&error::Error> {
-        // Generic error, underlying cause isn't tracked.
-        None
-    }
-}
+impl error::Error for EmptyVec {}
 
 // The same structure as before but rather than chain all `Results`
 // and `Options` along, we `?` to get the inner value out immediately.

--- a/src/std_misc/file/create.md
+++ b/src/std_misc/file/create.md
@@ -14,24 +14,23 @@ cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non
 proident, sunt in culpa qui officia deserunt mollit anim id est laborum.
 ";
 
-use std::error::Error;
 use std::fs::File;
 use std::io::prelude::*;
 use std::path::Path;
 
 fn main() {
-    let path = Path::new("out/lorem_ipsum.txt");
+    let path = Path::new("lorem_ipsum.txt");
     let display = path.display();
 
     // Open a file in write-only mode, returns `io::Result<File>`
     let mut file = match File::create(&path) {
-        Err(why) => panic!("couldn't create {}: {}", display, why.description()),
+        Err(why) => panic!("couldn't create {}: {}", display, why),
         Ok(file) => file,
     };
 
     // Write the `LOREM_IPSUM` string to `file`, returns `io::Result<()>`
     match file.write_all(LOREM_IPSUM.as_bytes()) {
-        Err(why) => panic!("couldn't write to {}: {}", display, why.description()),
+        Err(why) => panic!("couldn't write to {}: {}", display, why),
         Ok(_) => println!("successfully wrote to {}", display),
     }
 }
@@ -40,10 +39,9 @@ fn main() {
 Here's the expected successful output:
 
 ```shell
-$ mkdir out
 $ rustc create.rs && ./create
-successfully wrote to out/lorem_ipsum.txt
-$ cat out/lorem_ipsum.txt
+successfully wrote to lorem_ipsum.txt
+$ cat lorem_ipsum.txt
 Lorem ipsum dolor sit amet, consectetur adipisicing elit, sed do eiusmod
 tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam,
 quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo

--- a/src/std_misc/file/open.md
+++ b/src/std_misc/file/open.md
@@ -6,7 +6,6 @@ A `File` owns a resource, the file descriptor and takes care of closing the
 file when it is `drop`ed.
 
 ```rust,editable,ignore
-use std::error::Error;
 use std::fs::File;
 use std::io::prelude::*;
 use std::path::Path;
@@ -18,24 +17,19 @@ fn main() {
 
     // Open the path in read-only mode, returns `io::Result<File>`
     let mut file = match File::open(&path) {
-        // The `description` method of `io::Error` returns a string that
-        // describes the error
-        Err(why) => panic!("couldn't open {}: {}", display,
-                                                   why.description()),
+        Err(why) => panic!("couldn't open {}: {}", display, why),
         Ok(file) => file,
     };
 
     // Read the file contents into a string, returns `io::Result<usize>`
     let mut s = String::new();
     match file.read_to_string(&mut s) {
-        Err(why) => panic!("couldn't read {}: {}", display,
-                                                   why.description()),
+        Err(why) => panic!("couldn't read {}: {}", display, why),
         Ok(_) => print!("{} contains:\n{}", display, s),
     }
 
     // `file` goes out of scope, and the "hello.txt" file gets closed
 }
-
 ```
 
 Here's the expected successful output:

--- a/src/std_misc/process/pipe.md
+++ b/src/std_misc/process/pipe.md
@@ -5,7 +5,6 @@ The `std::Child` struct represents a running child process, and exposes the
 process via pipes.
 
 ```rust,ignore
-use std::error::Error;
 use std::io::prelude::*;
 use std::process::{Command, Stdio};
 
@@ -18,7 +17,7 @@ fn main() {
                                 .stdin(Stdio::piped())
                                 .stdout(Stdio::piped())
                                 .spawn() {
-        Err(why) => panic!("couldn't spawn wc: {}", why.description()),
+        Err(why) => panic!("couldn't spawn wc: {}", why),
         Ok(process) => process,
     };
 
@@ -27,8 +26,7 @@ fn main() {
     // `stdin` has type `Option<ChildStdin>`, but since we know this instance
     // must have one, we can directly `unwrap` it.
     match process.stdin.unwrap().write_all(PANGRAM.as_bytes()) {
-        Err(why) => panic!("couldn't write to wc stdin: {}",
-                           why.description()),
+        Err(why) => panic!("couldn't write to wc stdin: {}", why),
         Ok(_) => println!("sent pangram to wc"),
     }
 
@@ -41,8 +39,7 @@ fn main() {
     // The `stdout` field also has type `Option<ChildStdout>` so must be unwrapped.
     let mut s = String::new();
     match process.stdout.unwrap().read_to_string(&mut s) {
-        Err(why) => panic!("couldn't read wc stdout: {}",
-                           why.description()),
+        Err(why) => panic!("couldn't read wc stdout: {}", why),
         Ok(_) => print!("wc responded with:\n{}", s),
     }
 }


### PR DESCRIPTION
This pull requests removes `std::error::Error::{cause,description}` as they are deprecated. Also, this PR contains these minor changes:
- change `Path::new("out/lorem_ipsum.txt");` to `Path::new("lorem_ipsum.txt");` in `src/std_misc/file/create.md` to be able to run the example on the [playground](https://play.rust-lang.org/)
- remove unnecessary `impl error::Error for ...`