### PR TITLE
Add clarity to name of file being used in library example.

### DIFF
--- a/src/crates/lib.md
+++ b/src/crates/lib.md
@@ -2,6 +2,8 @@
 
 Let's create a library, and then see how to link it to another crate.
 
+In `rary.rs`:
+
 ```rust,ignore
 pub fn public_function() {
     println!("called rary's `public_function()`");


### PR DESCRIPTION
It was really unclear that `lib` prefix was being applied to a file called `rary.rs`. Adding a file label consistent with the rest of rust-by-example.