### PR TITLE
Fixes a typo in print.md

### DIFF
--- a/src/hello/print.md
+++ b/src/hello/print.md
@@ -68,7 +68,7 @@ fn main() {
     // surrounding variable. Just like the above, this will output
     // "     1". 5 white spaces and a "1".
     let number: f64 = 1.0;
-    let width: usize = 5;
+    let width: usize = 6;
     println!("{number:>width$}");
 }
 ```

--- a/src/hello/print.md
+++ b/src/hello/print.md
@@ -64,11 +64,11 @@ fn main() {
     println!("This struct `{}` won't print...", Structure(3));
     // FIXME ^ Comment out this line.
 
-    // For Rust 1.58 and above, you can directly capture the argument from
+    // For Rust 1.58 and above, you can directly capture the argument from a
     // surrounding variable. Just like the above, this will output
     // "     1". 5 white spaces and a "1".
     let number: f64 = 1.0;
-    let width: usize = 6;
+    let width: usize = 5;
     println!("{number:>width$}");
 }
 ```


### PR DESCRIPTION
Found a typo in `print.md`.
