### PR TITLE
fix incorrect trait bound demonstration

### DIFF
--- a/src/generics/bounds.md
+++ b/src/generics/bounds.md
@@ -58,10 +58,10 @@ fn main() {
     let _triangle = Triangle  { length: 3.0, height: 4.0 };
 
     print_debug(&rectangle);
-    println!("Area: {}", rectangle.area());
+    println!("Area: {}", area(&rectangle));
 
     //print_debug(&_triangle);
-    //println!("Area: {}", _triangle.area());
+    //println!("Area: {}", area(&_triangle));
     // ^ TODO: Try uncommenting these.
     // | Error: Does not implement either `Debug` or `HasArea`. 
 }


### PR DESCRIPTION
### Motivation
- The trait bound issue should be demonstrated using generic function rather than method in this demo.
- Method ```area``` is not defined on ``` _triangle``` . Uncomment the line and compile it gives a _method not defined_ error rather than anything related to generic type bound issue.
- Besides, the compiler generates a ```fn area``` unused warning which is not consistent with the rest of the book.