### PR TITLE
This explanation incorrectly inverts the meaning of SuperTrait

### DIFF
--- a/src/trait/supertraits.md
+++ b/src/trait/supertraits.md
@@ -8,7 +8,7 @@ trait Person {
     fn name(&self) -> String;
 }
 
-// Student is a supertrait of Person.
+// Person is a supertrait of Student.
 // Implementing Student requires you to also impl Person.
 trait Student: Person {
     fn university(&self) -> String;
@@ -18,8 +18,8 @@ trait Programmer {
     fn fav_language(&self) -> String;
 }
 
-// CompSciStudent (computer science student) is a supertrait of both Programmer 
-// and Student. Implementing CompSciStudent requires you to impl both subtraits.
+// CompSciStudent (computer science student) is a subtrait of both Programmer 
+// and Student. Implementing CompSciStudent requires you to impl both supertraits.
 trait CompSciStudent: Programmer + Student {
     fn git_username(&self) -> String;
 }


### PR DESCRIPTION
@AloeareV and I noted this discrepancy with the [Rust lang reference definition of Supetraits](https://doc.rust-lang.org/stable/reference/items/traits.html?highlight=SuperTrait#supertraits).

They can't both be correct, (they're inverted!) we prefer the language reference definition.