### PR TITLE
fix compile bug with panic!

### DIFF
--- a/src/std/result/question_mark.md
+++ b/src/std/result/question_mark.md
@@ -54,7 +54,7 @@ mod checked {
 
     pub fn op(x: f64, y: f64) {
         match op_(x, y) {
-            Err(why) => panic!(match why {
+            Err(why) => panic!("{}", match why {
                 MathError::NonPositiveLogarithm
                     => "logarithm of non-positive number",
                 MathError::DivisionByZero


### PR DESCRIPTION
in [question_mark](https://doc.rust-lang.org/rust-by-example/std/result/question_mark.html) article
```bash
 Compiling playground v0.0.1 (/playground)
warning: panic message is not a string literal
  --> src/main.rs:48:32
   |
48 |               Err(why) => panic!(match why {
   |  ________________________________^
49 | |                 MathError::NonPositiveLogarithm
50 | |                     => "logarithm of non-positive number",
51 | |                 MathError::DivisionByZero
...  |
54 | |                     => "square root of negative number",
55 | |             }),
   | |_____________^
   |
   = note: `#[warn(non_fmt_panic)]` on by default
   = note: this is no longer accepted in Rust 2021
help: add a "{}" format string to Display the message
   |
48 |             Err(why) => panic!("{}", match why {
   |                                ^^^^^
help: or use std::panic::panic_any instead
   |
48 |             Err(why) => std::panic::panic_any(match why {
   |                         ^^^^^^^^^^^^^^^^^^^^^^

warning: 1 warning emitted

    Finished dev [unoptimized + debuginfo] target(s) in 1.46s
     Running `target/debug/playground`
thread 'main' panicked at 'square root of negative number', src/main.rs:48:25
note: run with `RUST_BACKTRACE=1` environment variable to display a backtrace
```