### PR TITLE
std_misc/path.md: update `Show` to `Display`

### DIFF
--- a/src/std_misc/path.md
+++ b/src/std_misc/path.md
@@ -19,7 +19,7 @@ fn main() {
     // Create a `Path` from an `&'static str`
     let path = Path::new(".");
 
-    // The `display` method returns a `Show`able structure
+    // The `display` method returns a `Display`able structure
     let _display = path.display();
 
     // `join` merges a path with a byte container using the OS specific


### PR DESCRIPTION
Hello!

Is `Show` is the old name of `Display` before 1.0? I just noticed this while reading the book.
Feel free to discard this PR if this is intended. Thanks!