### PR TITLE
fix: make spelling/style of rustdoc consistent

### DIFF
--- a/src/meta/doc.md
+++ b/src/meta/doc.md
@@ -9,7 +9,7 @@ These commands will appropriately invoke `rustdoc` (and `rustc`) as required.
 ### Doc comments
 
 Doc comments are very useful for big projects that require documentation. When
-running Rustdoc, these are the comments that get compiled into
+running `rustdoc`, these are the comments that get compiled into
 documentation. They are denoted by a `///`, and support [Markdown].
 
 ```rust,editable,ignore
@@ -32,7 +32,7 @@ impl Person {
     ///
     /// ```
     /// // You can have rust code between fences inside the comments
-    /// // If you pass --test to Rustdoc, it will even test it for you!
+    /// // If you pass --test to `rustdoc`, it will even test it for you!
     /// use doc::Person;
     /// let person = Person::new("name");
     /// ```
@@ -57,7 +57,7 @@ fn main() {
 }
 ```
 
-To run the tests, first build the code as a library, then tell rustdoc where
+To run the tests, first build the code as a library, then tell `rustdoc` where
 to find the library so it can link it into each doctest program:
 
 ```shell
@@ -68,7 +68,7 @@ $ rustdoc --test --extern doc="libdoc.rlib" doc.rs
 ### See also:
 
 * [The Rust Book: Making Useful Documentation Comments][book]
-* [The Rustdoc Book][rustdoc-book]
+* [The rustdoc Book][rustdoc-book]
 * [The Reference: Doc comments][ref-comments]
 * [RFC 1574: API Documentation Conventions][api-conv]
 * [RFC 1946: Relative links to other items from doc comments (intra-rustdoc links)][intra-links]


### PR DESCRIPTION
On the "[Documentation](https://doc.rust-lang.org/rust-by-example/meta/doc.html?highlight=rustdoc#doc-comments)" page, there is inconsistency for how "rustdoc" is spelled. 

There are three versions being used:
- Rustdoc
- rustdoc
- `rustdoc`

This PR fixes that by making them all `rustdoc` (where it makes sense) as part of #108 


