### PR TITLE
fix a compile error in iter_any.md

### DIFF
--- a/src/fn/closures/closure_examples/iter_any.md
+++ b/src/fn/closures/closure_examples/iter_any.md
@@ -15,7 +15,7 @@ pub trait Iterator {
         // `FnMut` meaning any captured variable may at most be
         // modified, not consumed. `Self::Item` states it takes
         // arguments to the closure by value.
-        F: FnMut(Self::Item) -> bool {}
+        F: FnMut(Self::Item) -> bool;
 }
 ```
 


### PR DESCRIPTION
The last line of "pub trait Iterator” in iter_any.md is
```F: FnMut(Self::Item) -> bool {}```
but this results in a compile error.

The reason is that there is a "{}" at the end.

I think that it should be as follows.
```F: FnMut(Self::Item) -> bool;```

The playground example broken:
https://play.rust-lang.org/?version=stable&mode=debug&edition=2021&gist=8f5be8dc945faa1e70bad4039f132e83

The playground  example working:
https://play.rust-lang.org/?version=stable&mode=debug&edition=2021&gist=7c3206888e4931bb77110557231ce723