### PR TITLE
Make flow_control/for/.into_iter() example run

### DIFF
--- a/src/flow_control/for.md
+++ b/src/flow_control/for.md
@@ -60,7 +60,7 @@ within.
 * `iter` - This borrows each element of the collection through each iteration.
   Thus leaving the collection untouched and available for reuse after the loop.
 
-```rust, editable
+```rust,editable
 fn main() {
     let names = vec!["Bob", "Frank", "Ferris"];
 
@@ -80,7 +80,7 @@ fn main() {
   data is provided. Once the collection has been consumed it is no longer
   available for reuse as it has been 'moved' within the loop.
 
-```rust, editable, ignore
+```rust,editable,ignore,mdbook-runnable
 fn main() {
     let names = vec!["Bob", "Frank", "Ferris"];
 
@@ -99,7 +99,7 @@ fn main() {
 * `iter_mut` - This mutably borrows each element of the collection, allowing for
   the collection to be modified in place.
 
-```rust, editable
+```rust,editable
 fn main() {
     let mut names = vec!["Bob", "Frank", "Ferris"];
 


### PR DESCRIPTION
For: `https://doc.rust-lang.org/rust-by-example/flow_control/for.html`,
the example containing `.into_iter()` the suggestion is to comment the
line trying to print the vector, after move. This code throws compilation
error.
In order to fix this, commit `4cc85655b97be83acbca5d036cf679f39ea66eb8`
has been introduced. This indeed makes the example pass the tests, but
disables the run option. Now, if I want to learn, I need to copy paste
the example in my own editor and compile it, rather than being able to
click run, comment as suggested and click run again.

This commit fixes this issue.
Alongside, it makes the style of playpen attributes consistent with the
rest of the book (majority, seems `rust,editable` is preferred over
`rust, editable`).