### PR TITLE
fix irrelevant comments

### DIFF
--- a/src/error/result/result_map.md
+++ b/src/error/result/result_map.md
@@ -56,7 +56,7 @@ use std::num::ParseIntError;
 
 // As with `Option`, we can use combinators such as `map()`.
 // This function is otherwise identical to the one above and reads:
-// Modify n if the value is valid, otherwise pass on the error.
+// Multiply if both values can be parsed from str, otherwise pass on the error.
 fn multiply(first_number_str: &str, second_number_str: &str) -> Result<i32, ParseIntError> {
     first_number_str.parse::<i32>().and_then(|first_number| {
         second_number_str.parse::<i32>().map(|second_number| first_number * second_number)


### PR DESCRIPTION
Mentioned ```n``` in the comment does not exists, and nothing is _modified_ either.