### PR TITLE
Fix the inaccurate rule of `Fn` trait inference in `fn/closures/input_parameters.md`

### DIFF
--- a/src/fn/closures/input_parameters.md
+++ b/src/fn/closures/input_parameters.md
@@ -3,12 +3,13 @@
 While Rust chooses how to capture variables on the fly mostly without type
 annotation, this ambiguity is not allowed when writing functions. When
 taking a closure as an input parameter, the closure's complete type must be
-annotated using one of a few `traits`. In order of decreasing restriction,
+annotated using one of a few `traits`, and they're determined by what the
+closure does with captured value. In order of decreasing restriction,
 they are:
 
-* `Fn`: the closure captures by reference (`&T`)
-* `FnMut`: the closure captures by mutable reference (`&mut T`)
-* `FnOnce`: the closure captures by value (`T`)
+* `Fn`: the closure uses the captured value by reference (`&T`)
+* `FnMut`: the closure uses the captured value by mutable reference (`&mut T`)
+* `FnOnce`: the closure uses the captured value by value (`T`)
 
 On a variable-by-variable basis, the compiler will capture variables in the
 least restrictive manner possible.


### PR DESCRIPTION
Fixes #1495.

According to [Keyword `move`](https://doc.rust-lang.org/std/keyword.move.html),

> Note: `move` closures may still implement [`Fn`] or [`FnMut`], even though
> they capture variables by `move`. This is because the traits implemented by
> a closure type are determined by *what* the closure does with captured
> values, not *how* it captures them:

we should not say the `Fn` traits are determined by how   the closure captures the variable. For example we use `move` to capture a variable by `T` but use it by `&T`, the closure is still `Fn` instead of `FnOnce`.