### PR TITLE
Add example for destructuring structs without match

### DIFF
--- a/src/flow_control/match/destructuring/destructure_structures.md
+++ b/src/flow_control/match/destructuring/destructure_structures.md
@@ -24,6 +24,12 @@ fn main() {
         // this will give an error: pattern does not mention field `x`
         //Foo { y } => println!("y = {}", y),
     }
+
+    let faa = Foo { x: (1, 2), y: 3 };
+
+    // You do not need a match block to destructure structs:
+    let Foo { x : x0, y: y0 } = faa;
+    println!("Outside: x0 = {x0:?}, y0 = {y0}");
 }
 ```
 


### PR DESCRIPTION
Add

```rust
    // You do not need a match block to destructure structs:
    let Foo { x : x0, y: y0 } = faa;
    println!("Outside: x0 = {x0:?}, y0 = {y0}");
```