### PR TITLE
Make all new types have UpperCamelCase names in code example in the Aliasing section

### DIFF
--- a/src/types/alias.md
+++ b/src/types/alias.md
@@ -5,19 +5,15 @@ must have `UpperCamelCase` names, or the compiler will raise a warning. The
 exception to this rule are the primitive types: `usize`, `f32`, etc.
 
 ```rust,editable
-// `NanoSecond` is a new name for `u64`.
+// `NanoSecond`, `Inch`, and `U64` are new names for `u64`.
 type NanoSecond = u64;
 type Inch = u64;
-
-// Use an attribute to silence warning.
-#[allow(non_camel_case_types)]
-type u64_t = u64;
-// TODO ^ Try removing the attribute
+type U64 = u64;
 
 fn main() {
-    // `NanoSecond` = `Inch` = `u64_t` = `u64`.
-    let nanoseconds: NanoSecond = 5 as u64_t;
-    let inches: Inch = 2 as u64_t;
+    // `NanoSecond` = `Inch` = `U64` = `u64`.
+    let nanoseconds: NanoSecond = 5 as U64;
+    let inches: Inch = 2 as U64;
 
     // Note that type aliases *don't* provide any extra type safety, because
     // aliases are *not* new types


### PR DESCRIPTION
Dear Rustaceans,

As was mentioned by @xiaochuanyu in his comment https://github.com/rust-lang/rust-by-example/issues/1328#issuecomment-687883454 currently there is no way to see warnings while running Rust code blocks in `mdbook`.

Thus, my proposition for the code example in the Aliasing section is to use only correct UpperCamelCase names for the new types. These changes do not influence the explanation of how type aliasing works, but can prevent readers from the confusion of not being able to see the warning by removing `#[allow(non_camel_case_types)]` attribute as TODO suggests.