### PR TITLE
Misleading textual statement in HOF

### DIFF
--- a/src/fn/hof.md
+++ b/src/fn/hof.md
@@ -10,7 +10,7 @@ fn is_odd(n: u32) -> bool {
 }
 
 fn main() {
-    println!("Find the sum of all the squared odd numbers under 1000");
+    println!("Find the sum of all the numbers with odd squares under 1000");
     let upper = 1000;
 
     // Imperative approach


### PR DESCRIPTION
The example checks if the calculated square is less than 1000, and if it is odd, then adds it to the sum - not if the **not squared number** is odd. The amount of calculations is much lower than if it was checking if the not squared number is less than 1000 and then square it and add it to the sum.