### PR TITLE
Clarify array out-of-bounds behavior.

### DIFF
--- a/src/primitives/array.md
+++ b/src/primitives/array.md
@@ -63,7 +63,9 @@ fn main() {
         }
     }
 
-    // Out of bound indexing causes compile time error.
+    // Out of bound indexing on array causes compile time error.
     //println!("{}", xs[5]);
+    // Out of bound indexing on slice causes runtime error.
+    //println!("{}", xs[..][5]);
 }
 ```


### PR DESCRIPTION
The example says that out-of-bound indexing causes a runtime error, but 1) doesn't specify array or slice, then 2) proceeds to demonstrate with an array, which is a _compile_ error. Add both cases and clarify the prose.