### PR TITLE
Make `Person::name` field `pub`

### DIFF
--- a/src/meta/doc.md
+++ b/src/meta/doc.md
@@ -18,7 +18,7 @@ documentation. They are denoted by a `///`, and support [Markdown].
 /// A human being is represented here
 pub struct Person {
     /// A person must have a name, no matter how much Juliet may hate it
-    name: String,
+    pub name: String,
 }
 
 impl Person {


### PR DESCRIPTION
Otherwise, the link to Person::name in the documentation of function `Person::hello` below is private, which is warned by compiler.