### PR TITLE
Fix typo in iter_result.md

### DIFF
--- a/src/error/iter_result.md
+++ b/src/error/iter_result.md
@@ -51,7 +51,7 @@ fn main() {
 
 ## Fail the entire operation with `collect()`
 
-`Result` implements `FromIter` so that a vector of results (`Vec<Result<T, E>>`)
+`Result` implements `FromIterator` so that a vector of results (`Vec<Result<T, E>>`)
 can be turned into a result with a vector (`Result<Vec<T>, E>`). Once an
 `Result::Err` is found, the iteration will terminate.
 


### PR DESCRIPTION
This is a fix of a typo in a trait name. I replaced `FromIter` with `FromIterator`.