### PR TITLE
Minor grammar suggestion

### DIFF
--- a/src/hello/print/print_debug.md
+++ b/src/hello/print/print_debug.md
@@ -20,7 +20,7 @@ struct UnPrintable(i32);
 struct DebugPrintable(i32);
 ```
 
-All `std` library types automatically are printable with `{:?}` too:
+All `std` library types are automatically printable with `{:?}` too:
 
 ```rust,editable
 // Derive the `fmt::Debug` implementation for `Structure`. `Structure`


### PR DESCRIPTION
Adverbs follow the verb _to be_ and all auxiliary verbs.