### PR TITLE
Fix link to "integration testing" page

### DIFF
--- a/src/cargo/test.md
+++ b/src/cargo/test.md
@@ -150,5 +150,5 @@ Ferris
 
 [testing]: ../testing.md
 [unit_testing]: ../testing/unit_testing.md
-[integration_testing]: ../testing/unit_testing.md
+[integration_testing]: ../testing/integration_testing.md
 [doc_testing]: ../testing/doc_testing.md


### PR DESCRIPTION
The old link was pointing to `unit_testing.md` instead of `integration_testing.md`

https://doc.rust-lang.org/rust-by-example/cargo/test.html