### PR TITLE
area(&rectangle) do not compile with rustc 1.56.0. Use rectangle.area()

### DIFF
--- a/src/generics/bounds.md
+++ b/src/generics/bounds.md
@@ -58,10 +58,10 @@ fn main() {
     let _triangle = Triangle  { length: 3.0, height: 4.0 };
 
     print_debug(&rectangle);
-    println!("Area: {}", area(&rectangle));
+    println!("Area: {}", rectangle.area());
 
     //print_debug(&_triangle);
-    //println!("Area: {}", area(&_triangle));
+    //println!("Area: {}", _triangle.area());
     // ^ TODO: Try uncommenting these.
     // | Error: Does not implement either `Debug` or `HasArea`. 
 }


### PR DESCRIPTION
With rustc 1.56.0 (Debian sid)
"area(&rectangle)" produces the compilation error: error[E0425]: cannot find function `area` in this scope
rectangle.area() compiles. Change also _triangle.area() for consistency.