### PR TITLE
diverging: fix issues with example code

### DIFF
--- a/src/fn/diverging.md
+++ b/src/fn/diverging.md
@@ -21,8 +21,8 @@ fn some_fn() {
 }
 
 fn main() {
-    let a: () = some_fn();
-    println!("This function returns and you can see this line.")
+    let _a: () = some_fn();
+    println!("This function returns and you can see this line.");
 }
 ```
 


### PR DESCRIPTION
- Fixes code not compiling due to missing semicolon
- Fixes warning about the unused variable `a`