### PR TITLE
fix test name in cargo/test.md

### DIFF
--- a/src/cargo/test.md
+++ b/src/cargo/test.md
@@ -135,7 +135,7 @@ Corro
 ```
 What actually gets put into `ferris.txt` is this:
 ```shell
-$ cargo test test_file
+$ cargo test test_file && cat ferris.txt
 Corro
 Ferris
 Corro

--- a/src/cargo/test.md
+++ b/src/cargo/test.md
@@ -42,13 +42,13 @@ $ cargo test
     Finished dev [unoptimized + debuginfo] target(s) in 0.89 secs
      Running target/debug/deps/blah-d3b32b97275ec472
 
-running 3 tests
+running 4 tests
 test test_bar ... ok
 test test_baz ... ok
 test test_foo_bar ... ok
 test test_foo ... ok
 
-test result: ok. 3 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out
+test result: ok. 4 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out
 ```
 
 You can also run tests whose name matches a pattern:

--- a/src/cargo/test.md
+++ b/src/cargo/test.md
@@ -135,7 +135,7 @@ Corro
 ```
 What actually gets put into `ferris.txt` is this:
 ```shell
-$ cargo test test_foo
+$ cargo test test_file
 Corro
 Ferris
 Corro


### PR DESCRIPTION
I think the _name_ of the test being ran is incorrect.