### PR TITLE
Move allow dead code attribute and add comment

### DIFF
--- a/src/custom_types/structs.md
+++ b/src/custom_types/structs.md
@@ -8,6 +8,9 @@ There are three types of structures ("structs") that can be created using the
 * Unit structs, which are field-less, are useful for generics.
 
 ```rust,editable
+// An attribute to hide warnings for unused code.
+#![allow(dead_code)]
+
 #[derive(Debug)]
 struct Person {
     name: String,
@@ -27,7 +30,6 @@ struct Point {
 }
 
 // Structs can be reused as fields of another struct
-#[allow(dead_code)]
 struct Rectangle {
     // A rectangle can be specified by where the top left and bottom right
     // corners are in space.


### PR DESCRIPTION
Dear @marioidival,

The attribute #![allow(dead_code)] is first time mentioned in section [3.1. Structures]. So my proposition for this section is to move #![allow(dead_code)] attribute to the top of the code and add a comment for it similarly like it is done in other sections (for example in [3.2.1. use] and [3.2.2. C-like]). I think this will help better to understand for the first time what this attribute is for.