### PR TITLE
Improved wording in asm.md

### DIFF
--- a/src/unsafe/asm.md
+++ b/src/unsafe/asm.md
@@ -254,7 +254,8 @@ fn main() {
     // String is stored as ascii in ebx, edx, ecx in order
     // Because ebx is reserved, the asm needs to preserve the value of it.
     // So we push and pop it around the main asm.
-    // (in 64 bit mode for 64 bit processors, 32 bit processors would use ebx)
+    // 64 bit mode on 64 bit processors does not allow pushing/popping of
+    // 32 bit registers (like ebx), so we have to use the extended rbx register instead.
 
     unsafe {
         asm!(


### PR DESCRIPTION
The old version did not make clear that and why rbx was used in the code instead of ebx (this only happens much later at the end of the explanation after the code block), and the difference between which register is used in which cpu mode wasn't clear.