### PR TITLE
[TRIVIAL] Remove confusing `also`

### DIFF
--- a/src/scope/move.md
+++ b/src/scope/move.md
@@ -1,7 +1,7 @@
 # Ownership and moves
 
 Because variables are in charge of freeing their own resources, 
-**resources can only have one owner**. This also prevents resources 
+**resources can only have one owner**. This prevents resources 
 from being freed more than once. Note that not all variables own 
 resources (e.g. [references]).
 


### PR DESCRIPTION
The original text says:

> Because variables are in charge of freeing their own resources, **resources can only have one owner**. This also prevents resources from being freed more than once.

After reading the second sentence, my thought was "what was the first reason?" I don't see the other reason. Both sentences carry the same idea, namely that resources should not have multiple owners so they are not freed multiple times. The second sentence is just an expanded explanation. Therefore, `also` is superfluous.