### PR TITLE
in Meta, replace 'playpen' with 'playground'

### DIFF
--- a/src/SUMMARY.md
+++ b/src/SUMMARY.md
@@ -219,4 +219,4 @@
 
 - [Meta](meta.md)
     - [Documentation](meta/doc.md)
-    - [Playpen](meta/playpen.md)
+    - [Playground](meta/playground.md)

--- a/src/meta.md
+++ b/src/meta.md
@@ -6,7 +6,7 @@ everyone. These topics include:
 
 - [Documentation][doc]: Generate library documentation for users via the included
   `rustdoc`.
-- [Playpen][playpen]: Integrate the Rust Playpen (also known as the Rust Playground) in your documentation.
+- [Playground][playground]: Integrate the Rust Playground in your documentation.
 
 [doc]: meta/doc.md
-[playpen]: meta/playpen.md
+[playground]: meta/playground.md

--- a/src/meta/playground.md
+++ b/src/meta/playground.md
@@ -1,6 +1,6 @@
-# Playpen
+# Playground
 
-The [Rust Playpen](https://github.com/rust-lang/rust-playpen) is a way to experiment with Rust code through a web interface. This project is now commonly referred to as [Rust Playground](https://play.rust-lang.org/).
+The [Rust Playground](https://play.rust-lang.org/) is a way to experiment with Rust code through a web interface.
 
 ## Using it with `mdbook`
 
@@ -35,11 +35,11 @@ You may have noticed in some of the [official Rust docs][official-rust-docs] a b
 ### See also:
 
 - [The Rust Playground][rust-playground]
-- [The next-gen playpen][next-gen-playpen]
+- [rust-playground][rust-playground]
 - [The rustdoc Book][rustdoc-book]
 
 [rust-playground]: https://play.rust-lang.org/
-[next-gen-playpen]: https://github.com/integer32llc/rust-playground/
+[rust-playground]: https://github.com/integer32llc/rust-playground/
 [mdbook]: https://github.com/rust-lang/mdBook
 [official-rust-docs]: https://doc.rust-lang.org/core/
 [rustdoc-book]: https://doc.rust-lang.org/rustdoc/what-is-rustdoc.html


### PR DESCRIPTION
The rust-lang/rust-playpen github is marked as archived and points
to integer32llc/rust-playground

Integer32 hosts https://play.rust-lang.org
It seems the 'playpen' references can be fully removed and replaced with
just 'playground'
