### PR TITLE
Fix Typo in LRBE section; closes #1434

### DIFF
--- a/src/hello/print.md
+++ b/src/hello/print.md
@@ -39,7 +39,7 @@ fn main() {
     println!("{number:>width$}", number=1, width=6);
 
     // You can pad numbers with extra zeroes. This will output "000001".
-    println!("{number:>0width$}", number=1, width=6);
+    println!("{number:0>width$}", number=1, width=6);
 
     // Rust even checks to make sure the correct number of arguments are
     // used.


### PR DESCRIPTION
Howdy,

This PR changes line 42 from:
```rust
println!("{number:>0width$}", number=1, width=6);
```
to:
```rust
println!("{number:0>width$}", number=1, width=6);
```

As per #1434 and https://doc.rust-lang.org/std/fmt/

Best,
Mautamu