### PR TITLE
Clarify conditional compilation

### DIFF
--- a/src/attribute/cfg.md
+++ b/src/attribute/cfg.md
@@ -1,11 +1,13 @@
 # `cfg`
 
-Conditional compilation is possible through two different operators:
+Configuration conditional checks are possible through two different operators:
 
 * the `cfg` attribute: `#[cfg(...)]` in attribute position
 * the `cfg!` macro: `cfg!(...)` in boolean expressions
 
-Both utilize identical argument syntax.
+While the former enables conditional compilation, the latter conditionally
+evaluates to `true` or `false` literals allowing for checks at run-time. Both
+utilize identical argument syntax.
 
 ```rust,editable
 // This function only gets compiled if the target OS is linux
@@ -22,7 +24,7 @@ fn are_you_on_linux() {
 
 fn main() {
     are_you_on_linux();
-    
+
     println!("Are you sure?");
     if cfg!(target_os = "linux") {
         println!("Yes. It's definitely linux!");


### PR DESCRIPTION
Introduction of `cfg` attribute and `cfg!` macro operators can be confusing. `cfg!` macro and `cfg` attribute behave differently in terms of conditional compilation. While `cfg` attribute enables conditional compilation of some code, `cfg!` macro conditionally evaluates to `true` or `false` literals for run-time checks.