### PR TITLE
Add destructuring example to generics new type

### DIFF
--- a/src/generics/new_types.md
+++ b/src/generics/new_types.md
@@ -40,13 +40,14 @@ fn main() {
 
 Uncomment the last print statement to observe that the type supplied must be `Years`.
 
-To obtain the `newtype`'s value as the base type, you may use tuple syntax like so:
+To obtain the `newtype`'s value as the base type, you may use the tuple or destructuring syntax like so:
 ```rust, editable
 struct Years(i64);
 
 fn main() {
     let years = Years(42);
-    let years_as_primitive: i64 = years.0;
+    let years_as_primitive_1: i64 = years.0; // Tuple
+    let Years(years_as_primitive_2) = years; // Destructuring
 }
 ```
 


### PR DESCRIPTION
Would be great to have both examples so new users can get to know the other way to do it.