### PR TITLE
feat: add playpen topic

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,4 @@
 book
+
+# Auto-generated files from macOS
+.DS_Store

--- a/src/SUMMARY.md
+++ b/src/SUMMARY.md
@@ -213,3 +213,4 @@
 
 - [Meta](meta.md)
     - [Documentation](meta/doc.md)
+    - [Playpen](meta/playpen.md)

--- a/src/meta.md
+++ b/src/meta.md
@@ -4,9 +4,5 @@ Some topics aren't exactly relevant to how you program but provide you
 tooling or infrastructure support which just makes things better for
 everyone. These topics include:
 
-* Documentation: Generate library documentation for users via the included
-`rustdoc`.
-* Testing: Create testsuites for libraries to give confidence that your
-library does exactly what it's supposed to.
-* Benchmarking: Create benchmarks for functionality to be confident that
-they run quickly.
+- Documentation: Generate library documentation for users via the included
+  `rustdoc`.

--- a/src/meta.md
+++ b/src/meta.md
@@ -4,5 +4,7 @@ Some topics aren't exactly relevant to how you program but provide you
 tooling or infrastructure support which just makes things better for
 everyone. These topics include:
 
-- Documentation: Generate library documentation for users via the included
+- [Documentation][doc]: Generate library documentation for users via the included
   `rustdoc`.
+
+[doc]: meta/doc.md

--- a/src/meta.md
+++ b/src/meta.md
@@ -6,5 +6,7 @@ everyone. These topics include:
 
 - [Documentation][doc]: Generate library documentation for users via the included
   `rustdoc`.
+- [Playpen][playpen]: Integrate the Rust Playpen(also known as the Rust Playground) in your documentation.
 
 [doc]: meta/doc.md
+[playpen]: meta/playpen.md

--- a/src/meta/playpen.md
+++ b/src/meta/playpen.md
@@ -1,0 +1,38 @@
+# Playpen
+
+The [Rust Playpen](https://github.com/rust-lang/rust-playpen) is a way to experiment with Rust code through a web interface. This project is now commonly referred to as [Rust Playground](https://play.rust-lang.org/).
+
+## Using it with `mdbook`
+
+In [`mdbook`][mdbook], you can make code examples playable and editable.
+
+```rust,editable
+fn main() {
+    println!("Hello World!");
+}
+```
+
+This allows the reader to both run your code sample, but also modify and tweak it. The key here is the adding the word `editable` to your codefence block separated by a comma.
+
+````markdown
+```rust,editable
+//...place your code here
+```
+````
+
+## Using it with docs
+
+You may have noticed in some of the [official Rust docs][official-rust-docs] a button that says "Run", which opens the code sample up in a new tab in Rust Playground. This feature is enabled if you use the #[doc] attribute called [`html_playground_url`][html-playground-url].
+
+### See also:
+
+- [The Rust Playground][rust-playground]
+- [The next-gen playpen][next-gen-playpen]
+- [The rustdoc Book][rustdoc-book]
+
+[rust-playground]: https://play.rust-lang.org/
+[next-gen-playpen]: https://github.com/integer32llc/rust-playground/
+[mdbook]: https://github.com/rust-lang/mdBook
+[official-rust-docs]: https://doc.rust-lang.org/core/
+[rustdoc-book]: https://doc.rust-lang.org/rustdoc/what-is-rustdoc.html
+[html-playground-url]: https://doc.rust-lang.org/rustdoc/the-doc-attribute.html#html_playground_url


### PR DESCRIPTION
This PR accomplishes the last effort proposed in #108 

Specific changes:
- refactor the "Meta" page by removing Testing and Benchmarking 
- update the `.gitignore` to ignore `.DS_Store` files (macOS thing)
- add link to "Documentation" topic page from "Meta" page
- add a "Playpen" topic page
- add "Playpen" link to the "Meta" page

## Screenshots

Updated "Meta" page
<img width="1552" alt="image" src="https://user-images.githubusercontent.com/3806031/77828900-7ddcea00-70db-11ea-84f3-6999d0f3875b.png">

New "Playpen" page
![2020-03-28 10 04 47](https://user-images.githubusercontent.com/3806031/77828915-9a792200-70db-11ea-99db-b6231192086f.gif)
