### PR TITLE
fix a compile error in iter_find.md

### DIFF
--- a/src/fn/closures/closure_examples/iter_find.md
+++ b/src/fn/closures/closure_examples/iter_find.md
@@ -15,7 +15,7 @@ pub trait Iterator {
         // `FnMut` meaning any captured variable may at most be
         // modified, not consumed. `&Self::Item` states it takes
         // arguments to the closure by reference.
-        P: FnMut(&Self::Item) -> bool {}
+        P: FnMut(&Self::Item) -> bool;
 }
 ```
 


### PR DESCRIPTION
The last line of "pub trait Iterator” in iter_find.md is
```P: FnMut(&Self::Item) -> bool {}```
but this results in a compile error.

The reason is that there is a "{}" at the end.

I think that it should be as follows.
```P: FnMut(&Self::Item) -> bool;```


Playground example broken:
https://play.rust-lang.org/?version=stable&mode=debug&edition=2021&gist=9044cf7161b4c00819faf7e44f542d9b

Playground example working:
https://play.rust-lang.org/?version=stable&mode=debug&edition=2021&gist=b2874b986d8bc2434ef971b303fa73db