### PR TITLE
Make rust editable in chapter on defaults

### DIFF
--- a/src/error/option_unwrap/defaults.md
+++ b/src/error/option_unwrap/defaults.md
@@ -8,7 +8,7 @@ The is more than one way to unpack an `Option` and fall back on a default if it 
 
 `or()`is chainable and eagerly evaluates its argument, as is shown in the following example. Note that because `or`'s arguments are evaluated eagerly, the variable passed to `or` is moved.
 
-```
+```rust,editable
 #[derive(Debug)] 
 enum Fruit { Apple, Orange, Banana, Kiwi, Lemon }
 
@@ -33,7 +33,7 @@ fn main() {
 
 Another alternative is to use `or_else`, which is also chainable, and evaluates lazily, as is shown in the following example:
 
-```
+```rust,editable
 #[derive(Debug)] 
 enum Fruit { Apple, Orange, Banana, Kiwi, Lemon }
 
@@ -62,7 +62,7 @@ fn main() {
 
 To make sure that an `Option` contains a value, we can use `get_or_insert` to modify it in place with a fallback value, as is shown in the following example. Note that `get_or_insert` eagerly evaluaes its parameter, so variable `apple` is moved:
 
-```
+```rust,editable
 #[derive(Debug)] 
 enum Fruit { Apple, Orange, Banana, Kiwi, Lemon }
 
@@ -82,7 +82,7 @@ fn main() {
 ##  `get_or_insert_with()` evaluates lazily, modifies empty value im place
 
 Instead of explicitly providing a value to fall back on, we can pass a closure to `get_or_insert_with`, as follows:
-```
+```rust,editable
 #[derive(Debug)] 
 enum Fruit { Apple, Orange, Banana, Kiwi, Lemon }
 

--- a/src/error/option_unwrap/defaults.md
+++ b/src/error/option_unwrap/defaults.md
@@ -58,7 +58,7 @@ fn main() {
 }
 ```
 
-##  `get_or_insert()` evaluates eagerly, modifies empty value im place
+##  `get_or_insert()` evaluates eagerly, modifies empty value in place
 
 To make sure that an `Option` contains a value, we can use `get_or_insert` to modify it in place with a fallback value, as is shown in the following example. Note that `get_or_insert` eagerly evaluaes its parameter, so variable `apple` is moved:
 
@@ -79,7 +79,7 @@ fn main() {
 }
 ```
 
-##  `get_or_insert_with()` evaluates lazily, modifies empty value im place
+##  `get_or_insert_with()` evaluates lazily, modifies empty value in place
 
 Instead of explicitly providing a value to fall back on, we can pass a closure to `get_or_insert_with`, as follows:
 ```rust,editable


### PR DESCRIPTION
* add `rust,editable` to code examples
* fix typo: replace `im` with `in`