### PR TITLE
Add note about distinction between attribute and macro cfg from std docs into rust-by-example docs

### DIFF
--- a/src/attribute/cfg.md
+++ b/src/attribute/cfg.md
@@ -9,6 +9,8 @@ While the former enables conditional compilation, the latter conditionally
 evaluates to `true` or `false` literals allowing for checks at run-time. Both
 utilize identical argument syntax.
 
+`cfg!`, unlike `#[cfg]`, does not remove any code and only evaluates to true or false. For example, all blocks in an if/else expression need to be valid when `cfg!` is used for the condition, regardless of what `cfg!` is evaluating.
+
 ```rust,editable
 // This function only gets compiled if the target OS is linux
 #[cfg(target_os = "linux")]


### PR DESCRIPTION
The docs for `std::cfg` located at https://doc.rust-lang.org/std/macro.cfg.html contain this distinction between the attribute vs the macro.

> `cfg!`, unlike `#[cfg]`, does not remove any code and only evaluates to true or false. For example, all blocks in an if/else expression need to be valid when `cfg!` is used for the condition, regardless of what `cfg!` is evaluating.

I think we can copy this note over the the docs in rust-by-example - it's important enough that I ran into this exact problem but the rust-by-example docs didn't contain the disclaimer. 

Test plan:
- `cargo install mdbook`
- `mdbook serve`
- navigate to http://localhost:3000/attribute/cfg.html
- screenshot below of new docs!

<img width="1275" alt="Screen Shot 2021-11-10 at 2 15 28 PM" src="https://user-images.githubusercontent.com/8730703/141202562-61771e2a-acbb-47d3-861d-bedf6bed3d70.png">

