### PR TITLE
Fix link of formatting traits

### DIFF
--- a/src/hello/print.md
+++ b/src/hello/print.md
@@ -89,6 +89,6 @@ and [`traits`][traits]
 [macros]: ../macros.md
 [string]: ../std/str.md
 [structs]: ../custom_types/structs.md
-[traits]: ../trait.md
+[traits]: https://doc.rust-lang.org/std/fmt/#formatting-traits
 [`ToString`]: https://doc.rust-lang.org/std/string/trait.ToString.html
 [convert]: ../conversion/string.md


### PR DESCRIPTION
According to the actual context (print formatting), the author probably wanted to reference the "formatting traits" instead of traits as a "collection of methods".