### PR TITLE
Use T::MAX instead of std::T::MAX where T is an integer

### DIFF
--- a/src/types/cast.md
+++ b/src/types/cast.md
@@ -25,7 +25,7 @@ fn main() {
     println!("Casting: {} -> {} -> {}", decimal, integer, character);
 
     // when casting any value to an unsigned type, T,
-    // std::T::MAX + 1 is added or subtracted until the value
+    // T::MAX + 1 is added or subtracted until the value
     // fits into the new type
 
     // 1000 already fits in a u16


### PR DESCRIPTION
It's simpler (shorter) to access MIN/MAX directly on the integer types now. This repository only had a single instance of this, so the PR is tiny. But it's basically a follow up of rust-lang/rust#69860 to make all documentation consistently use the newest version of the constants.

r? @dtolnay