### PR TITLE
struct_visibility.md:  Remove unneeded '#[allow(dead_code)]'

### DIFF
--- a/src/mod/struct_visibility.md
+++ b/src/mod/struct_visibility.md
@@ -13,7 +13,6 @@ mod my {
     }
 
     // A public struct with a private field of generic type `T`
-    #[allow(dead_code)]
     pub struct ClosedBox<T> {
         contents: T,
     }


### PR DESCRIPTION
Directive to allow dead code on struct ClosedBox is not needed and confusing.  It is used when calling using the public constructor about line 44: `let _closed_box = my::ClosedBox::new("classified information");`