### PR TITLE
Add book.description in book.toml

### DIFF
--- a/book.toml
+++ b/book.toml
@@ -1,6 +1,6 @@
 [book]
 title = "Rust By Example"
-description = "A description"
+description = "Rust by Example (RBE) is a collection of runnable examples that illustrate various Rust concepts and standard libraries."
 author = "The Rust Community"
 
 [output.html.playpen]


### PR DESCRIPTION
`book.description` value in book.toml provides nice HTML document metadata. 

Ref: https://github.com/rust-lang/mdBook/blob/8e673c9/src/theme/index.hbs#L12



Current description is not even useful 😂

<img width="356" alt="image" src="https://user-images.githubusercontent.com/14314532/102803326-0c746280-43f3-11eb-8479-2607be635d14.png">
