### PR TITLE
Suggest using mod.rs pattern to share test code

### DIFF
--- a/src/testing/integration_testing.md
+++ b/src/testing/integration_testing.md
@@ -47,11 +47,11 @@ running 0 tests
 test result: ok. 0 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out
 ```
 
-Each Rust source file in the `tests` directory is compiled as a separate crate. One
-way of sharing some code between integration tests is making a module with public
+Each Rust source file in the `tests` directory is compiled as a separate crate. In
+order to share some code between integration tests we can make a module with public
 functions, importing and using it within tests.
 
-File `tests/common.rs`:
+File `tests/common/mod.rs`:
 
 ```rust,ignore
 pub fn setup() {
@@ -74,8 +74,9 @@ fn test_add() {
 }
 ```
 
-Modules with common code follow the ordinary [modules][mod] rules, so it's ok to
-create common module as `tests/common/mod.rs`.
+Creating the module as `tests/common.rs` also works, but is not recommended
+because the test runner will treat the file as a test crate and try to run tests
+inside it.
 
 [unit]: unit_testing.md
 [mod]: ../mod.md


### PR DESCRIPTION
This brings the information inline with how it's presented in the Rust book[1]
with regarding on how to structure common/shared code in integration tests.

[1] https://doc.rust-lang.org/book/ch11-03-test-organization.html#submodules-in-integration-tests