### PR TITLE
Add tuple `..` operator example

### DIFF
--- a/src/flow_control/match/destructuring/destructure_tuple.md
+++ b/src/flow_control/match/destructuring/destructure_tuple.md
@@ -4,15 +4,16 @@ Tuples can be destructured in a `match` as follows:
 
 ```rust,editable
 fn main() {
-    let pair = (0, -2);
-    // TODO ^ Try different values for `pair`
+    let triple = (0, -2, 3);
+    // TODO ^ Try different values for `triple`
 
-    println!("Tell me about {:?}", pair);
+    println!("Tell me about {:?}", triple);
     // Match can be used to destructure a tuple
-    match pair {
-        // Destructure the second
-        (0, y) => println!("First is `0` and `y` is `{:?}`", y),
-        (x, 0) => println!("`x` is `{:?}` and last is `0`", x),
+    match triple {
+        // Destructure the second and third elements
+        (0, y, z) => println!("First is `0`, `y` is {:?}, and `z` is {:?}", y, z),
+        (1, ..)  => println!("First is `1` and the rest doesn't matter"),
+        // `..` can be the used ignore the rest of the tuple
         _      => println!("It doesn't matter what they are"),
         // `_` means don't bind the value to a variable
     }


### PR DESCRIPTION
Modifies example to show off `..` operator for tuples.
Addresses #1364.