### PR TITLE
Fix sample code mismatching its comments

### DIFF
--- a/src/error/option_unwrap/defaults.md
+++ b/src/error/option_unwrap/defaults.md
@@ -98,7 +98,7 @@ fn main() {
     println!("my_fruit is: {:?}", my_fruit);
     // Providing lemon as fallback
     // first_available_fruit is: Lemon
-    // my_fruit is: Lemon
+    // my_fruit is: Some(Lemon)
 
     // If the Option has a value, it is left unchanged, and the closure is not invoked
     let mut my_apple = Some(Fruit::Apple);

--- a/src/error/option_unwrap/defaults.md
+++ b/src/error/option_unwrap/defaults.md
@@ -94,11 +94,11 @@ fn main() {
     };
     let first_available_fruit = my_fruit
         .get_or_insert_with(get_lemon_as_fallback);
-    println!("my_fruit is: {:?}", first_available_fruit);
     println!("first_available_fruit is: {:?}", first_available_fruit);
+    println!("my_fruit is: {:?}", my_fruit);
     // Providing lemon as fallback
-    // my_fruit is: Lemon
     // first_available_fruit is: Lemon
+    // my_fruit is: Lemon
 
     // If the Option has a value, it is left unchanged, and the closure is not invoked
     let mut my_apple = Some(Fruit::Apple);


### PR DESCRIPTION
I assume the intention was to demonstrate how `get_or_insert_with()` can modify value in place. If that's the case, the code should print `my_fruit`, instead of printing `first_available_fruit` twice. 

However, I need to swap the order of the two prints to avoid borrow checker issue