### PR TITLE
Fix incorrect note on 2.3 - primitives > arrays&slices

### DIFF
--- a/src/primitives/array.md
+++ b/src/primitives/array.md
@@ -63,7 +63,7 @@ fn main() {
         }
     }
 
-    // Out of bound indexing on array causes compile time error.
+    // Out of bound indexing on array causes runtime error.
     //println!("{}", xs[5]);
     // Out of bound indexing on slice causes runtime error.
     //println!("{}", xs[..][5]);


### PR DESCRIPTION
The comment in the example is incorrect.

Rust does not check for out of bound indexing at compile time 
https://users.rust-lang.org/t/why-index-out-of-bound-is-not-checked-at-compile-time/28393