### PR TITLE
Make guard examples clearer around `_`

### DIFF
--- a/src/flow_control/match/guard.md
+++ b/src/flow_control/match/guard.md
@@ -26,14 +26,15 @@ fn main() {
 Note that the compiler won't take guard conditions into account when checking
 if all patterns are covered by the match expression.
 
-```rust,editable
+```rust,editable,ignore,mdbook-runnable
 fn main() {
     let number: u8 = 4;
 
     match number {
         i if i == 0 => println!("Zero"),
         i if i > 0 => println!("Greater than zero"),
-        // _ => unreachable!("Should never happen."), // uncomment to fix compilation
+        // _ => unreachable!("Should never happen."),
+        // TODO ^ uncomment to fix compilation
     }
 }
 ```

--- a/src/flow_control/match/guard.md
+++ b/src/flow_control/match/guard.md
@@ -13,11 +13,11 @@ fn main() {
     // ^ TODO try different values for `temperature`
 
     match temperature {
-        Temperature::Celsius(t) if t >= 30 => println!("{}C is above 30 Celsius", t),
+        Temperature::Celsius(t) if t > 30 => println!("{}C is above 30 Celsius", t),
         // The `if condition` part ^ is a guard
         Temperature::Celsius(t) => println!("{}C is below 30 Celsius", t),
 
-        Temperature::Farenheit(t) if t >= 86 => println!("{}F is above 86 Farenheit", t),
+        Temperature::Farenheit(t) if t > 86 => println!("{}F is above 86 Farenheit", t),
         Temperature::Farenheit(t) => println!("{}F is below 86 Farenheit", t),
     }
 }

--- a/src/flow_control/match/guard.md
+++ b/src/flow_control/match/guard.md
@@ -3,24 +3,28 @@
 A `match` *guard* can be added to filter the arm.
 
 ```rust,editable
-fn main() {
-    let pair = (2, -2);
-    // TODO ^ Try different values for `pair`
+enum Temperature {
+    Celsius(i32),
+    Farenheit(i32),
+}
 
-    println!("Tell me about {:?}", pair);
-    match pair {
-        (x, y) if x == y => println!("These are twins"),
-        // The ^ `if condition` part is a guard
-        (x, y) if x + y == 0 => println!("Antimatter, kaboom!"),
-        (x, _) if x % 2 == 1 => println!("The first one is odd"),
-        _ => println!("No correlation..."),
+fn main() {
+    let temperature = Temperature::C(35);
+    // ^ TODO try different values for `temperature`
+
+    match temperature {
+        Temperature::Celsius(t) if t >= 30 => println!("{}C is above 30 Celsius", t),
+        // The `if condition` part ^ is a guard
+        Temperature::Celsius(t) => println!("{}C is below 30 Celsius", t),
+
+        Temperature::Farenheit(t) if t >= 86 => println!("{}F is above 86 Farenheit", t),
+        Temperature::Farenheit(t) => println!("{}F is below 86 Farenheit", t),
     }
 }
 ```
 
-Note that the compiler does not check arbitrary expressions for whether all
-possible conditions have been checked.  Therefore, you must use the `_` pattern
-at the end.
+Note that the compiler won't take guard conditions into account when checking
+if all patterns are covered by the match expression.
 
 ```rust,editable
 fn main() {
@@ -29,7 +33,7 @@ fn main() {
     match number {
         i if i == 0 => println!("Zero"),
         i if i > 0 => println!("Greater than zero"),
-        _ => println!("Fell through"), // This should not be possible to reach
+        // _ => unreachable!("Should never happen."), // uncomment to fix compilation
     }
 }
 ```
@@ -37,3 +41,4 @@ fn main() {
 ### See also:
 
 [Tuples](../../primitives/tuples.md)
+[Enums](../../custom_types/enum.md)

--- a/src/flow_control/match/guard.md
+++ b/src/flow_control/match/guard.md
@@ -9,7 +9,7 @@ enum Temperature {
 }
 
 fn main() {
-    let temperature = Temperature::C(35);
+    let temperature = Temperature::Celsius(35);
     // ^ TODO try different values for `temperature`
 
     match temperature {


### PR DESCRIPTION
This attempts to address https://github.com/rust-lang/rust-by-example/issues/1539.
I adjusted examples to illustrate cases where we have guard conditions both with using `_` arm and without using `_` arm.
