### PR TITLE
Migrate from highfive to triagebot

### DIFF
--- a/triagebot.toml
+++ b/triagebot.toml
@@ -1,1 +1,4 @@
 [assign]
+
+[assign.owners]
+"*" = ["@marioidival"]


### PR DESCRIPTION
This migrates this repository from using the highfive bot to using triagebot (aka rustbot).

This should not be merged without coordinating the removal of the highfive webhook and/or merging https://github.com/rust-lang/highfive/pull/434.