### PR TITLE
fix a syntax bug in example assembly

### DIFF
--- a/src/unsafe/asm.md
+++ b/src/unsafe/asm.md
@@ -309,7 +309,7 @@ fn call_foo(arg: i32) -> i32 {
     unsafe {
         let result;
         asm!(
-            "call *{}",
+            "call {}",
             // Function pointer to call
             in(reg) foo,
             // 1st argument in rdi


### PR DESCRIPTION
The `call *` syntax is used in AT&T syntax but not in Intel syntax.
(Source: https://stackoverflow.com/a/19088205/823869.) To make this
example compile, I think we need to remove the `*`.

Playground example broken: https://play.rust-lang.org/?version=stable&mode=debug&edition=2021&gist=585dff3c1b43c7a493082ea66c7cdaad
Playground example working: https://play.rust-lang.org/?version=stable&mode=debug&edition=2021&gist=c4517f46219140ba4345a1656fe7e106