### PR TITLE
Added new Rust 1.58 direct format args

### DIFF
--- a/src/hello/print.md
+++ b/src/hello/print.md
@@ -54,6 +54,13 @@ fn main() {
     // handling. This will not work.
     println!("This struct `{}` won't print...", Structure(3));
     // FIXME ^ Comment out this line.
+
+    // For Rust 1.58 and above, you can directly capture the argument from
+    // surrounding variable. Just like the above, this will output
+    // "     1". 5 white spaces and a "1".
+    let number: f64 = 1.0;
+    let width: usize = 6;
+    println!("{number:>width$}");
 }
 ```
 


### PR DESCRIPTION
I revisited the book for fun, and it seems that the new formatter can be added for the `hello` samples