### PR TITLE
fix(arg): Remove reference to Rust Cookbook in arg parsing

### DIFF
--- a/src/std_misc/arg.md
+++ b/src/std_misc/arg.md
@@ -30,8 +30,7 @@ I got 3 arguments: ["1", "2", "3"].
 ## Crates
 
 Alternatively, there are numerous crates that can provide extra functionality
-when creating command-line applications. The [Rust Cookbook] exhibits best
-practices on how to use one of the more popular command line argument crates,
-`clap`.
+when creating command-line applications. One of the more popular command line
+argument crates being [`clap`].
 
-[Rust Cookbook]: https://rust-lang-nursery.github.io/rust-cookbook/cli/arguments.html
+[`clap`]: https://rust-cli.github.io/book/tutorial/cli-args.html#parsing-cli-arguments-with-clap


### PR DESCRIPTION
This PR removes the reference to the Rust Cookbook in the argument parsing section. The example linked is outdated and no longer works. Additionally, the repo hasn't seen any activity in a few years and rust-lang-nursery has been deprecated anyway
(https://internals.rust-lang.org/t/rust-lang-nursery-deprecation/11205).

I chose to replace it with the `rust-cli` book link that also uses a `clap` example.