### PR TITLE
Make REUSE ignore `valgrind` copyright statements

### DIFF
--- a/src/scope/raii.md
+++ b/src/scope/raii.md
@@ -41,6 +41,8 @@ fn main() {
 
 Of course, we can double check for memory errors using [`valgrind`][valgrind]:
 
+<!-- REUSE-IgnoreStart -->
+<!-- Prevent REUSE from parsing the copyright statement in the sample code -->
 ```shell
 $ rustc raii.rs && valgrind ./raii
 ==26873== Memcheck, a memory error detector
@@ -58,6 +60,7 @@ $ rustc raii.rs && valgrind ./raii
 ==26873== For counts of detected and suppressed errors, rerun with: -v
 ==26873== ERROR SUMMARY: 0 errors from 0 contexts (suppressed: 2 from 2)
 ```
+<!-- REUSE-IgnoreEnd -->
 
 No leaks here!
 

--- a/src/std/panic.md
+++ b/src/std/panic.md
@@ -34,6 +34,8 @@ fn main() {
 
 Let's check that `panic!` doesn't leak memory.
 
+<!-- REUSE-IgnoreStart -->
+<!-- Prevent REUSE from parsing the copyright statement in the sample code -->
 ```shell
 $ rustc panic.rs && valgrind ./panic
 ==4401== Memcheck, a memory error detector
@@ -52,3 +54,4 @@ thread '<main>' panicked at 'division by zero', panic.rs:5
 ==4401== For counts of detected and suppressed errors, rerun with: -v
 ==4401== ERROR SUMMARY: 0 errors from 0 contexts (suppressed: 0 from 0)
 ```
+<!-- REUSE-IgnoreEnd -->


### PR DESCRIPTION
As part of https://github.com/rust-lang/rust/issues/99414 I'm implementing support for REUSE in the rust-lang/rust repository (of which this repository is a submodule) to automatically gather licensing information.

Unfortunately REUSE is occasionally too eager to find copyright statements, and in this case it's marking those files as being copyrighted by `2002-2013, and GNU GPL'd, by Julian Seward et al.`. This PR adds ignore comments to prevent that from happening.