### PR TITLE
Update let-else example with main function

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -44,7 +44,7 @@ We use the following labels:
 
 ## Development workflow
 
-To build RBE, [install Rust], and then:
+To build RBE, [install Rust](https://www.rust-lang.org/tools/install), and then:
 
 ```bash
 $ git clone https://github.com/rust-lang/rust-by-example
@@ -56,7 +56,7 @@ $ mdbook build
 [install Rust]: http://rust-lang.org/install.html
 
 The files will be in the `book` directory at the top-level; `mdbook serve` will
-open the contents in your web browser.
+open the contents in your web browser ([localhost:3000](http://localhost:3000) by default).
 
 To run the tests:
 

--- a/src/flow_control/let_else.md
+++ b/src/flow_control/let_else.md
@@ -2,6 +2,9 @@
 
 
 > 🛈 stable since: rust 1.65
+>
+> 🛈 you can target specific edition by compiling like this
+> `rustc --edition=2021 main.rs`
 
 
 With `let`-`else`, a refutable pattern can match and bind variables
@@ -22,7 +25,9 @@ fn get_count_item(s: &str) -> (u64, &str) {
     (count, item)
 }
 
-assert_eq!(get_count_item("3 chairs"), (3, "chairs"));
+fn main() {
+    assert_eq!(get_count_item("3 chairs"), (3, "chairs"));
+}
 ```
 
 The scope of name bindings is the main thing that makes this different from


### PR DESCRIPTION
### Changes
* Update `CONTRIBUTING` with extra links
* Update code block to fix error
```
error[E0601]: `main` function not found in crate `letelse`
  --> letelse.rs:15:59
   |
15 |     assert_eq!(get_count_item("3 chairs"), (3, "chairs"));
   |                                                           ^ consider adding a `main` function to `letelse.rs
```
* Show hint to compile for the specific edition to eliminate warning
```
warning: panic message contains an unused formatting placeholder
 --> letelse.rs:9:39
  |
9 |         panic!("Can't parse integer: '{count_str}'");
  |                                       ^^^^^^^^^^^
  |
  = note: this message is not used as a format string when given without arguments, but will be in Rust 2021
```