### PR TITLE
Support GitHub Actions

### DIFF
--- a/.github/workflows/rbe.yml
+++ b/.github/workflows/rbe.yml
@@ -1,0 +1,33 @@
+name: Build and Publish
+
+on:
+  push:
+    branches: [ master ]
+  pull_request:
+    branches: [ master ]
+
+jobs:
+  build:
+
+    runs-on: ubuntu-latest
+
+    steps:
+    - uses: actions/checkout@v2
+      
+    - name: Install mdbook
+      run: cargo install mdbook
+      
+    - name: Build
+      run: mdbook build
+      
+    - name: Publish
+      uses: peaceiris/actions-gh-pages@v3
+      with:
+        github_token: ${{ secrets.GITHUB_TOKEN }}
+        publish_dir: ./book
+        
+    - name: Upload Artifact
+      uses: actions/upload-artifact@v1
+      with:
+        name: rust-by-example
+        path: book


### PR DESCRIPTION
Added GitHub Actions support for building and publishing the book. It automatically publishes to the `gh-pages` branch, and uploads a zip file for the entire book as built artifact. There are a few benefits for GitHub Actions:

1. The most current version of the book will always be available on github pages.

2. When people fork the repo, they can immediately edit it in GitHub and see the results on their own GitHub pages.