### PR TITLE
Modify supertraits sample code

### DIFF
--- a/src/trait/supertraits.md
+++ b/src/trait/supertraits.md
@@ -26,9 +26,10 @@ trait CompSciStudent: Programmer + Student {
 
 fn comp_sci_student_greeting(student: &dyn CompSciStudent) -> String {
     format!(
-        "My name is {} and I attend {}. My Git username is {}",
+        "My name is {} and I attend {}. My favorite language is {}. My Git username is {}",
         student.name(),
         student.university(),
+        student.fav_language(),
         student.git_username()
     )
 }


### PR DESCRIPTION
I think it makes more obvious that implementing supertrait of ```CompSciStudent``` requires implementing trait of ```Programmer```.