### PR TITLE
fixes link for turbofish in testcase_mapreduce.md

### DIFF
--- a/src/std_misc/threads/testcase_mapreduce.md
+++ b/src/std_misc/threads/testcase_mapreduce.md
@@ -139,6 +139,6 @@ defined by a static constant at the beginning of the program.
 [closures]: ../../fn/closures.md
 [move]: ../../scope/move.md
 [move_closure]: https://doc.rust-lang.org/book/ch13-01-closures.html#closures-can-capture-their-environment
-[turbofish]: https://doc.rust-lang.org/std/iter/trait.Iterator.html#method.collect
+[turbofish]: https://doc.rust-lang.org/book/appendix-02-operators.html?highlight=turbofish
 [unwrap]: ../../error/option_unwrap.md
 [enumerate]: https://doc.rust-lang.org/book/loops.html#enumerate


### PR DESCRIPTION
Fixes wrong link for turbofish notation found in #1533.