### PR TITLE
use consistent wording about type annotation

### DIFF
--- a/src/conversion/from_into.md
+++ b/src/conversion/from_into.md
@@ -66,7 +66,7 @@ impl From<i32> for Number {
 
 fn main() {
     let int = 5;
-    // Try removing the type declaration
+    // Try removing the type annotation
     let num: Number = int.into();
     println!("My number is {:?}", num);
 }


### PR DESCRIPTION
Hello! This syntax has been referenced and introduced as type *annotation* in the previous chapters. Would my proposed change be correct? Thanks!