### PR TITLE
Fix example for if/else expression return types

### DIFF
--- a/src/flow_control/if_else.md
+++ b/src/flow_control/if_else.md
@@ -7,7 +7,7 @@ and, all branches must return the same type.
 
 ```rust,editable
 fn main() {
-    let n = 5;
+    let n = 20;
 
     if n < 0 {
         print!("{} is negative", n);
@@ -20,15 +20,15 @@ fn main() {
     let big_n =
         if n < 10 && n > -10 {
             println!(", and is a small number, increase ten-fold");
-
+    
             // This expression returns an `i32`.
             10 * n
         } else {
             println!(", and is a big number, halve the number");
-
+    
             // This expression must return an `i32` as well.
-            n / 2
-            // TODO ^ Try suppressing this expression with a semicolon.
+            n / 2;
+            // TODO ^ Try removing the semicolon to return the expression's result.
         };
     //   ^ Don't forget to put a semicolon here! All `let` bindings need it.
 


### PR DESCRIPTION
This fixes the [example](https://doc.rust-lang.org/stable/rust-by-example/flow_control/if_else.html) for `if`/`else` expressions where the different branches must all return the same type:

```rust
let big_n =
    if n < 10 && n > -10 {
        println!(", and is a small number, increase ten-fold");

        // This expression returns an `i32`.
        10 * n
    } else {
        println!(", and is a big number, halve the number");

        // This expression must return an `i32` as well.
        n / 2
        // TODO ^ Try suppressing this expression with a semicolon.
    };
//   ^ Don't forget to put a semicolon here! All `let` bindings need it.
```

Apparently `n / 2` already results in an `i32` so this example doesn't result in an error. Also the suggested fix _"TODO ^ Try suppressing this expression with a semicolon."_ doesn't work because apparently that only ends up generating the error originally intended by the example (since now the branches return `i32` and `()` respectively):

```rust
error[E0308]: `if` and `else` have incompatible types
  --> src/main.rs:22:13
   |
13 | /         if n < 10 && n > -10 {
14 | |             println!(", and is a small number, increase ten-fold");
15 | |
16 | |             // This expression returns an `i32`.
17 | |             10 * n
   | |             ------ expected because of this
...  |
22 | |             n / 2;
   | |             ^^^^^-
   | |             |    |
   | |             |    help: consider removing this semicolon
   | |             expected integer, found `()`
23 | |             // TODO ^ Try suppressing this expression with a semicolon.
24 | |         };
   | |_________- `if` and `else` have incompatible types

For more information about this error, try `rustc --explain E0308`.
error: could not compile `playground` due to previous error
```

So I assume some things changed in Rust since the example was first created and it was never updated?

This PR changes the example so that instead of `n / 2`, it now does `n / 2;` to prevent the `i32` from being returned from the branch and changes the TODO to `// TODO ^ Try removing the semicolon to return the expression's result.`.