### PR TITLE
Update hello-print exercise to be clearer

### DIFF
--- a/src/hello/print.md
+++ b/src/hello/print.md
@@ -61,8 +61,8 @@ fn main() {
 
     // This will not compile because `Structure` does not implement
     // fmt::Display
-    println!("This struct `{}` won't print...", Structure(3));
-    // FIXME ^ Comment out this line.
+    //println!("This struct `{}` won't print...", Structure(3));
+    // TODO ^ Try uncommenting this line
 
     // For Rust 1.58 and above, you can directly capture the argument from
     // surrounding variable. Just like the above, this will output
@@ -88,8 +88,9 @@ Implementing the `fmt::Display` trait automatically implements the
 
 ### Activities
 
- * Fix the two issues in the above code (see FIXME) so that it runs without
+ * Fix the issue in the above code (see FIXME) so that it runs without
    error.
+ * Try uncommenting the line that attempts to format the `Structure` struct (see TODO)
  * Add a `println!` macro call that prints: `Pi is roughly 3.142` by controlling
    the number of decimal places shown. For the purposes of this exercise,
    use `let pi = 3.141592` as an estimate for pi. (Hint: you may need to


### PR DESCRIPTION
This makes this exercise consistent with other errors that are intended to show the error without resolving it, such as the `TODO` here: https://doc.rust-lang.org/stable/rust-by-example/trait/derive.html

When I first encountered this exercise, I was primed to "fix the issue" and saw the rust compiler error:
```
error[E0277]: `Structure` doesn't implement `std::fmt::Display`
```

Enterprising me didn't really read the rest of the code surrounding the error and promptly went to implement `fmt::Display`, which was a pretty big escalation from "hello world" and the actual intention of the exercise to just comment out the offending line. I did it, but I was frustrated a large portion of the time and had to jump around to the source and other parts of rust by example.