### PR TITLE
Add the edition requirement and fix into_array for arrays

### DIFF
--- a/book.toml
+++ b/book.toml
@@ -3,6 +3,9 @@ title = "Rust By Example"
 description = "Rust by Example (RBE) is a collection of runnable examples that illustrate various Rust concepts and standard libraries."
 author = "The Rust Community"
 
+[rust]
+edition = "2021"
+
 [output.html.playpen]
 editable = true
 editor = "ace"

--- a/src/fn/closures/closure_examples/iter_any.md
+++ b/src/fn/closures/closure_examples/iter_any.md
@@ -35,7 +35,7 @@ fn main() {
     // `iter()` for arrays yields `&i32`.
     println!("2 in array1: {}", array1.iter()     .any(|&x| x == 2));
     // `into_iter()` for arrays unusually yields `&i32`.
-    println!("2 in array2: {}", array2.into_iter().any(|&x| x == 2));
+    println!("2 in array2: {}", array2.into_iter().any(| x| x == 2));
 }
 ```
 


### PR DESCRIPTION
Add the edition requirement in the book.toml file and update the code in Iterator::any part for it can compile in the 2021 edition.