### PR TITLE
store Person.age on the heap

### DIFF
--- a/src/scope/move/partial_move.md
+++ b/src/scope/move/partial_move.md
@@ -13,12 +13,12 @@ fn main() {
     #[derive(Debug)]
     struct Person {
         name: String,
-        age: u8,
+        age: Box<u8>,
     }
 
     let person = Person {
         name: String::from("Alice"),
-        age: 20,
+        age: Box::new(20),
     };
 
     // `name` is moved out of person, but `age` is referenced
@@ -35,6 +35,13 @@ fn main() {
     println!("The person's age from person struct is {}", person.age);
 }
 ```
+(In this example, we store the `age` variable on the heap to 
+illustrate the partial move: deleting `ref` in the above code would 
+give an error as the ownership of `person.age` would be moved to the 
+variable `age`. If `Person.age` were stored on the stack, `ref`would 
+not be required as the definition of `age` would copy the data from 
+`person.age` without moving it.)
+
 ### See also:
 [destructuring][destructuring]
 

--- a/src/scope/move/partial_move.md
+++ b/src/scope/move/partial_move.md
@@ -38,7 +38,7 @@ fn main() {
 (In this example, we store the `age` variable on the heap to 
 illustrate the partial move: deleting `ref` in the above code would 
 give an error as the ownership of `person.age` would be moved to the 
-variable `age`. If `Person.age` were stored on the stack, `ref`would 
+variable `age`. If `Person.age` were stored on the stack, `ref` would 
 not be required as the definition of `age` would copy the data from 
 `person.age` without moving it.)
 


### PR DESCRIPTION
I think that `ref` is not required in this example if Person.age is stored on the stack, as the definition of `age` copies the data instead of moving it. I have thus changed the code to store it on the heap, to illustrate the usefulness of `ref` in this context, and added a short explanation. 

An alternative possibility could be to use `name` instead of `age` for the illustration; not sure which is clearer. Please feel free to edit or request edits to this PR if you see a clearer way!