### PR TITLE
fix name from rectangle to Rectangle

### DIFF
--- a/src/custom_types/structs.md
+++ b/src/custom_types/structs.md
@@ -86,7 +86,7 @@ fn main() {
 
 ### Activity
 
-1. Add a function `rect_area` which calculates the area of a rectangle (try
+1. Add a function `rect_area` which calculates the area of a `Rectangle` (try
    using nested destructuring).
 2. Add a function `square` which takes a `Point` and a `f32` as arguments, and
    returns a `Rectangle` with its lower left corner on the point, and a width and


### PR DESCRIPTION
rectangle is not defined in sample code.

it is seems `Rectangle` or `_rectangle`. but `_rectangle` is variable name. Struct name better than variable name.