### PR TITLE
adding missing blank before opening brace in text

### DIFF
--- a/src/meta.md
+++ b/src/meta.md
@@ -6,7 +6,7 @@ everyone. These topics include:
 
 - [Documentation][doc]: Generate library documentation for users via the included
   `rustdoc`.
-- [Playpen][playpen]: Integrate the Rust Playpen(also known as the Rust Playground) in your documentation.
+- [Playpen][playpen]: Integrate the Rust Playpen (also known as the Rust Playground) in your documentation.
 
 [doc]: meta/doc.md
 [playpen]: meta/playpen.md


### PR DESCRIPTION
Thanks for providing these excellent docs!

This fixes the missing blank on this page:  https://doc.rust-lang.org/rust-by-example/meta.html

![image](https://user-images.githubusercontent.com/3957921/147884320-01024628-abb7-42c8-9474-5e56cece733f.png)
