### PR TITLE
Line comments: change 'inside' to 'after'

### DIFF
--- a/src/hello/comment.md
+++ b/src/hello/comment.md
@@ -14,7 +14,7 @@ a few different varieties:
 fn main() {
     // This is an example of a line comment.
     // There are two slashes at the beginning of the line.
-    // And nothing written inside these will be read by the compiler.
+    // And nothing written after these will be read by the compiler.
 
     // println!("Hello, world!");
 


### PR DESCRIPTION
For line comments, it makes more sense to talk about text written 'after' the slashes rather than 'between' the slashes