### PR TITLE
Pedantic `'static` lifetime corrections

### DIFF
--- a/src/scope/lifetime/static_lifetime.md
+++ b/src/scope/lifetime/static_lifetime.md
@@ -69,7 +69,7 @@ demonstrate, the below example uses
 to dynamically create `'static` references. In that case it definitely doesn't
 live for the entire duration, but only for the leaking point onward.
 
-```rust,editable,norun
+```rust,editable,compile_fail
 extern crate rand;
 use rand::Fill;
 

--- a/src/scope/lifetime/static_lifetime.md
+++ b/src/scope/lifetime/static_lifetime.md
@@ -17,10 +17,10 @@ confusion when learning Rust. Here are some examples for each situation:
 ## Reference lifetime
 
 As a reference lifetime `'static` indicates that the data pointed to by
-the reference lives for the entire lifetime of the running program.
+the reference lives for the remaining lifetime of the running program.
 It can still be coerced to a shorter lifetime.
 
-There are two ways to make a variable with `'static` lifetime, and both
+There are two common ways to make a variable with `'static` lifetime, and both
 are stored in the read-only memory of the binary:
 
 * Make a constant with the `static` declaration.
@@ -59,6 +59,30 @@ fn main() {
     }
 
     println!("NUM: {} stays accessible!", NUM);
+}
+```
+
+Since `'static` references only need to be valid for the _remainder_ of
+a program's life, they can created while the program is executed. Just to
+demonstrate, the below example uses
+[`Box::leak`](https://doc.rust-lang.org/std/boxed/struct.Box.html#method.leak)
+to dynamically create `'static` references. In that case it definitely doesn't
+live for the entire duration, but only for the leaking point onward.
+
+```rust,editable
+use rand::Fill;
+
+fn random_vec() -> &'static [usize; 100] {
+    let mut rng = rand::thread_rng();
+    let mut boxed = Box::new([0; 100]);
+    boxed.try_fill(&mut rng).unwrap();
+    Box::leak(boxed)
+}
+
+fn main() {
+    let first: &'static [usize; 100] = random_vec();
+    let second: &'static [usize; 100] = random_vec();
+    assert_ne!(first, second)
 }
 ```
 

--- a/src/scope/lifetime/static_lifetime.md
+++ b/src/scope/lifetime/static_lifetime.md
@@ -69,7 +69,7 @@ demonstrate, the below example uses
 to dynamically create `'static` references. In that case it definitely doesn't
 live for the entire duration, but only for the leaking point onward.
 
-```rust,editable
+```rust,editable,norun
 extern crate rand;
 use rand::Fill;
 

--- a/src/scope/lifetime/static_lifetime.md
+++ b/src/scope/lifetime/static_lifetime.md
@@ -70,6 +70,7 @@ to dynamically create `'static` references. In that case it definitely doesn't
 live for the entire duration, but only for the leaking point onward.
 
 ```rust,editable
+extern crate rand;
 use rand::Fill;
 
 fn random_vec() -> &'static [usize; 100] {

--- a/src/scope/lifetime/static_lifetime.md
+++ b/src/scope/lifetime/static_lifetime.md
@@ -63,7 +63,7 @@ fn main() {
 ```
 
 Since `'static` references only need to be valid for the _remainder_ of
-a program's life, they can created while the program is executed. Just to
+a program's life, they can be created while the program is executed. Just to
 demonstrate, the below example uses
 [`Box::leak`](https://doc.rust-lang.org/std/boxed/struct.Box.html#method.leak)
 to dynamically create `'static` references. In that case it definitely doesn't


### PR DESCRIPTION
I just thought the `Box::leak` was example was too good to keep to myself - i think it further emphazises how memory leaks are safe rust.

Thank you for maintaining this project!