### PR TITLE
Add note for match guards to include catch-all

### DIFF
--- a/src/flow_control/match/guard.md
+++ b/src/flow_control/match/guard.md
@@ -18,6 +18,22 @@ fn main() {
 }
 ```
 
+Note that the compiler does not check arbitrary expressions for whether all
+possible conditions have been checked.  Therefore, you must use the `_` pattern
+at the end.
+
+```rust,editable
+fn main() {
+    let number: u8 = 4;
+
+    match number {
+        i if i == 0 => println!("Zero"),
+        i if i > 0 => println!("Greater than zero"),
+        _ => println!("Fell through"), // This should not be possible to reach
+    }
+}
+```
+
 ### See also:
 
 [Tuples](../../primitives/tuples.md)


### PR DESCRIPTION
The compiler doesn't check for conditions being exhausted when using arbitrary expressions (https://github.com/rust-lang/rust/issues/74277).  This adds a note with example specifying that you need to cover all remaining conditions with `_`.

My main concern is that my example may encourage people to use match guards as I did there, instead of something like:

```rust
    match number {
        0 => println!("Zero"),
        1..=u8::MAX => println!("Greater than zero"),
    }
```

Also, maybe I should just add this as a note without an example?