### PR TITLE
Add pub keyword before mod bar definition in doc.md

### DIFF
--- a/src/meta/doc.md
+++ b/src/meta/doc.md
@@ -80,7 +80,7 @@ Used to inline docs, instead of linking out to separate page.
 pub use bar::Bar;
 
 /// bar docs
-mod bar {
+pub mod bar {
     /// the docs for Bar
     pub struct Bar;
 }


### PR DESCRIPTION
Based on the `https://doc.rust-lang.org/rustdoc/write-documentation/the-doc-attribute.html#inline-and-no_inline `, rustdoc will inline these definitions so there is no need to inline it. If we want to notice the diffrence we should make module public.