### PR TITLE
Allow dead code to avoid warning

### DIFF
--- a/src/flow_control/match/guard.md
+++ b/src/flow_control/match/guard.md
@@ -3,6 +3,7 @@
 A `match` *guard* can be added to filter the arm.
 
 ```rust,editable
+#[allow(dead_code)]
 enum Temperature {
     Celsius(i32),
     Fahrenheit(i32),


### PR DESCRIPTION
Without it the compiler generates following warning:
```
warning: variant `Fahrenheit` is never constructed
```