### PR TITLE
Update `Development dependencies` page.

### DIFF
--- a/src/testing/dev_dependencies.md
+++ b/src/testing/dev_dependencies.md
@@ -11,17 +11,12 @@ File `Cargo.toml`:
 ```toml
 # standard crate data is left out
 [dev-dependencies]
-pretty_assertions = "0.4.0"
+pretty_assertions = "1"
 ```
 
 File `src/lib.rs`:
 
 ```rust,ignore
-// externing crate for test-only use
-#[cfg(test)]
-#[macro_use]
-extern crate pretty_assertions;
-
 pub fn add(a: i32, b: i32) -> i32 {
     a + b
 }
@@ -29,6 +24,7 @@ pub fn add(a: i32, b: i32) -> i32 {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use pretty_assertions::assert_eq; // crate for test-only use. Cannot be used in non-test code.
 
     #[test]
     fn test_add() {

--- a/src/testing/dev_dependencies.md
+++ b/src/testing/dev_dependencies.md
@@ -5,7 +5,7 @@ or benchmarks) only. Such dependencies are added to `Cargo.toml` in the
 `[dev-dependencies]` section. These dependencies are not propagated to other
 packages which depend on this package.
 
-One such example is using a crate that extends standard `assert!` macros.  
+One such example is [`pretty_assertions`](https://docs.rs/pretty_assertions/1.0.0/pretty_assertions/index.html), which extends standard `assert_eq!` and `assert_ne!` macros, to provide colorful diff.  
 File `Cargo.toml`:
 
 ```toml


### PR DESCRIPTION
Switch example to 2018 edition, and better explain what the crate given in example does.

I've also linked to the relevant doc.rs page, but it looks like it's the only occurence in the book so I'm not sure if it good to have.