### PR TITLE
Use rust 2018 module file hierarchy

### DIFF
--- a/src/mod/split.md
+++ b/src/mod/split.md
@@ -6,17 +6,17 @@ Modules can be mapped to a file/directory hierarchy. Let's break down the
 ```shell
 $ tree .
 .
-|-- my
-|   |-- inaccessible.rs
-|   |-- mod.rs
-|   `-- nested.rs
-`-- split.rs
+├── my
+│   ├── inaccessible.rs
+│   └── nested.rs
+├── my.rs
+└── split.rs
 ```
 
 In `split.rs`:
 
 ```rust,ignore
-// This declaration will look for a file named `my.rs` or `my/mod.rs` and will
+// This declaration will look for a file named `my.rs` and will
 // insert its contents inside a module named `my` under this scope
 mod my;
 
@@ -36,7 +36,7 @@ fn main() {
 
 ```
 
-In `my/mod.rs`:
+In `my.rs`:
 
 ```rust,ignore
 // Similarly `mod inaccessible` and `mod nested` will locate the `nested.rs`


### PR DESCRIPTION
With 2018 edition, we no longer need mod.rs files. The book follows the
new convention in its dedicated chapter and the reference encourages its
usage over the mod.rs files. In order to be consistent with the book, we
now have `my.rs` and `my` folder in the same directory instead of
`my/mod.rs`.

Please see [reference](https://doc.rust-lang.org/reference/items/modules.html), [edition guide](https://doc.rust-lang.org/edition-guide/rust-2018/path-changes.html), and [the book](https://doc.rust-lang.org/book/ch07-05-separating-modules-into-different-files.html).