### PR TITLE
Fix some markdown lint warnings

### DIFF
--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -11,12 +11,11 @@ A version of this document [can be found online](https://www.rust-lang.org/condu
 * Please be kind and courteous. There's no need to be mean or rude.
 * Respect that people have differences of opinion and that every design or implementation choice carries a trade-off and numerous costs. There is seldom a right answer.
 * Please keep unstructured critique to a minimum. If you have solid ideas you want to experiment with, make a fork and see how it works.
-* We will exclude you from interaction if you insult, demean or harass anyone. That is not welcome behavior. We interpret the term "harassment" as including the definition in the <a href="http://citizencodeofconduct.org/">Citizen Code of Conduct</a>; if you have any lack of clarity about what might be included in that concept, please read their definition. In particular, we don't tolerate behavior that excludes people in socially marginalized groups.
+* We will exclude you from interaction if you insult, demean or harass anyone. That is not welcome behavior. We interpret the term "harassment" as including the definition in the [Citizen Code of Conduct](http://citizencodeofconduct.org/); if you have any lack of clarity about what might be included in that concept, please read their definition. In particular, we don't tolerate behavior that excludes people in socially marginalized groups.
 * Private harassment is also unacceptable. No matter who you are, if you feel you have been or are being harassed or made uncomfortable by a community member, please contact one of the channel ops or any of the [Rust moderation team][mod_team] immediately. Whether you're a regular contributor or a newcomer, we care about making this community a safe place for you and we've got your back.
 * Likewise any spamming, trolling, flaming, baiting or other attention-stealing behavior is not welcome.
 
 ## Moderation
-
 
 These are the policies for upholding our community's standards of conduct. If you feel that a thread needs moderation, please contact the [Rust moderation team][mod_team].
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -27,7 +27,6 @@ If you make additions or other changes to a pull request, feel free to either am
 previous commits or only add new ones, however you prefer. We may ask you to squash
 your commits before merging, depending.
 
-
 ## Issue Tracker
 
 You can find the issue tracker [on

--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ Learn Rust with examples (Live code editor included)
 
 ## Using
 
-If you'd like to read Rust by Example, you can visit https://doc.rust-lang.org/rust-by-example/
+If you'd like to read Rust by Example, you can visit <https://doc.rust-lang.org/rust-by-example/>
 to read it online.
 
 If you'd like to read it locally, [install Rust], and then:
@@ -44,10 +44,10 @@ Please see the [CONTRIBUTING.md] file for more details.
 
 Rust by Example is licensed under either of
 
- * Apache License, Version 2.0, ([LICENSE-APACHE](LICENSE-APACHE) or
-   http://www.apache.org/licenses/LICENSE-2.0)
- * MIT license ([LICENSE-MIT](LICENSE-MIT) or
-   http://opensource.org/licenses/MIT)
+* Apache License, Version 2.0, ([LICENSE-APACHE](LICENSE-APACHE) or
+  <http://www.apache.org/licenses/LICENSE-2.0>)
+* MIT license ([LICENSE-MIT](LICENSE-MIT) or
+  <http://opensource.org/licenses/MIT>)
 
 at your option.
 

--- a/src/custom_types/structs.md
+++ b/src/custom_types/structs.md
@@ -88,9 +88,11 @@ fn main() {
 
 1. Add a function `rect_area` which calculates the area of a rectangle (try
    using nested destructuring).
-2. Add a function `square` which takes a `Point` and a `f32` as arguments, and returns a `Rectangle` with its lower left corner on the point, and a width and height corresponding to the `f32`.
+2. Add a function `square` which takes a `Point` and a `f32` as arguments, and
+   returns a `Rectangle` with its lower left corner on the point, and a width and
+   height corresponding to the `f32`.
 
-### See also:
+### See also
 
 [`attributes`][attributes], and [destructuring][destructuring]
 


### PR DESCRIPTION
On README.md, CODE_OF_CONDUCT.md and CONTRIBUTING.md