### PR TITLE
Add missing triple backticks

### DIFF
--- a/src/testing/doc_testing.md
+++ b/src/testing/doc_testing.md
@@ -89,6 +89,7 @@ to the rescue: one may write `fn try_main() -> Result<(), ErrorType>`, hide it a
 /// #    try_main().unwrap(); // calling try_main and unwrapping
 /// #                         // so that test will panic in case of error
 /// # }
+/// ```
 pub fn try_div(a: i32, b: i32) -> Result<i32, String> {
     if b == 0 {
         Err(String::from("Divide-by-zero"))


### PR DESCRIPTION
Ending tiple backticks are missing in the doc testing example. Add these
backticks.