### PR TITLE
fix: Fibonacci sequence starts from zero

### DIFF
--- a/src/trait/iter.md
+++ b/src/trait/iter.md
@@ -1,12 +1,13 @@
 # Iterators
 
-The [`Iterator`][iter] trait is used to implement iterators over collections such as arrays.
+The [`Iterator`][iter] trait is used to implement iterators over collections
+such as arrays.
 
-The trait requires only a method to be defined for the `next` element, 
-which may be manually defined in an `impl` block or automatically 
+The trait requires only a method to be defined for the `next` element,
+which may be manually defined in an `impl` block or automatically
 defined (as in arrays and ranges).
 
-As a point of convenience for common situations, the `for` construct 
+As a point of convenience for common situations, the `for` construct
 turns some collections into iterators using the [`.into_iter()`][intoiter] method.
 
 ```rust,editable
@@ -20,7 +21,7 @@ struct Fibonacci {
 impl Iterator for Fibonacci {
     // We can refer to this type using Self::Item
     type Item = u32;
-    
+
     // Here, we define the sequence using `.curr` and `.next`.
     // The return type is `Option<T>`:
     //     * When the `Iterator` is finished, `None` is returned.
@@ -28,14 +29,14 @@ impl Iterator for Fibonacci {
     // We use Self::Item in the return type, so we can change
     // the type without having to update the function signatures.
     fn next(&mut self) -> Option<Self::Item> {
-        let new_next = self.curr + self.next;
+        let current = self.curr;
 
         self.curr = self.next;
-        self.next = new_next;
+        self.next = current + self.next;
 
         // Since there's no endpoint to a Fibonacci sequence, the `Iterator` 
         // will never return `None`, and `Some` is always returned.
-        Some(self.curr)
+        Some(current)
     }
 }
 


### PR DESCRIPTION
Correct fibonacci sequence is
    [0, 1, 1, 2, 3, 5, 8, ..]
and not
    [1, 1, 2, 3, 5, 8, ..].

In the form of function calls, to get Nth element of the Fibonacci
sequence, it should look like this:
    F(0) = 0
    F(1) = 1
    F(2) = 1
    F(3) = 2