### PR TITLE
Update incorrect print output in std/box.md

### DIFF
--- a/src/std/box.md
+++ b/src/std/box.md
@@ -62,11 +62,11 @@ fn main() {
              mem::size_of_val(&rectangle));
 
     // box size == pointer size
-    println!("Boxed point occupies {} bytes on the stack",
+    println!("Boxed point occupies {} bytes on the heap",
              mem::size_of_val(&boxed_point));
-    println!("Boxed rectangle occupies {} bytes on the stack",
+    println!("Boxed rectangle occupies {} bytes on the heap",
              mem::size_of_val(&boxed_rectangle));
-    println!("Boxed box occupies {} bytes on the stack",
+    println!("Boxed box occupies {} bytes on the heap",
              mem::size_of_val(&box_in_a_box));
 
     // Copy the data contained in `boxed_point` into `unboxed_point`


### PR DESCRIPTION
All the print statements that output the size of a boxed object use the phrase "...occupies {} bytes on the stack", which is incorrect and should be changed to "...occupies {} bytes on the heap"