### PR TITLE
Capture example should use String

### DIFF
--- a/src/fn/closures/capture.md
+++ b/src/fn/closures/capture.md
@@ -16,7 +16,7 @@ required.
 fn main() {
     use std::mem;
     
-    let color = "green";
+    let color = String::from("green");
 
     // A closure to print `color` which immediately borrows (`&`) `color` and
     // stores the borrow and closure in the `print` variable. It will remain


### PR DESCRIPTION
Using a `&'static str` like "green" would not prevent us from using the closure `print` post the move. 

https://play.rust-lang.org/?version=stable&mode=debug&edition=2018&gist=411cb0b9776ece079c97d820ea6733ee