### PR TITLE
Fix incorrect padding in fixed-width print

### DIFF
--- a/src/hello/print.md
+++ b/src/hello/print.md
@@ -38,10 +38,10 @@ fn main() {
     println!("Base 16 (hexadecimal) repr: {:X}", 69420);
 
     // You can right-align text with a specified width. This will output
-    // "     1". 5 white spaces and a "1".
+    // "    1". 4 white spaces and a "1", for a total width of 5.
     println!("{number:>5}", number=1);
 
-    // You can pad numbers with extra zeroes. This will output "000001".
+    // You can pad numbers with extra zeroes. This will output "00001".
     println!("{number:0>5}", number=1);
 
     // You can use named arguments in the format specifier by appending a `$`


### PR DESCRIPTION
When using fixed-width padded strings, the explanation/example adds an extra padding character.
println!("{number:>5}", number=1); formats the string to length 5, but the example text displays a string of width 6.
Similarly:
println!("{number:0>5}", number=1); pads with four zeroes, but the example shows five zeroes and then a "1" which is incorrect.
This PR corrects both of these errors.