### PR TITLE
Add partial moves example for `move_ref_pattern` stabilization

### DIFF
--- a/src/SUMMARY.md
+++ b/src/SUMMARY.md
@@ -116,6 +116,7 @@
     - [RAII](scope/raii.md)
     - [Ownership and moves](scope/move.md)
         - [Mutability](scope/move/mut.md)
+        - [Partial moves](scope/move/partial_move.md)
     - [Borrowing](scope/borrow.md)
         - [Mutability](scope/borrow/mut.md)
         - [Aliasing](scope/borrow/alias.md)

--- a/src/scope/move/partial_move.md
+++ b/src/scope/move/partial_move.md
@@ -1,0 +1,40 @@
+# Partial moves
+
+Pattern bindings can have `by-move` and `by-reference` bindings at
+the same time which is used in [destructuring]. Using these pattern
+will result in partial move for the variable, which means that part
+of the variable is moved while other parts stayed. In this case, the
+parent variable cannot be used afterwards as a whole. However, parts
+of it that are referenced and not moved can be used.
+
+```rust,editable
+fn main() {
+    #[derive(Debug)]
+    struct Person {
+        name: String,
+        age: u8,
+    }
+
+    let person = Person {
+        name: String::from("Alice"),
+        age: 20,
+    };
+
+    // `name` is moved out of person, but `age` is referenced
+    let Person { name, ref age } = person;
+
+    println!("The person's age is {}", age);
+
+    println!("The person's name is {}", name);
+
+    // Error! borrow of partially moved value: `person` partial move occurs
+    //println!("The person struct is {:?}", person);
+
+    // `person` cannot be used but `person.age` can be used as it is not moved
+    println!("The person's age from person struct is {}", person.age);
+}
+```
+### See also:
+[destructuring][destructuring]
+
+[destructuring]: ../../flow_control/match/destructuring.md


### PR DESCRIPTION
Documenting the *Partial move* pattern, which occurs when binding by ref and moving at the same time.

This is for stabilizing `move_ref_pattern` feature. (see rust-lang/rust#76049)

This is waiting for the stabilizing PR to be merged