### PR TITLE
Remove trailing semicolon from macro expression

### DIFF
--- a/src/macros.md
+++ b/src/macros.md
@@ -16,12 +16,12 @@ macro_rules! say_hello {
     // `()` indicates that the macro takes no argument.
     () => {
         // The macro will expand into the contents of this block.
-        println!("Hello!");
+        println!("Hello!")
     };
 }
 
 fn main() {
-    // This call will expand into `println!("Hello");`
+    // This call will expand into `println!("Hello")`
     say_hello!()
 }
 ```


### PR DESCRIPTION
Trailing semicolon in macro expression is being phased out.

The Rust compiler gives the following warning when compiling this code.

```
warning: trailing semicolon in macro used in expression position
  --> macro.rs:6:27
   |
6  |         println!("Hello!");
   |                           ^
...
12 |     say_hello!()
   |     ------------ in this macro invocation
   |
   = note: `#[warn(semicolon_in_expressions_from_macros)]` on by default
   = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
   = note: for more information, see issue #79813 <https://github.com/rust-lang/rust/issues/79813>
   = note: macro invocations at the end of a block are treated as expressions
   = note: to ignore the value produced by the macro, add a semicolon after the invocation of `say_hello`
   = note: this warning originates in the macro `say_hello` (in Nightly builds, run with -Z macro-backtrace for more info)

warning: 1 warning emitted
```