### PR TITLE
Remove explicit .iter() / deref from fmt chapter

### DIFF
--- a/src/hello/print/fmt.md
+++ b/src/hello/print/fmt.md
@@ -49,17 +49,17 @@ fn main() {
         City { name: "Dublin", lat: 53.347778, lon: -6.259722 },
         City { name: "Oslo", lat: 59.95, lon: 10.75 },
         City { name: "Vancouver", lat: 49.25, lon: -123.1 },
-    ].iter() {
-        println!("{}", *city);
+    ] {
+        println!("{}", city);
     }
     for color in [
         Color { red: 128, green: 255, blue: 90 },
         Color { red: 0, green: 3, blue: 254 },
         Color { red: 0, green: 0, blue: 0 },
-    ].iter() {
+    ] {
         // Switch this to use {} once you've added an implementation
         // for fmt::Display.
-        println!("{:?}", *color);
+        println!("{:?}", color);
     }
 }
 ```


### PR DESCRIPTION
Removes unnecessary usage of the dereferencing operator from the early formatting chapter.
With this change, for-loop desugaring and the introduction of the dereferencing operator is deferred until (I think) chapter 8.4 ("for and range").