### PR TITLE
Add documentation for let-else.

### DIFF
--- a/src/SUMMARY.md
+++ b/src/SUMMARY.md
@@ -59,6 +59,7 @@
         - [Guards](flow_control/match/guard.md)
         - [Binding](flow_control/match/binding.md)
     - [if let](flow_control/if_let.md)
+    - [let-else](flow_control/let_else.md)
     - [while let](flow_control/while_let.md)
 
 - [Functions](fn.md)

--- a/src/flow_control/let_else.md
+++ b/src/flow_control/let_else.md
@@ -9,6 +9,8 @@ in the surrounding scope like a normal `let`, or else diverge (e.g. `break`,
 `return`, `panic!`) when the pattern doesn't match.
 
 ```rust
+use std::str::FromStr;
+
 fn get_count_item(s: &str) -> (u64, &str) {
     let mut it = s.split(' ');
     let (Some(count_str), Some(item)) = (it.next(), it.next()) else {
@@ -19,6 +21,7 @@ fn get_count_item(s: &str) -> (u64, &str) {
     };
     (count, item)
 }
+
 assert_eq!(get_count_item("3 chairs"), (3, "chairs"));
 ```
 
@@ -27,6 +30,10 @@ The scope of name bindings is the main thing that makes this different from
 patterns with an unfortunate bit of repetition and an outer `let`:
 
 ```rust
+# use std::str::FromStr;
+# 
+# fn get_count_item(s: &str) -> (u64, &str) {
+#     let mut it = s.split(' ');
     let (count_str, item) = match (it.next(), it.next()) {
         (Some(count_str), Some(item)) => (count_str, item),
         _ => panic!("Can't segment count item pair: '{s}'"),
@@ -36,6 +43,10 @@ patterns with an unfortunate bit of repetition and an outer `let`:
     } else {
         panic!("Can't parse integer: '{count_str}'");
     };
+#     (count, item)
+# }
+# 
+# assert_eq!(get_count_item("3 chairs"), (3, "chairs"));
 ```
 
 ### See also:

--- a/src/flow_control/let_else.md
+++ b/src/flow_control/let_else.md
@@ -1,0 +1,49 @@
+# let-else
+
+
+> 🛈 stable since: rust 1.65
+
+
+With `let`-`else`, a refutable pattern can match and bind variables
+in the surrounding scope like a normal `let`, or else diverge (e.g. `break`,
+`return`, `panic!`) when the pattern doesn't match.
+
+```rust
+fn get_count_item(s: &str) -> (u64, &str) {
+    let mut it = s.split(' ');
+    let (Some(count_str), Some(item)) = (it.next(), it.next()) else {
+        panic!("Can't segment count item pair: '{s}'");
+    };
+    let Ok(count) = u64::from_str(count_str) else {
+        panic!("Can't parse integer: '{count_str}'");
+    };
+    (count, item)
+}
+assert_eq!(get_count_item("3 chairs"), (3, "chairs"));
+```
+
+The scope of name bindings is the main thing that makes this different from
+`match` or `if let`-`else` expressions. You could previously approximate these
+patterns with an unfortunate bit of repetition and an outer `let`:
+
+```rust
+    let (count_str, item) = match (it.next(), it.next()) {
+        (Some(count_str), Some(item)) => (count_str, item),
+        _ => panic!("Can't segment count item pair: '{s}'"),
+    };
+    let count = if let Ok(count) = u64::from_str(count_str) {
+        count
+    } else {
+        panic!("Can't parse integer: '{count_str}'");
+    };
+```
+
+### See also:
+
+[option][option], [match][match], [if let][if_let] and the [let-else RFC][let_else_rfc].
+
+
+[match]: ./match.md
+[if_let]: ./if_let.md
+[let_else_rfc]: https://rust-lang.github.io/rfcs/3137-let-else.html
+[option]: ../std/option.md


### PR DESCRIPTION
Text mostly copied from the [rust 1.65 announcement](https://blog.rust-lang.org/2022/11/03/Rust-1.65.0.html#let-else-statements.
).

I inserted the section after `if let` as it seemed the most natural to me.

I used the wording `let`-`else` as opposed to `let else` because the rust 1.65 announcement does so as well. 

It might make sense to coordinate this with #1623.

Closes #1639 