### PR TITLE
Update mdbook

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -10,7 +10,7 @@ before_script:
     set -ex
     rustup --version
     rustc -Vv
-    curl -sSL https://github.com/rust-lang/mdBook/releases/download/v0.3.7/mdbook-v0.3.7-x86_64-unknown-linux-gnu.tar.gz | tar -xz --directory=$HOME/.cargo/bin
+    curl -sSL https://github.com/rust-lang/mdBook/releases/download/v0.4.5/mdbook-v0.4.5-x86_64-unknown-linux-gnu.tar.gz | tar -xz --directory=$HOME/.cargo/bin
     mdbook --version
     rustup toolchain update nightly -c rust-docs
 script:


### PR DESCRIPTION
- Changelog to 0.4.5: https://github.com/rust-lang/mdBook/blob/master/CHANGELOG.md#mdbook-045)
- mdbook security advisory: https://blog.rust-lang.org/2021/01/04/mdbook-security-advisory.html

Some breaking changes were introduced in 0.4.0 but I skimmed RBD built by 0.4.5 and no regression detected.