### PR TITLE
str: The number of #s delimiting a raw string is limited to 65535

### DIFF
--- a/src/std/str.md
+++ b/src/std/str.md
@@ -106,7 +106,7 @@ fn main() {
     println!("{}", quotes);
 
     // If you need "# in your string, just use more #s in the delimiter.
-    // There is no limit for the number of #s you can use.
+    // You can use up to 65535 #s.
     let longer_delimiter = r###"A string with "# in it. And even "##!"###;
     println!("{}", longer_delimiter);
 }


### PR DESCRIPTION
https://github.com/rust-lang/rust/blob/308fc2322bf00b5dc12454489679de1420320f56/compiler/rustc_lexer/src/lib.rs#L690