### PR TITLE
Added attribute unused_labels - fixed warning.

### DIFF
--- a/src/flow_control/loop/nested.md
+++ b/src/flow_control/loop/nested.md
@@ -5,7 +5,7 @@ loops. In these cases, the loops must be annotated with some `'label`, and the
 label must be passed to the `break`/`continue` statement.
 
 ```rust,editable
-#![allow(unreachable_code)]
+#![allow(unreachable_code, unused_labels)]
 
 fn main() {
     'outer: loop {


### PR DESCRIPTION
rustc 1.70.0 (90c541806 2023-05-31)
warns about unused labels.