### PR TITLE
Fix for.md to use mdbook-runnable on ignored example

### DIFF
--- a/src/flow_control/for.md
+++ b/src/flow_control/for.md
@@ -80,7 +80,7 @@ fn main() {
   data is provided. Once the collection has been consumed it is no longer
   available for reuse as it has been 'moved' within the loop.
 
-```rust, editable, ignore
+```rust, editable, ignore, mdbook-runnable
 fn main() {
     let names = vec!["Bob", "Frank", "Ferris"];
 


### PR DESCRIPTION
Without this the user cannot run the example even after addressing the FIXME