### PR TITLE
Add a comment to note that warnings may not be shown in a browser in the Variable Bindings section

### DIFF
--- a/src/variable_bindings.md
+++ b/src/variable_bindings.md
@@ -26,5 +26,6 @@ fn main() {
 
     let noisy_unused_variable = 2u32;
     // FIXME ^ Prefix with an underscore to suppress the warning
+    // Please note that warnings may not be shown in a browser
 }
 ```


### PR DESCRIPTION
Dear Rustaceans,

As was mentioned by @xiaochuanyu in his comment https://github.com/rust-lang/rust-by-example/issues/1328#issuecomment-687883454 currently there is no way to see warnings while running Rust code blocks in `mdbook`.

The [Variable Bindings](https://doc.rust-lang.org/stable/rust-by-example/variable_bindings.html#variable-bindings) section contains a comment with a suggestion to prefix the variable name with an underscore to suppress the warning, which currently can not be seen in a browser.

My proposition is to add after the mentioned comment an additional comment to note that warnings may not be shown in a browser.

closes #1332