### PR TITLE
fix: HashSet::insert() an already present value example code

### DIFF
--- a/src/std/hash/hashset.md
+++ b/src/std/hash/hashset.md
@@ -44,8 +44,9 @@ fn main() {
 
     // `HashSet::insert()` returns false if
     // there was a value already present.
-    assert!(b.insert(4), "Value 4 is already in set B!");
-    // FIXME ^ Comment out this line
+    if !b.insert(4) {
+      println!("Value 4 is already in set B!");
+    }
 
     b.insert(5);
 


### PR DESCRIPTION
example code: use  if to judge insert result, no panic!