### PR TITLE
Fix tests and update to 2021

### DIFF
--- a/.github/workflows/rbe.yml
+++ b/.github/workflows/rbe.yml
@@ -14,7 +14,7 @@ jobs:
     - name: Install Rust
       run: |
         rustup set profile minimal
-        rustup toolchain install stable -c rust-docs
+        rustup toolchain install nightly -c rust-docs
         rustup default nightly
 
     - name: Install mdbook
@@ -34,6 +34,12 @@ jobs:
 
     - name: Build HTML
       run: mdbook build
+
+    - name: Check for broken links
+      run: |
+        curl -sSLo linkcheck.sh \
+          https://raw.githubusercontent.com/rust-lang/rust/master/src/tools/linkchecker/linkcheck.sh
+        sh linkcheck.sh --all rust-by-example
 
     - name: Upload Artifact
       uses: actions/upload-artifact@v1

--- a/book.toml
+++ b/book.toml
@@ -12,3 +12,6 @@ enable = true
 
 [output.html]
 git-repository-url = "https://github.com/rust-lang/rust-by-example"
+
+[rust]
+edition = "2021"

--- a/src/error/result/enter_question_mark.md
+++ b/src/error/result/enter_question_mark.md
@@ -43,7 +43,7 @@ The `?` operator is now recommended, but you may still find `try!` when looking
 at older code. The same `multiply` function from the previous example
 would look like this using `try!`:
 
-```rust,editable
+```rust,editable,edition2015
 // To compile and run this example without errors, while using Cargo, change the value 
 // of the `edition` field, in the `[package]` section of the `Cargo.toml` file, to "2015".
 

--- a/src/fn/closures/closure_examples/iter_any.md
+++ b/src/fn/closures/closure_examples/iter_any.md
@@ -35,7 +35,7 @@ fn main() {
     // `iter()` for arrays yields `&i32`.
     println!("2 in array1: {}", array1.iter()     .any(|&x| x == 2));
     // `into_iter()` for arrays unusually yields `&i32`.
-    println!("2 in array2: {}", array2.into_iter().any(|&x| x == 2));
+    println!("2 in array2: {}", array2.iter().any(|&x| x == 2));
 }
 ```
 

--- a/src/generics/assoc_items/types.md
+++ b/src/generics/assoc_items/types.md
@@ -13,7 +13,7 @@ trait Contains {
     type B;
 
     // Updated syntax to refer to these new types generically.
-    fn contains(&self, &Self::A, &Self::B) -> bool;
+    fn contains(&self, _: &Self::A, _: &Self::B) -> bool;
 }
 ```
 

--- a/src/unsafe/asm.md
+++ b/src/unsafe/asm.md
@@ -285,7 +285,9 @@ assert_eq!(x, 4 * 6);
 
 ## Symbol operands and ABI clobbers
 
-By default, `asm!` assumes that any register not specified as an output will have its contents preserved by the assembly code. The [`clobber_abi`](#abi-clobbers) argument to `asm!` tells the compiler to automatically insert the necessary clobber operands according to the given calling convention ABI: any register which is not fully preserved in that ABI will be treated as clobbered.  Multiple `clobber_abi` arguments may be provided and all clobbers from all specified ABIs will be inserted.
+By default, `asm!` assumes that any register not specified as an output will have its contents preserved by the assembly code. The [`clobber_abi`] argument to `asm!` tells the compiler to automatically insert the necessary clobber operands according to the given calling convention ABI: any register which is not fully preserved in that ABI will be treated as clobbered.  Multiple `clobber_abi` arguments may be provided and all clobbers from all specified ABIs will be inserted.
+
+[`clobber_abi`]: ../../reference/inline-assembly.html#abi-clobbers
 
 ```rust
 use std::arch::asm;


### PR DESCRIPTION
This adds a few fixes to get CI passing:

* Fixes a broken link.
* Adds the broken link checker to CI.
* Properly installs nightly.
* Updates to 2021 edition to fix an example.
* Update the rest of the examples to work with 2021.
