### PR TITLE
fix into_iter for arrays

### DIFF
--- a/book.toml
+++ b/book.toml
@@ -9,3 +9,6 @@ editor = "ace"
 
 [output.html.fold]
 enable = true
+
+[output.html]
+git-repository-url = "https://github.com/rust-lang/rust-by-example"

--- a/src/fn/closures/closure_examples/iter_find.md
+++ b/src/fn/closures/closure_examples/iter_find.md
@@ -41,8 +41,8 @@ fn main() {
 
     // `iter()` for arrays yields `&i32`
     println!("Find 2 in array1: {:?}", array1.iter()     .find(|&&x| x == 2));
-    // `into_iter()` for arrays unusually yields `&i32`
-    println!("Find 2 in array2: {:?}", array2.into_iter().find(|&&x| x == 2));
+    // `into_iter()` for arrays yields `i32`
+    println!("Find 2 in array2: {:?}", array2.into_iter().find(|&x| x == 2));
 }
 ```
 


### PR DESCRIPTION
https://doc.rust-lang.org/stable/rust-by-example/fn/closures/closure_examples/iter_find.html#searching-through-iterators
Present code is out of date due to 2021 edition and gives error on compile. Replacing extra & fixes it.