### PR TITLE
Remove awkward match in if_let

### DIFF
--- a/src/flow_control/if_let.md
+++ b/src/flow_control/if_let.md
@@ -7,11 +7,7 @@ For some use cases, when matching enums, `match` is awkward. For example:
 let optional = Some(7);
 
 match optional {
-    Some(i) => {
-        println!("This is a really long string and `{:?}`", i);
-        // ^ Needed 2 indentations just so we could destructure
-        // `i` from the option.
-    },
+    Some(i) => println!("This is a really long string and `{:?}`", i),
     _ => {},
     // ^ Required because `match` is exhaustive. Doesn't it seem
     // like wasted space?

--- a/src/flow_control/if_let.md
+++ b/src/flow_control/if_let.md
@@ -1,5 +1,24 @@
 # if let
 
+For some use cases, when matching enums, `match` is awkward. For example:
+
+```rust
+// Make `optional` of type `Option<i32>`
+let optional = Some(7);
+
+match optional {
+    Some(i) => {
+        println!("This is a really long string and `{:?}`", i);
+        // ^ Needed 2 indentations just so we could destructure
+        // `i` from the option.
+    },
+    _ => {},
+    // ^ Required because `match` is exhaustive. Doesn't it seem
+    // like wasted space?
+};
+
+```
+
 `if let` is cleaner for this use case and in addition allows various
 failure options to be specified:
 

--- a/src/flow_control/if_let.md
+++ b/src/flow_control/if_let.md
@@ -1,24 +1,5 @@
 # if let
 
-For some use cases, when matching enums, `match` is awkward. For example:
-
-```rust
-// Make `optional` of type `Option<i32>`
-let optional = Some(7);
-
-match optional {
-    Some(i) => {
-        println!("This is a really long string and `{:?}`", i);
-        // ^ Needed 2 indentations just so we could destructure
-        // `i` from the option.
-    },
-    _ => {},
-    // ^ Required because `match` is exhaustive. Doesn't it seem
-    // like wasted space?
-};
-
-```
-
 `if let` is cleaner for this use case and in addition allows various
 failure options to be specified:
 


### PR DESCRIPTION
I tried removing the braces from that code example and it compiled, so I assume this feature was introduced to rust after RBE was written thus the whole example became obsolete.
```rust
let optional = Some(7);
match optional {
  Some(i) => println!("This is a really long string and `{:?}`", i),
  _ => {}
};
```