### PR TITLE
Replace the "among us" reference with "here"

### DIFF
--- a/src/flow_control/for.md
+++ b/src/flow_control/for.md
@@ -66,7 +66,7 @@ fn main() {
 
     for name in names.iter() {
         match name {
-            &"Ferris" => println!("There is a rustacean among us!"),
+            &"Ferris" => println!("There is a rustacean here!"),
             // TODO ^ Try deleting the & and matching just "Ferris"
             _ => println!("Hello {}", name),
         }
@@ -86,7 +86,7 @@ fn main() {
 
     for name in names.into_iter() {
         match name {
-            "Ferris" => println!("There is a rustacean among us!"),
+            "Ferris" => println!("There is a rustacean here!"),
             _ => println!("Hello {}", name),
         }
     }
@@ -105,7 +105,7 @@ fn main() {
 
     for name in names.iter_mut() {
         *name = match name {
-            &mut "Ferris" => "There is a rustacean among us!",
+            &mut "Ferris" => "There is a rustacean here!",
             _ => "Hello",
         }
     }


### PR DESCRIPTION
I can't fucking take it. I see an image of a random object posted and then I see it, I fucking see it. "Oh that looks kinda like the among us guy" it started as. That's funny, that's a cool reference. But I kept going, I'd see a fridge that looked like among us, I'd see an animated bag of chips that looked like among us, I'd see a hat that looked like among us. And every time I'd burst into an insane, breath deprived laugh staring at the image as the words AMOGUS ran through my head. It's torment, psychological torture, I am being conditioned to laugh maniacly any time I see an oval on a red object. I can't fucking live like this... I can't I can't I can't I can't I can't! And don't get me fucking started on the words! I'll never hear the word suspicious again without thinking of among us. Someone does something bad and I can't say anything other than "sus." I could watch a man murder everyone I love and all I would be able to say is "red sus" and laugh like a fucking insane person. And the word "among" is ruined. The phrase "among us" is ruined. I can't live anymore. Among us has destroyed my fucking life. I want to eject myself from this plane of existence. MAKE IT STOP!

![Sus](https://i.kym-cdn.com/entries/icons/original/000/031/671/cover1.jpg)