### PR TITLE
Update read_lines example to flatten iterator

### DIFF
--- a/src/std_misc/file/read_lines.md
+++ b/src/std_misc/file/read_lines.md
@@ -56,10 +56,8 @@ fn main() {
     // File hosts.txt must exist in the current path
     if let Ok(lines) = read_lines("./hosts.txt") {
         // Consumes the iterator, returns an (Optional) String
-        for line in lines {
-            if let Ok(ip) = line {
-                println!("{}", ip);
-            }
+        for line in lines.flatten() {
+            println!("{}", line);
         }
     }
 }


### PR DESCRIPTION
Clippy now complains about manual flatten in the original example, see https://rust-lang.github.io/rust-clippy/master/index.html#/manual_flatten