### PR TITLE
Update iter_any.md

### DIFF
--- a/src/fn/closures/closure_examples/iter_any.md
+++ b/src/fn/closures/closure_examples/iter_any.md
@@ -35,7 +35,7 @@ fn main() {
     // `iter()` for arrays yields `&i32`.
     println!("2 in array1: {}", array1.iter()     .any(|&x| x == 2));
     // `into_iter()` for arrays yields `i32`.
-    println!("2 in array2: {}", array2.iter().any(|&x| x == 2));
+    println!("2 in array2: {}", array2.into_iter().any(|x| x == 2));
 }
 ```
 


### PR DESCRIPTION
Line#38 used iter() method instead of into_iter as specified in the comment on line#37.
Modified code from:
println!("2 in array2: {}", array2.iter().any(|&x| x == 2));
to:
println!("2 in array2: {}", array2.into_iter().any(|x| x == 2));