### PR TITLE
fix into_iter for arrays in chapter Iterator::any

### DIFF
--- a/src/fn/closures/closure_examples/iter_any.md
+++ b/src/fn/closures/closure_examples/iter_any.md
@@ -35,7 +35,7 @@ fn main() {
     // `iter()` for arrays yields `&i32`.
     println!("2 in array1: {}", array1.iter()     .any(|&x| x == 2));
     // `into_iter()` for arrays unusually yields `&i32`.
-    println!("2 in array2: {}", array2.into_iter().any(|&x| x == 2));
+    println!("2 in array2: {}", array2.into_iter().any(| x| x == 2));
 }
 ```
 


### PR DESCRIPTION
 Same as PR#1476. The present code is out of date due to 2021 edition and gives error on compile. Replacing extra & fixes it.