### PR TITLE
fix #1608: Array - out-of-bound indexing is a runtime error

### DIFF
--- a/src/primitives/array.md
+++ b/src/primitives/array.md
@@ -64,7 +64,7 @@ fn main() {
         }
     }
 
-    // Out of bound indexing causes compile error
+    // Out of bound indexing causes runtime error
     //println!("{}", xs[5]);
 }
 ```


### PR DESCRIPTION
Fixes #1608 
Fixes #1575
Out-of-bound indexing is a runtime error, not a compile-time error