### PR TITLE
add missing 'return' in std/result/question_mark.html

### DIFF
--- a/src/std/result/question_mark.md
+++ b/src/std/result/question_mark.md
@@ -3,7 +3,7 @@
 Chaining results using match can get pretty untidy; luckily, the `?` operator
 can be used to make things pretty again. `?` is used at the end of an expression
 returning a `Result`, and is equivalent to a match expression, where the 
-`Err(err)` branch expands to an early `Err(From::from(err))`, and the `Ok(ok)`
+`Err(err)` branch expands to an early `return Err(From::from(err))`, and the `Ok(ok)`
 branch expands to an `ok` expression.
 
 ```rust,editable,ignore,mdbook-runnable


### PR DESCRIPTION
A previous PR changed this code snippet to `Err(From::from(err))` and dropped the `return`, but according to the [docs](https://doc.rust-lang.org/std/result/index.html#the-question-mark-operator-) the `?` operator _does_ return.