### PR TITLE
fix: spacing in iter_any example

### DIFF
--- a/src/fn/closures/closure_examples/iter_any.md
+++ b/src/fn/closures/closure_examples/iter_any.md
@@ -33,7 +33,7 @@ fn main() {
     let array2 = [4, 5, 6];
 
     // `iter()` for arrays yields `&i32`.
-    println!("2 in array1: {}", array1.iter()     .any(|&x| x == 2));
+    println!("2 in array1: {}", array1.iter().any(|&x| x == 2));
     // `into_iter()` for arrays yields `i32`.
     println!("2 in array2: {}", array2.iter().any(|&x| x == 2));
 }


### PR DESCRIPTION
Hi there, while reading the doc (which is great btw!) I noticed that you use to space code between examples to match `.` and function names that are being explained.

I think that this line should be changed in order to be properly aligned with the example below.

Thanks