### PR TITLE
Remove space between `&` and `self`

### DIFF
--- a/src/meta/doc.md
+++ b/src/meta/doc.md
@@ -46,7 +46,7 @@ impl Person {
     /// Gives a friendly hello!
     ///
     /// Says "Hello, [name](Person::name)" to the `Person` it is called on.
-    pub fn hello(& self) {
+    pub fn hello(&self) {
         println!("Hello, {}!", self.name);
     }
 }


### PR DESCRIPTION
Confirmed that `rustfmt` would remove that space.