### PR TITLE
Clarify first matching arm and all possible values

### DIFF
--- a/src/flow_control/match.md
+++ b/src/flow_control/match.md
@@ -1,7 +1,8 @@
 # match
 
 Rust provides pattern matching via the `match` keyword, which can be used like
-a C `switch`.
+a C `switch`. The first matching arm is evaluated and all possible values must be
+covered.
 
 ```rust,editable
 fn main() {
@@ -14,10 +15,12 @@ fn main() {
         1 => println!("One!"),
         // Match several values
         2 | 3 | 5 | 7 | 11 => println!("This is a prime"),
+        // TODO ^ Try adding 13 to the list of prime values
         // Match an inclusive range
         13..=19 => println!("A teen"),
         // Handle the rest of cases
         _ => println!("Ain't special"),
+        // TODO ^ Try commenting out this catch-all arm
     }
 
     let boolean = true;


### PR DESCRIPTION
The point that the first matching arm is evaluated must be made in the text. Prompt the user to add `13` to the list of primes to demonstrate this in action.

The importance of the catch-all expression `_` would be more clear once the user tries commenting it out.