### PR TITLE
fix erroneous white spaces in types/cast.md

### DIFF
--- a/src/types/cast.md
+++ b/src/types/cast.md
@@ -22,7 +22,7 @@ fn main() {
     let integer = decimal as u8;
     let character = integer as char;
 
-    // Error! There are limitations in conversion rules. 
+    // Error! There are limitations in conversion rules.
     // A float cannot be directly converted to a char.
     let character = decimal as char;
     // FIXME ^ Comment out this line
@@ -52,7 +52,7 @@ fn main() {
 
     // Unless it already fits, of course.
     println!(" 128 as a i16 is: {}", 128 as i16);
-    
+
     // 128 as u8 -> 128, whose value in 8-bit two's complement representation is:
     println!(" 128 as a i8 is : {}", 128 as i8);
 
@@ -61,21 +61,21 @@ fn main() {
     println!("1000 as a u8 is : {}", 1000 as u8);
     // and the value of 232 in 8-bit two's complement representation is -24
     println!(" 232 as a i8 is : {}", 232 as i8);
-    
-    // Since Rust 1.45, the `as` keyword performs a *saturating cast* 
-    // when casting from float to int. If the floating point value exceeds 
-    // the upper bound or is less than the lower bound, the returned value 
+
+    // Since Rust 1.45, the `as` keyword performs a *saturating cast*
+    // when casting from float to int. If the floating point value exceeds
+    // the upper bound or is less than the lower bound, the returned value
     // will be equal to the bound crossed.
-    
+
     // 300.0 as u8 is 255
     println!(" 300.0 as u8 is : {}", 300.0_f32 as u8);
     // -100.0 as u8 is 0
     println!("-100.0 as u8 is : {}", -100.0_f32 as u8);
     // nan as u8 is 0
     println!("   nan as u8 is : {}", f32::NAN as u8);
-    
-    // This behavior incurs a small runtime cost and can be avoided 
-    // with unsafe methods, however the results might overflow and 
+
+    // This behavior incurs a small runtime cost and can be avoided
+    // with unsafe methods, however the results might overflow and
     // return **unsound values**. Use these methods wisely:
     unsafe {
         // 300.0 as u8 is 44


### PR DESCRIPTION
Sorry, I know that the change is super super minor, just happened to notice this as I was trying to relearn the language again and got a *super* tiny *bit* annoyed. I promise I'm not doing it for Hacktoberfest or something like that :D