### PR TITLE
feat: add sentence about rustdoc & std library

### DIFF
--- a/src/meta/doc.md
+++ b/src/meta/doc.md
@@ -65,6 +65,8 @@ $ rustc doc.rs --crate-type lib
 $ rustdoc --test --extern doc="libdoc.rlib" doc.rs
 ```
 
+For documentation, `rustdoc` is widely used by the community. It's what is used to generate the [std library docs](https://doc.rust-lang.org/std/).
+
 ### See also:
 
 * [The Rust Book: Making Useful Documentation Comments][book]


### PR DESCRIPTION
One of the suggestions in #108 was mentioning:

> The std docs have been generated using rustdoc

The goal of the PR is to accomplish that by adding a short sentence to the "Documentation" topic in RBE. 