### PR TITLE
Grammatical mistake: Comparison as ... as the

### DIFF
--- a/src/conversion/string.md
+++ b/src/conversion/string.md
@@ -33,7 +33,7 @@ approach to this is to use the [`parse`] function and either to arrange for
 type inference or to specify the type to parse using the 'turbofish' syntax.
 Both alternatives are shown in the following example.
 
-This will convert the string into the type specified so long as the [`FromStr`]
+This will convert the string into the type specified so as long as the [`FromStr`]
 trait is implemented for that type. This is implemented for numerous types
 within the standard library. To obtain this functionality on a user defined type
 simply implement the [`FromStr`] trait for that type.


### PR DESCRIPTION
The sentence: This will convert the string into the type specified **so long as the** [`FromStr`]
trait is implemented for that type.
Misses an _as_: so **as long as the**
Thank you!