### PR TITLE
types/alias: use io::{Result,Error} instead of Io{Result,Error}

### DIFF
--- a/src/types/alias.md
+++ b/src/types/alias.md
@@ -24,8 +24,8 @@ fn main() {
 }
 ```
 
-The main use of aliases is to reduce boilerplate; for example the `IoResult<T>` type
-is an alias for the `Result<T, IoError>` type.
+The main use of aliases is to reduce boilerplate; for example the `io::Result<T>` type
+is an alias for the `Result<T, io::Error>` type.
 
 ### See also:
 


### PR DESCRIPTION
seealso: https://github.com/rust-lang/rust-by-example/pull/537