### PR TITLE
Fix example in from_into.md

### DIFF
--- a/src/conversion/from_into.md
+++ b/src/conversion/from_into.md
@@ -51,16 +51,16 @@ convert into as the compiler is unable to determine this most of the time.
 However this is a small trade-off considering we get the functionality for free.
 
 ```rust,editable
-use std::convert::From;
+use std::convert::Into;
 
 #[derive(Debug)]
 struct Number {
     value: i32,
 }
 
-impl From<i32> for Number {
-    fn from(item: i32) -> Self {
-        Number { value: item }
+impl Into<Number> for i32 {
+    fn into(self) -> Number {
+        Number { value: self }
     }
 }
 


### PR DESCRIPTION
The code using `From` trait is being misused as an example for `Into` trait. I fixed it properly.