### PR TITLE
Add +1 to next_age

### DIFF
--- a/src/error/option_unwrap/question_mark.md
+++ b/src/error/option_unwrap/question_mark.md
@@ -9,7 +9,7 @@ function is being executed and return `None`.
 fn next_birthday(current_age: Option<u8>) -> Option<String> {
 	// If `current_age` is `None`, this returns `None`.
 	// If `current_age` is `Some`, the inner `u8` gets assigned to `next_age`
-    let next_age: u8 = current_age?;
+    let next_age: u8 = current_age? + 1;
     Some(format!("Next year I will be {}", next_age))
 }
 ```


### PR DESCRIPTION
While the example as it is correctly demonstrates the use of the `?` operator, I feel adding 1 to `next_age` makes it more consistent with the variable name (unless I am missing something?)