### PR TITLE
Moved "See also" link to the correct page.

### DIFF
--- a/src/flow_control/match/destructuring/destructure_pointers.md
+++ b/src/flow_control/match/destructuring/destructure_pointers.md
@@ -59,3 +59,7 @@ fn main() {
     }
 }
 ```
+
+### See also:
+
+[The ref pattern](../../../scope/borrow/ref.md)

--- a/src/flow_control/match/destructuring/destructure_structures.md
+++ b/src/flow_control/match/destructuring/destructure_structures.md
@@ -29,4 +29,4 @@ fn main() {
 
 ### See also:
 
-[Structs](../../../custom_types/structs.md), [The ref pattern](../../../scope/borrow/ref.md)
+[Structs](../../../custom_types/structs.md)


### PR DESCRIPTION
The "8.5.1.3. pointers/ref" code example contains multiple usages of the
ref pattern, however no link to it is included in the "See also" section
at the end of the page (the section is missing). In the next page,
"8.5.1.4. structs", the code example contains no usage of the ref
pattern, however its "See also" section contains a link to it. This
commit moves the ref pattern link to the previous page: "8.5.1.3.
pointers/ref" to remedy the problem.