### PR TITLE
Add missing main function in static life time example.

### DIFF
--- a/src/scope/lifetime/static_lifetime.md
+++ b/src/scope/lifetime/static_lifetime.md
@@ -75,13 +75,11 @@ does not:
 ```rust,editable,compile_fail
 use std::fmt::Debug;
 
-fn print_it( input: impl Debug + 'static )
-{
+fn print_it( input: impl Debug + 'static ) {
     println!( "'static value passed in is: {:?}", input );
 }
 
-fn use_it()
-{
+fn main() {
     // i is owned and contains no references, thus it's 'static:
     let i = 5;
     print_it(i);


### PR DESCRIPTION
Hi everyone, I just realized that the static lifetime trait bound example mentions a specific compiler error but if the example is compiled through the playground  this is not shown as the example misses a `main` function. I therefore renamed the function `use_it` into `main` to ensure the expected error message appears.

Is this the expected solution? If not feel free to nitpick and I am going to adjust the commit based on your requests.