### PR TITLE
Fix assorted typos in docs

### DIFF
--- a/src/error/option_unwrap/defaults.md
+++ b/src/error/option_unwrap/defaults.md
@@ -60,7 +60,7 @@ fn main() {
 
 ##  `get_or_insert()` evaluates eagerly, modifies empty value in place
 
-To make sure that an `Option` contains a value, we can use `get_or_insert` to modify it in place with a fallback value, as is shown in the following example. Note that `get_or_insert` eagerly evaluaes its parameter, so variable `apple` is moved:
+To make sure that an `Option` contains a value, we can use `get_or_insert` to modify it in place with a fallback value, as is shown in the following example. Note that `get_or_insert` eagerly evaluates its parameter, so variable `apple` is moved:
 
 ```rust,editable
 #[derive(Debug)] 
@@ -75,7 +75,7 @@ fn main() {
     // my_fruit is: Apple
     // first_available_fruit is: Apple
     //println!("Variable named `apple` is moved: {:?}", apple);
-    // TODO: uncomment the line above to see the compliler error
+    // TODO: uncomment the line above to see the compiler error
 }
 ```
 

--- a/src/flow_control/match/guard.md
+++ b/src/flow_control/match/guard.md
@@ -5,7 +5,7 @@ A `match` *guard* can be added to filter the arm.
 ```rust,editable
 enum Temperature {
     Celsius(i32),
-    Farenheit(i32),
+    Fahrenheit(i32),
 }
 
 fn main() {
@@ -17,8 +17,8 @@ fn main() {
         // The `if condition` part ^ is a guard
         Temperature::Celsius(t) => println!("{}C is below 30 Celsius", t),
 
-        Temperature::Farenheit(t) if t > 86 => println!("{}F is above 86 Farenheit", t),
-        Temperature::Farenheit(t) => println!("{}F is below 86 Farenheit", t),
+        Temperature::Fahrenheit(t) if t > 86 => println!("{}F is above 86 Fahrenheit", t),
+        Temperature::Fahrenheit(t) => println!("{}F is below 86 Fahrenheit", t),
     }
 }
 ```

--- a/src/std/str.md
+++ b/src/std/str.md
@@ -69,7 +69,7 @@ This way you can add any character to your string, even unprintable ones
 and ones that you don't know how to type. If you want a literal backslash,
 escape it with another one: `\\`
 
-String or character literal delimiters occuring within a literal must be escaped: `"\""`, `'\''`.
+String or character literal delimiters occurring within a literal must be escaped: `"\""`, `'\''`.
 
 ```rust,editable
 fn main() {

--- a/src/unsafe/asm.md
+++ b/src/unsafe/asm.md
@@ -333,7 +333,7 @@ In some cases, fine control is needed over the way a register name is formatted 
 
 By default the compiler will always choose the name that refers to the full register size (e.g. `rax` on x86-64, `eax` on x86, etc).
 
-This default can be overriden by using modifiers on the template string operands, just like you would with format strings:
+This default can be overridden by using modifiers on the template string operands, just like you would with format strings:
 
 ```rust
 use std::arch::asm;


### PR DESCRIPTION
This PR simply fixes a couple of typos.