### PR TITLE
Split out variable shadowing into a separate example

### DIFF
--- a/src/variable_bindings/scope.md
+++ b/src/variable_bindings/scope.md
@@ -1,9 +1,7 @@
 # Scope and Shadowing
 
 Variable bindings have a scope, and are constrained to live in a *block*. A
-block is a collection of statements enclosed by braces `{}`. Also, [variable
-shadowing][variable-shadow] is allowed.
-
+block is a collection of statements enclosed by braces `{}`. 
 ```rust,editable,ignore,mdbook-runnable
 fn main() {
     // This binding lives in the main function
@@ -15,11 +13,6 @@ fn main() {
         let short_lived_binding = 2;
 
         println!("inner short: {}", short_lived_binding);
-
-        // This binding *shadows* the outer one
-        let long_lived_binding = 5_f32;
-
-        println!("inner long: {}", long_lived_binding);
     }
     // End of the block
 
@@ -28,12 +21,23 @@ fn main() {
     // FIXME ^ Comment out this line
 
     println!("outer long: {}", long_lived_binding);
-    
-    // This binding also *shadows* the previous binding
-    let long_lived_binding = 'a';
-    
-    println!("outer long: {}", long_lived_binding);
 }
 ```
+Also, a binding may have the same name as a binding from an outer block. This is
+known as [variable shadowing][variable-shadow].
+```rust,editable,ignore,mdbook-runnable
+fn main() {
+    let shadowed_binding = 1;
 
+    {
+        println!("before being shadowed: {}", shadowed_binding);
+
+        // This binding *shadows* the outer one
+        let shadowed_binding = "a";
+
+        println!("after being shadowed: {}", shadowed_binding);
+    }
+
+}
+```
 [variable-shadow]: https://en.wikipedia.org/wiki/Variable_shadowing

--- a/src/variable_bindings/scope.md
+++ b/src/variable_bindings/scope.md
@@ -23,8 +23,7 @@ fn main() {
     println!("outer long: {}", long_lived_binding);
 }
 ```
-Also, a binding may have the same name as a binding from an outer block. This is
-known as [variable shadowing][variable-shadow].
+Also, [variable shadowing][variable-shadow] is allowed.
 ```rust,editable,ignore,mdbook-runnable
 fn main() {
     let shadowed_binding = 1;
@@ -33,11 +32,15 @@ fn main() {
         println!("before being shadowed: {}", shadowed_binding);
 
         // This binding *shadows* the outer one
-        let shadowed_binding = "a";
+        let shadowed_binding = "abc";
 
-        println!("after being shadowed: {}", shadowed_binding);
+        println!("shadowed in inner block: {}", shadowed_binding);
     }
+    println!("outside inner block: {}", shadowed_binding);
 
+    // This binding *shadows* the previous binding
+    let shadowed_binding = 2;
+    println!("shadowed in outer block: {}", shadowed_binding);
 }
 ```
 [variable-shadow]: https://en.wikipedia.org/wiki/Variable_shadowing


### PR DESCRIPTION
This PR addresses #1271.

The current example for scoping and variable shadowing is really two examples interleaved together.
In my opinion, the less there is to keep track of when examples are read linearly from top to bottom, the easier it is to read and understand. Therefore, this PR splits out shadowing into its own example.

