### PR TITLE
Clone.md comment and variable name change

### DIFF
--- a/src/trait/clone.md
+++ b/src/trait/clone.md
@@ -30,9 +30,9 @@ fn main() {
     let pair = Pair(Box::new(1), Box::new(2));
     println!("original: {:?}", pair);
 
-    // Copy `pair` into `moved_pair`, moves resources
+    // Move `pair` into `moved_pair`, moves resources
     let moved_pair = pair;
-    println!("copy: {:?}", moved_pair);
+    println!("moved: {:?}", moved_pair);
 
     // Error! `pair` has lost its resources
     //println!("original: {:?}", pair);


### PR DESCRIPTION
If I understand this correctly, moved_pair is not a copy, as Pair does not implement Copy, it is a move. Perhaps 'copy' is used in the comment and name because of the similar example in lines 22-23 above, where there is an actual copy.