### PR TITLE
Add empty slice example

### DIFF
--- a/src/primitives/array.md
+++ b/src/primitives/array.md
@@ -16,8 +16,8 @@ use std::mem;
 
 // This function borrows a slice
 fn analyze_slice(slice: &[i32]) {
-    println!("first element of the slice: {}", slice[0]);
-    println!("the slice has {} elements", slice.len());
+    println!(" first element of the slice: {}", slice[0]);
+    println!(" the slice has {} elements", slice.len());
 }
 
 fn main() {
@@ -48,7 +48,12 @@ fn main() {
     println!("borrow a section of the array as a slice");
     analyze_slice(&ys[1 .. 4]);
 
+    // Example of empty slice `&[]`
+    let empty_array: [u32; 0] = [];
+    assert_eq!(&empty_array, &[]);
+    assert_eq!(&empty_array, &[][..]); // same but more verbose
+
     // Out of bound indexing causes compile error
-    println!("{}", xs[5]);
+    //println!("{}", xs[5]);
 }
 ```

--- a/src/primitives/array.md
+++ b/src/primitives/array.md
@@ -16,8 +16,8 @@ use std::mem;
 
 // This function borrows a slice
 fn analyze_slice(slice: &[i32]) {
-    println!(" first element of the slice: {}", slice[0]);
-    println!(" the slice has {} elements", slice.len());
+    println!("first element of the slice: {}", slice[0]);
+    println!("the slice has {} elements", slice.len());
 }
 
 fn main() {


### PR DESCRIPTION
Add example use empty slices.
Fix https://github.com/rust-lang/rust-by-example/issues/1198

Output after fix:
```
first element of the array: 1
second element of the array: 2
number of elements in array: 5
array occupies 20 bytes
borrow the whole array as a slice
 first element of the slice: 1
 the slice has 5 elements
borrow a section of the array as a slice
 first element of the slice: 0
 the slice has 3 elements
```
- Align output of the example
- Add example of empty slice(asserts)
- Comment line with compile error to allow `run this code`
