### PR TITLE
Replace `C` with C/C++

### DIFF
--- a/src/flow_control/match/destructuring/destructure_pointers.md
+++ b/src/flow_control/match/destructuring/destructure_pointers.md
@@ -2,7 +2,7 @@
 
 For pointers, a distinction needs to be made between destructuring
 and dereferencing as they are different concepts which are used
-differently from a language like `C`.
+differently from languages like C/C++.
 
  * Dereferencing uses `*`
  * Destructuring uses `&`, `ref`, and `ref mut`


### PR DESCRIPTION
This looks like a constant `C` because it is highlighted in backticks. This PR will clarify it by removing the backticks and replacing it with C/C++.