### PR TITLE
Ensure example error matches the comment

### DIFF
--- a/src/flow_control/match/destructuring/destructure_structures.md
+++ b/src/flow_control/match/destructuring/destructure_structures.md
@@ -22,7 +22,7 @@ fn main() {
         // and you can also ignore some variables:
         Foo { y, .. } => println!("y = {}, we don't care about x", y),
         // this will give an error: pattern does not mention field `x`
-        //Foo { y } => println!("y = {}", y);
+        //Foo { y } => println!("y = {}", y),
     }
 }
 ```


### PR DESCRIPTION
Replace the trailing semicolon with a comma, so that RLS raises an error about "pattern does not mention field `x`" instead of "expected one of `,`, `.`, `?`, `}`, or an operator, found `;`"