### PR TITLE
update std_misc/file/create.md: fixed grammar

### DIFF
--- a/src/std_misc/file/create.md
+++ b/src/std_misc/file/create.md
@@ -53,6 +53,6 @@ proident, sunt in culpa qui officia deserunt mollit anim id est laborum.
 (As in the previous example, you are encouraged to test this example under
 failure conditions.)
 
-There is [`OpenOptions`] struct that can be used to configure how a file is opened.
+The [`OpenOptions`] struct can be used to configure how a file is opened.
 
 [`OpenOptions`]: https://doc.rust-lang.org/std/fs/struct.OpenOptions.html


### PR DESCRIPTION
Changed line from

> There is [`OpenOptions`](https://doc.rust-lang.org/std/fs/struct.OpenOptions.html) struct that can be used to configure how a file is opened.

to

> The [OpenOptions](https://doc.rust-lang.org/std/fs/struct.OpenOptions.html) struct can be used to configure how a file is opened.

Using "there is" as a way to mark existence, without qualifiers or articles, is an experimental feature and is prone to instability.  I have changed the line to an implicit declaration of existence that can be parsed on most standard implementations of English.