### PR TITLE
Remove --edition from src/crates/using_lib.md

### DIFF
--- a/src/crates/using_lib.md
+++ b/src/crates/using_lib.md
@@ -20,7 +20,7 @@ fn main() {
 ```txt
 # Where library.rlib is the path to the compiled library, assumed that it's
 # in the same directory here:
-$ rustc executable.rs --extern rary=library.rlib --edition=2018 && ./executable 
+$ rustc executable.rs --extern rary=library.rlib && ./executable 
 called rary's `public_function()`
 called rary's `indirect_access()`, that
 > called rary's `private_function()`


### PR DESCRIPTION
It's already past 2021, we might as well presume that a newcomer won't be using an older version to learn instead of updating this parameter once every 3 years.