### PR TITLE
Improve the conversion example

### DIFF
--- a/src/conversion.md
+++ b/src/conversion.md
@@ -1,10 +1,14 @@
 # Conversion
 
-Rust addresses conversion between types by the use of [traits]. The generic
+Primitive types can be converted to each other through [casting].
+
+Rust addresses conversion between custom types (i.e., `struct` and `enum`)
+by the use of [traits]. The generic
 conversions will use the [`From`] and [`Into`] traits. However there are more
 specific ones for the more common cases, in particular when converting to and
 from `String`s.
 
+[casting]: types/cast.md
 [traits]: trait.md
 [`From`]: https://doc.rust-lang.org/std/convert/trait.From.html
 [`Into`]: https://doc.rust-lang.org/std/convert/trait.Into.html

--- a/src/types/cast.md
+++ b/src/types/cast.md
@@ -22,6 +22,10 @@ fn main() {
     let integer = decimal as u8;
     let character = integer as char;
 
+    // Error! There are limitations in conversion rules. A float cannot be directly converted to a char.
+    let character = decimal as char;
+    // FIXME ^ Comment out this line
+
     println!("Casting: {} -> {} -> {}", decimal, integer, character);
 
     // when casting any value to an unsigned type, T,


### PR DESCRIPTION
I added a sentence to the `conversion` chapter. It points the readers to the `types/cast` chapter if they want to convert between primitive types.

I also added an error example for `types/cast` to illustrate the limitations of primitive type casting.