### PR TITLE
Update doc comment to link to name field without compilation warning

### DIFF
--- a/src/meta/doc.md
+++ b/src/meta/doc.md
@@ -44,7 +44,7 @@ impl Person {
 
     /// Gives a friendly hello!
     ///
-    /// Says "Hello, [name]" to the `Person` it is called on.
+    /// Says "Hello, [name](Person::name)" to the `Person` it is called on.
     pub fn hello(& self) {
         println!("Hello, {}!", self.name);
     }


### PR DESCRIPTION
Was getting compilation error when running `cargo doc` using code example: https://doc.rust-lang.org/rust-by-example/meta/doc.html. `no item named `name` in scope`

I haven't tried tried compiling as lib, didn't think there was any difference in doc compilation warning, so decided to amend the example.  
