### PR TITLE
Add example for `array.get()`

### DIFF
--- a/src/primitives/array.md
+++ b/src/primitives/array.md
@@ -53,6 +53,17 @@ fn main() {
     assert_eq!(&empty_array, &[]);
     assert_eq!(&empty_array, &[][..]); // same but more verbose
 
+    // Arrays can be safely accessed using `.get`, which returns an
+    // `Option`. This can be matched as shown below, or used with
+    // `.expect()` if you would like the program to exit with a nice
+    // message instead of happily continue.
+    for i in 0..xs.len() + 1 { // OOPS, one element too far
+        match xs.get(i) {
+            Some(xval) => println!("{}: {}", i, xval),
+            None => println!("Slow down! {} is too far!", i),
+        }
+    }
+
     // Out of bound indexing causes compile error
     //println!("{}", xs[5]);
 }


### PR DESCRIPTION
One of the best features of arrays in Rust is missing! I added it here.