### PR TITLE
unsafe::asm.md: add some explicit declarations

### DIFF
--- a/src/unsafe/asm.md
+++ b/src/unsafe/asm.md
@@ -132,7 +132,7 @@ To achieve this Rust provides a `lateout` specifier. This can be used on any out
 written only after all inputs have been consumed.
 There is also a `inlateout` variant of this specifier.
 
-Here is an example where `inlateout` *cannot* be used:
+Here is an example where `inlateout` *cannot* be used in `release` mode or other optimized cases:
 
 ```rust
 use std::arch::asm;
@@ -151,8 +151,9 @@ unsafe {
 }
 assert_eq!(a, 12);
 ```
+The above could work well in unoptimized case (`Debug` mode), but if you want optimized performance(`release` mode or other optimized cases), it could not work.
 
-Here the compiler is free to allocate the same register for inputs `b` and `c` since it knows they have the same value. However it must allocate a separate register for `a` since it uses `inout` and not `inlateout`. If `inlateout` was used, then `a` and `c` could be allocated to the same register, in which case the first instruction to overwrite the value of `c` and cause the assembly code to produce the wrong result.
+That is because in optimized cases, the compiler is free to allocate the same register for inputs `b` and `c` since it knows they have the same value. However it must allocate a separate register for `a` since it uses `inout` and not `inlateout`. If `inlateout` was used, then `a` and `c` could be allocated to the same register, in which case the first instruction to overwrite the value of `c` and cause the assembly code to produce the wrong result.
 
 However the following example can use `inlateout` since the output is only modified after all input registers have been read:
 

--- a/src/unsafe/asm.md
+++ b/src/unsafe/asm.md
@@ -151,7 +151,7 @@ unsafe {
 }
 assert_eq!(a, 12);
 ```
-The above could work well in unoptimized case (`Debug` mode), but if you want optimized performance(`release` mode or other optimized cases), it could not work.
+The above could work well in unoptimized cases (`Debug` mode), but if you want optimized performance (`release` mode or other optimized cases), it could not work.
 
 That is because in optimized cases, the compiler is free to allocate the same register for inputs `b` and `c` since it knows they have the same value. However it must allocate a separate register for `a` since it uses `inout` and not `inlateout`. If `inlateout` was used, then `a` and `c` could be allocated to the same register, in which case the first instruction to overwrite the value of `c` and cause the assembly code to produce the wrong result.
 


### PR DESCRIPTION
in order to close  issue #1545

i consider it is better to add some declarations that the code only produces wrong result in optimized cases, it is crucial for beginers to understand what asm macro works under the hood.