### PR TITLE
Update while_let.md: address inconsistent use of fn main between 2 co…

### DIFF
--- a/src/flow_control/while_let.md
+++ b/src/flow_control/while_let.md
@@ -31,26 +31,24 @@ loop {
 Using `while let` makes this sequence much nicer:
 
 ```rust,editable
-fn main() {
-    // Make `optional` of type `Option<i32>`
-    let mut optional = Some(0);
+// Make `optional` of type `Option<i32>`
+let mut optional = Some(0);
 
-    // This reads: "while `let` destructures `optional` into
-    // `Some(i)`, evaluate the block (`{}`). Else `break`.
-    while let Some(i) = optional {
-        if i > 9 {
-            println!("Greater than 9, quit!");
-            optional = None;
-        } else {
-            println!("`i` is `{:?}`. Try again.", i);
-            optional = Some(i + 1);
-        }
-        // ^ Less rightward drift and doesn't require
-        // explicitly handling the failing case.
+// This reads: "while `let` destructures `optional` into
+// `Some(i)`, evaluate the block (`{}`). Else `break`.
+while let Some(i) = optional {
+    if i > 9 {
+        println!("Greater than 9, quit!");
+        optional = None;
+    } else {
+        println!("`i` is `{:?}`. Try again.", i);
+        optional = Some(i + 1);
     }
-    // ^ `if let` had additional optional `else`/`else if`
-    // clauses. `while let` does not have these.
+    // ^ Less rightward drift and doesn't require
+    // explicitly handling the failing case.
 }
+// ^ `if let` had additional optional `else`/`else if`
+// clauses. `while let` does not have these.
 ```
 
 ### See also:


### PR DESCRIPTION
…mpared code examples

The original document compares 2 code blocks to illustrate the benefits of while let. The first example **is not** placed in a main function while the second example **is** placed in a main function.

The problem: This inconsistency is significant because, among other points of comparison, they are being compared in terms of their level of indentation. Therefore...
Placing one example in a main function and not the other presents a visually unequal basis of comparison.

The solution I propose: is to just remove the main function in the second block since removing it reduces visual complexity.

I think adding in a main function to the first block and keeping the main function in the second block is also a good option. IMO consistency between the examples is what's most important.