### PR TITLE
Enums: Linked-List Needs Re-Wording

### DIFF
--- a/src/custom_types/enum/testcase_linked_list.md
+++ b/src/custom_types/enum/testcase_linked_list.md
@@ -1,6 +1,6 @@
 # Testcase: linked-list
 
-A common use for `enums` is to create a linked-list:
+A common way to implement a linked-list is via `enums`:
 
 ```rust,editable
 use crate::List::*;


### PR DESCRIPTION
Thank you for this wonderful resource!

https://doc.rust-lang.org/rust-by-example/custom_types/enum/testcase_linked_list.html

I had a colleague ask me a question by being confused with the first sentence in this chapter:

> A common use for enums is to create a linked-list:

IMO, this should be the other way around. A common way to implement Linked-Lists
is to use enums. But I find it misaligned with my experience that a common use
of enums are to create linked lists. I.e. every other use case of enums is much more common than implementing linked lists.