### PR TITLE
Add an example of collecting errors while iterating successes

### DIFF
--- a/src/error/iter_result.md
+++ b/src/error/iter_result.md
@@ -30,6 +30,25 @@ fn main() {
 }
 ```
 
+## Collect the failed items with `map_err()` and `filter_map()`
+
+`map_err` calls a function with the error, so by adding that to the previous
+`filter_map` solution we can save them off to the side while iterating.
+
+```rust,editable
+fn main() {
+    let strings = vec!["42", "tofu", "93", "999", "18"];
+    let mut errors = vec![];
+    let numbers: Vec<_> = strings
+        .into_iter()
+        .map(|s| s.parse::<u8>())
+        .filter_map(|r| r.map_err(|e| errors.push(e)).ok())
+        .collect();
+    println!("Numbers: {:?}", numbers);
+    println!("Errors: {:?}", errors);
+}
+```
+
 ## Fail the entire operation with `collect()`
 
 `Result` implements `FromIter` so that a vector of results (`Vec<Result<T, E>>`)


### PR DESCRIPTION
Inspired by the comments from people looking for something like this in https://github.com/rust-lang/rust/pull/87047#issuecomment-880326075 .

Sample output:
```
Numbers: [42, 93, 18]
Errors: [ParseIntError { kind: InvalidDigit }, ParseIntError { kind: PosOverflow }]
```
<https://play.rust-lang.org/?version=stable&mode=debug&edition=2021&gist=1fd4b9e4474ffe012e51696ba66c5f6f>