### PR TITLE
fix crate name in example

### DIFF
--- a/src/unsafe/asm.md
+++ b/src/unsafe/asm.md
@@ -227,7 +227,7 @@ This state is generally referred to as being "clobbered".
 We need to tell the compiler about this since it may need to save and restore this state around the inline assembly block.
 
 ```rust
-use core::arch::asm;
+use std::arch::asm;
 
 fn main() {
     // three entries of four bytes each


### PR DESCRIPTION
I think `core::arch::asm` is the actual new way of importing the crate, but it does not yet seem to work for me. The other examples are still using `std::arch::asm` anyways. 

I imagine a batch correction can be performed eventually.

``` shell
rustc --version
# rustc 1.63.0 (4b91a6ea7 2022-08-08)
rustc learn-8.rs
# error[E0433]: failed to resolve: maybe a missing crate `core`?
#  --> learn-8.rs:1:5
#   |
# 1 | use core::arch::asm;
#   |     ^^^^ maybe a missing crate `core`?
#   |
#   = help: consider adding `extern crate core` to use the `core` crate
# 
# error: cannot determine resolution for the macro `asm`
#   --> learn-8.rs:12:9
#    |
# 12 |         asm!(
#    |         ^^^
#    |
#    = note: import resolution is stuck, try simplifying macro imports
# 
# error: aborting due to 2 previous errors
# 
# For more information about this error, try `rustc --explain E0433`.
```