### PR TITLE
Fix possible typo

### DIFF
--- a/src/generics.md
+++ b/src/generics.md
@@ -58,7 +58,7 @@ fn main() {
 
 ### See also:
 
-[`struct`s][structs]
+[`structs`][structs]
 
 [structs]: custom_types/structs.md
 [camelcase]: https://en.wikipedia.org/wiki/CamelCase


### PR DESCRIPTION
I was reading the Generics page when I saw a typo and I thought I'd file a quick PR to fix.

I initially thought there might be a typo `struct`s -> `structs` as it seemed visually off. I thought about it further and realized that it might be intentional since `struct` is the keyword. Not too sure, feel free to close/merge as you see fit.