### PR TITLE
doc_testing.md: clarify tests vs doc-tests

### DIFF
--- a/src/testing/doc_testing.md
+++ b/src/testing/doc_testing.md
@@ -3,7 +3,7 @@
 The primary way of documenting a Rust project is through annotating the source
 code. Documentation comments are written in [markdown] and support code
 blocks in them. Rust takes care about correctness, so these code blocks are
-compiled and used as tests.
+compiled and used as documentation tests.
 
 ```rust,ignore
 /// First line is a short summary describing function.
@@ -48,7 +48,8 @@ pub fn div(a: i32, b: i32) -> i32 {
 }
 ```
 
-Tests can be run with `cargo test`:
+Code blocks in documentation are automatically tested
+when running the regular `cargo test` command:
 
 ```shell
 $ cargo test
@@ -73,8 +74,8 @@ the functionality, which is one of the most important
 [guidelines][question-instead-of-unwrap]. It allows using examples from docs as
 complete code snippets. But using `?` makes compilation fail since `main`
 returns `unit`. The ability to hide some source lines from documentation comes
-to the rescue: one may write `fn try_main() -> Result<(), ErrorType>`, hide it and
-`unwrap` it in hidden `main`. Sounds complicated? Here's an example:
+to the rescue: one may write `fn try_main() -> Result<(), ErrorType>`, hide it
+and `unwrap` it in hidden `main`. Sounds complicated? Here's an example:
 
 ```rust,ignore
 /// Using hidden `try_main` in doc tests.


### PR DESCRIPTION
The current language is a bit ambiguous about distinguishing the regular unit tests from the documentation tests. I tried to make the distinction a bit more explicit, to match the output of `cargo test` included in this page, which outputs the result in two sections:

```
running 0 tests

test result: ok. 0 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out
```
```
   Doc-tests doccomments

running 3 tests

test result: ok. 3 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out
```