### PR TITLE
Drop extern crate

### DIFF
--- a/src/cargo/deps.md
+++ b/src/cargo/deps.md
@@ -56,8 +56,7 @@ lots of great packages on [crates.io](https://crates.io) (the official Rust
 package registry). One popular choice is [clap](https://crates.io/crates/clap).
 As of this writing, the most recent published version of `clap` is `2.27.1`. To
 add a dependency to our program, we can simply add the following to our
-`Cargo.toml` under `[dependencies]`: `clap = "2.27.1"`.  And of course, `extern
-crate clap` in `main.rs`, just like normal. And that's it! You can start using
+`Cargo.toml` under `[dependencies]`: `clap = "2.27.1"`. And that's it! You can start using
 `clap` in your program.
 
 `cargo` also supports [other types of dependencies][dependencies]. Here is just


### PR DESCRIPTION
Hello,

I'm pretty new to Rust so apologize in advaced if Im wrong. Since version 2018, it is not longer required to use extern crate. This is similar to 
[Issue 1358](https://github.com/rust-lang/rust-by-example/issues/1358)

