### PR TITLE
Clarify distinction between for iter and into_iter

### DIFF
--- a/src/flow_control/for.md
+++ b/src/flow_control/for.md
@@ -67,9 +67,12 @@ fn main() {
     for name in names.iter() {
         match name {
             &"Ferris" => println!("There is a rustacean among us!"),
+            // TODO ^ Try deleting the & and matching just "Ferris"
             _ => println!("Hello {}", name),
         }
     }
+    
+    println!("names: {:?}", names);
 }
 ```
 
@@ -87,6 +90,9 @@ fn main() {
             _ => println!("Hello {}", name),
         }
     }
+    
+    println!("names: {:?}", names);
+    // FIXME ^ Comment out this line
 }
 ```
 

--- a/src/flow_control/for.md
+++ b/src/flow_control/for.md
@@ -80,7 +80,7 @@ fn main() {
   data is provided. Once the collection has been consumed it is no longer
   available for reuse as it has been 'moved' within the loop.
 
-```rust, editable
+```rust, editable, ignore
 fn main() {
     let names = vec!["Bob", "Frank", "Ferris"];
 


### PR DESCRIPTION
The existing code examples for `for iter` and `for into_iter` don't make the distinction very clear to the user. 

Although this is explained at the end, allowing the user to experiment with the match types and showing how the collection gets consumed in `into_iter` but not in `iter` would help them understand better.