### PR TITLE
rename `y` to `_y` to get the correct compile error

### DIFF
--- a/src/scope/lifetime/explicit.md
+++ b/src/scope/lifetime/explicit.md
@@ -40,7 +40,7 @@ fn failed_borrow<'a>() {
     let _x = 12;
 
     // ERROR: `_x` does not live long enough
-    let y: &'a i32 = &_x;
+    let _y: &'a i32 = &_x;
     // Attempting to use the lifetime `'a` as an explicit type annotation 
     // inside the function will fail because the lifetime of `&_x` is shorter
     // than that of `y`. A short lifetime cannot be coerced into a longer one.

--- a/src/scope/lifetime/explicit.md
+++ b/src/scope/lifetime/explicit.md
@@ -43,7 +43,7 @@ fn failed_borrow<'a>() {
     let _y: &'a i32 = &_x;
     // Attempting to use the lifetime `'a` as an explicit type annotation 
     // inside the function will fail because the lifetime of `&_x` is shorter
-    // than that of `y`. A short lifetime cannot be coerced into a longer one.
+    // than that of `_y`. A short lifetime cannot be coerced into a longer one.
 }
 
 fn main() {


### PR DESCRIPTION
Without this change, the error is:
```
   Compiling playground v0.0.1 (/playground)
warning: unused variable: `y`
  --> src/main.rs:13:9
   |
13 |     let y: &'a i32 = &_x;
   |         ^ help: if this is intentional, prefix it with an underscore: `_y`
   |
   = note: `#[warn(unused_variables)]` on by default

error[E0597]: `_x` does not live long enough
  --> src/main.rs:13:22
   |
9  | fn failed_borrow<'a>() {
   |                  -- lifetime `'a` defined here
10 |     let _x = 12;
   |         -- binding `_x` declared here
...
13 |     let y: &'a i32 = &_x;
   |            -------   ^^^ borrowed value does not live long enough
   |            |
   |            type annotation requires that `_x` is borrowed for `'a`
...
17 | }
   | - `_x` dropped here while still borrowed

For more information about this error, try `rustc --explain E0597`.
warning: `playground` (bin "playground") generated 1 warning
error: could not compile `playground` (bin "playground") due to previous error; 1 warning emitted
```