### PR TITLE
Fix Example -> Examples

### DIFF
--- a/src/meta/doc.md
+++ b/src/meta/doc.md
@@ -28,7 +28,7 @@ impl Person {
     ///
     /// * `name` - A string slice that holds the name of the person
     ///
-    /// # Example
+    /// # Examples
     ///
     /// ```
     /// // You can have rust code between fences inside the comments


### PR DESCRIPTION
As suggested by RFC505, use the plural form: "Examples" rather than
"Example" even for one example.