### PR TITLE
Fix typos

### DIFF
--- a/src/fn/closures.md
+++ b/src/fn/closures.md
@@ -26,7 +26,7 @@ fn main() {
     // TODO: uncomment the line above and see the compiler error. The compiler
     // suggests that we define a closure instead.
 
-    // Closures are anonymous, here we are binding them to references
+    // Closures are anonymous, here we are binding them to references.
     // Annotation is identical to function annotation but is optional
     // as are the `{}` wrapping the body. These nameless functions
     // are assigned to appropriately named variables.

--- a/src/std/hash/alt_key_types.md
+++ b/src/std/hash/alt_key_types.md
@@ -3,7 +3,7 @@
 Any type that implements the `Eq` and `Hash` traits can be a key in `HashMap`. 
 This includes:
 
-* `bool` (though not very useful since there is only two possible keys)
+* `bool` (though not very useful since there are only two possible keys)
 * `int`, `uint`, and all variations thereof
 * `String` and `&str` (protip: you can have a `HashMap` keyed by `String`
 and call `.get()` with an `&str`)

--- a/src/std_misc/file/read_lines.md
+++ b/src/std_misc/file/read_lines.md
@@ -62,7 +62,7 @@ fn main() {
     }
 }
 
-// The output is wrapped in a Result to allow matching on errors
+// The output is wrapped in a Result to allow matching on errors.
 // Returns an Iterator to the Reader of the lines of the file.
 fn read_lines<P>(filename: P) -> io::Result<io::Lines<io::BufReader<File>>>
 where P: AsRef<Path>, {

--- a/src/std_misc/threads/testcase_mapreduce.md
+++ b/src/std_misc/threads/testcase_mapreduce.md
@@ -30,7 +30,7 @@ use std::thread;
 fn main() {
 
     // This is our data to process.
-    // We will calculate the sum of all digits via a threaded  map-reduce algorithm.
+    // We will calculate the sum of all digits via a threaded map-reduce algorithm.
     // Each whitespace separated chunk will be handled in a different thread.
     //
     // TODO: see what happens to the output if you insert spaces!


### PR DESCRIPTION
Fix small typos throughout the book.

Closes:                                                 
                                                        
- https://github.com/rust-lang/rust-by-example/pull/1758
- https://github.com/rust-lang/rust-by-example/pull/1757
- https://github.com/rust-lang/rust-by-example/pull/1756