### PR TITLE
added "see also" for the @ binding sigil in match destructuring of arrays/slices

### DIFF
--- a/src/flow_control/match/destructuring/destructure_slice.md
+++ b/src/flow_control/match/destructuring/destructure_slice.md
@@ -45,4 +45,4 @@ fn main() {
 
 ### See also:
 
-[Arrays and Slices](../../../primitives/array.md)
+[Arrays and Slices](../../../primitives/array.md) and [Binding](../binding.md) for `@` sigil


### PR DESCRIPTION
In 8.5.1.2 "arrays/slices" the binding sigil `@` is briefly introduced in code before being explained in 8.5.3.
When I first encountered it, it lead me through some unnecessary searching that could've been avoided if there was a link for further explanation on the same page.

So, I amended the "see also" part of the arrays/slices match destructuring page.