### PR TITLE
Update function name in comment

### DIFF
--- a/src/scope/lifetime/static_lifetime.md
+++ b/src/scope/lifetime/static_lifetime.md
@@ -85,7 +85,7 @@ fn main() {
     print_it(i);
 
     // oops, &i only has the lifetime defined by the scope of
-    // use_it(), so it's not 'static:
+    // main(), so it's not 'static:
     print_it(&i);
 }
 ```


### PR DESCRIPTION
A minor nitpick: a function in the static lifetime example code was renamed from `use_it` to `main` in https://github.com/rust-lang/rust-by-example/pull/1383 but a comment mentioning the function just a couple of lines below it was not updated.