### PR TITLE
Fix comment to mention the correct type of error

### DIFF
--- a/src/primitives/array.md
+++ b/src/primitives/array.md
@@ -63,7 +63,7 @@ fn main() {
         }
     }
 
-    // Out of bound indexing causes runtime error.
+    // Out of bound indexing causes compile-time error.
     //println!("{}", xs[5]);
 }
 ```


### PR DESCRIPTION
Out-of-bounds indexing leads to compile-time error, as shown in below output from the playground run of this code snippet.

```
   Compiling playground v0.0.1 (/playground)
error: this operation will panic at runtime
  --> src/main.rs:54:20
   |
54 |     println!("{}", xs[5]);
   |                    ^^^^^ index out of bounds: the length is 5 but the index is 5
   |
   = note: `#[deny(unconditional_panic)]` on by default

error: could not compile `playground` due to previous error
```