### PR TITLE
avoid reserved keyword try as crate name

### DIFF
--- a/src/testing/doc_testing.md
+++ b/src/testing/doc_testing.md
@@ -83,7 +83,7 @@ and `unwrap` it in hidden `main`. Sounds complicated? Here's an example:
 /// ```
 /// # // hidden lines start with `#` symbol, but they're still compilable!
 /// # fn try_main() -> Result<(), String> { // line that wraps the body shown in doc
-/// let res = try::try_div(10, 2)?;
+/// let res = doccomments::try_div(10, 2)?;
 /// # Ok(()) // returning from try_main
 /// # }
 /// # fn main() { // starting main that'll unwrap()


### PR DESCRIPTION
Hello! I've tried to create a crate for the example but it seems `try` is not a valid crate name. A valid alternative is to continue using the `doccomments` package name from the previous example.

```shell
cargo new --lib try
# error: the name `try` cannot be used as a package name, it is a Rust keyword
# If you need a package name to not match the directory name, consider using --name flag.
```