### PR TITLE
Add Japanese translation

### DIFF
--- a/.github/workflows/rbe.yml
+++ b/.github/workflows/rbe.yml
@@ -3,7 +3,7 @@ on: [push, pull_request]
 
 env:
   # Update the language picker in index.hbs to link new languages.
-  LANGUAGES:
+  LANGUAGES: ja
 
 jobs:
   test:
@@ -32,7 +32,7 @@ jobs:
 
     - name: Install mdbook-i18n-helpers
       run: |
-        cargo install mdbook-i18n-helpers --locked --version 0.3.0
+        cargo install mdbook-i18n-helpers --locked --version 0.3.1
 
     - name: Report versions
       run: |

--- a/README.md
+++ b/README.md
@@ -58,6 +58,12 @@ Please see the [TRANSLATING.md] file for more details.
 
 [TRANSLATING.md]: https://github.com/rust-lang/rust-by-example/blob/master/TRANSLATING.md
 
+### Translating guide for each languages
+
+* Japanese/日本語: [TRANSLATING_JA.md]
+
+[TRANSLATING_JA.md]: https://github.com/rust-lang/rust-by-example/blob/master/TRANSLATING_JA.md
+
 ## Translations to other languages
 
 * [Bulgarian](https://github.com/kberov/rust-by-example-bg)

--- a/TRANSLATING_JA.md
+++ b/TRANSLATING_JA.md
@@ -1,0 +1,257 @@
+# Rust by Example 日本語版 翻訳ガイド
+
+日本語版の翻訳は https://github.com/rust-lang-ja/rust-by-example にて日本語のレビューを行います。
+翻訳に貢献される方は以下のフローに従ってください。
+
+* https://github.com/rust-lang/rust-by-example を自身のアカウントにフォークする
+* `po/ja.po` に訳文を追加・変更する
+* https://github.com/rust-lang-ja/rust-by-example （の`ja`ブランチ）にプルリクエストを出す
+  + 直接オリジナルのリポジトリに出しても訳文自体のレビューができないので rust-lang-ja で一旦レビューします
+  + 上記リポジトリは`ja`ブランチがデフォルトなので通常通りプルリクエストを作成すれば`ja`ブランチ向けになります
+
+rust-lang-ja のレビュワーは以下のように作業します。
+
+* プルリクエストをレビューし、問題なければ`ja`ブランチにマージ
+* https://github.com/rust-lang/rust-by-example にプルリクエストを出す
+
+最終的に https://github.com/rust-lang/rust-by-example でマージされれば公開されます。
+
+## 翻訳の方法
+
+### 全般的なこと
+
+* 文体は「です・ます」調
+* 記号類は原則として全角（括弧`（）`やコロン`：`など）
+
+### 対訳表
+
+* カタカナ語のままで違和感のない用語はカタカナ語のまま使う
+  + 気持としては「無理矢理和訳」を避けたい。そのための基準。
+  + カタカナ語の方が用語として認識しやすい
+* カタカナ語の末尾の長音記号「ー」は省く(JIS規格)
+* 構文キーワードなどはそのままアルファベットを使う
+
+| English                          | 日本語
+| :------------------------------- | :-------------
+| (lockの) acquire                 | 獲得
+| (lockの) release                 | 解放
+| Intrinsics                       | Intrinsic
+| Lang Items                       | Lang Item
+| Universal Function Call Syntax   | 共通の関数呼び出し構文
+| abort                            | アボート
+| activity                         | 実践
+| aggregate type                   | 合成型
+| alignment                        | アラインメント
+| allocator                        | アロケータ
+| antipattern                      | アンチパターン
+| application                      | アプリケーション
+| argument type                    | 引数タイプ
+| arity                            | アリティ
+| array                            | 配列
+| assignment                       | 代入
+| associated -                     | 関連-
+| atomic                           | アトミック
+| attribute                        | アトリビュート
+| binary                           | バイナリ
+| binding                          | 束縛
+| block                            | ブロック
+| borrow  checker                  | 借用チェッカー
+| borrowing                        | 借用
+| bounds                           | 境界
+| bug                              | バグ
+| capture                          | キャプチャ
+| case analysis                    | 場合分け
+| casting                          | キャスト
+| channel                          | チャネル
+| closure                          | クロージャ
+| code bloat                       | コードの膨張
+| coercion                         | 型強制
+| color model                      | カラーモデル
+| combinator                       | コンビネータ
+| comma                            | カンマ
+| command line                     | コマンドライン
+| compile-time error               | コンパイル時エラー
+| compiler                         | コンパイラ
+| composable                       | 合成可能
+| computer science                 | コンピュータサイエンス
+| concurrency                      | 並行性
+| constant                         | 定数
+| constructor                      | コンストラクタ
+| continuous integration           | 継続的インテグレーション
+| crate                            | クレート
+| custom type                      | カスタム型
+| dangling                         | ダングリング
+| data race                        | データ競合
+| deadlock                         | デッドロック
+| declaration statement            | 宣言文
+| dereferencing                    | 参照外し
+| derive                           | 導出
+| designator                       | 識別子
+| destructor                       | デストラクタ
+| destructuring                    | 分配
+| directive                        | ディレクティブ
+| directory                        | ディレクトリ
+| discriminant                     | 判別子
+| distribution                     | 配布物
+| diverge                          | ダイバージ
+| diverging                        | ダイバージング
+| diverging function               | 発散する関数
+| documentation comment            | ドキュメンテーションコメント
+| documentation test               | ドキュメンテーションテスト
+| early return                     | 早期リターン
+| empty tuple                      | 空タプル
+| encode                           | エンコード
+| endpoint                         | エンドポイント
+| entry point                      | エントリポイント
+| enum                             | 列挙型
+| equality                         | 等値性
+| ergonomic                        | エルゴノミック（人間にとって扱いやすいもの）
+| error                            | エラー
+| error handling                   | エラーハンドリング
+| executable                       | 実行可能形式
+| existentially quantified type    | 存在量型
+| expression statement             | 式文
+| exterior                         | 外側の
+| feature                          | フィーチャ
+| field                            | フィールド
+| foreign                          | 他言語
+| free-standing function           | フリースタンディングな関数
+| full path                        | 絶対パス
+| generic parameter                | ジェネリックパラメータ
+| generics                         | ジェネリクス
+| glob                             | グロブ
+| growable                         | 伸張可能
+| guard                            | ガード
+| handle                           | ハンドル
+| hash                             | ハッシュ
+| hash set                         | ハッシュ集合
+| higher order functions           | 高階関数
+| identifier                       | 識別子
+| immutability                     | イミュータビリティ
+| immutable                        | イミュータブル
+| implement                        | 実装する
+| initialize                       | 初期化する
+| input lifetime                   | 入力ライフタイム
+| install                          | インストール
+| installer                        | インストーラ
+| interior                         | 内側の
+| interpolate                      | インターポーレートする
+| interpolation                    | インターポーレーション
+| key                              | キー
+| keyword                          | キーワード
+| leak                             | リーク
+| least significant bit            | 最下位ビット
+| lending                          | 貸付け
+| library                          | ライブラリ
+| lifetime                         | ライフタイム
+| lifetime coercion                | ライフタイムの圧縮
+| lifetime elision                 | ライフタイムの省略
+| lifetime parameter               | ライフタイムパラメータ
+| link                             | リンク
+| lint                             | リント
+| mangling                         | マングリング
+| match                            | マッチ
+| memory                           | メモリ
+| method                           | メソッド
+| monomorphization                 | 単相化
+| move                             | ムーブ
+| mutability                       | ミュータビリティ
+| mutable                          | ミュータブル
+| mutable binding                  | ミュータブルな束縛
+| mutual-exclusion                 | 相互排他
+| null                             | ヌル
+| numeric literal                  | 数値リテラル
+| object-safe                      | オブジェクト安全
+| offline                          | オフライン
+| opaque                           | オペーク
+| open source                      | オープンソース
+| option                           | オプション
+| output lifetime                  | 出力ライフタイム
+| output type                      | アウトプット型
+| overflow                         | オーバーフロー
+| owner                            | 所有者
+| ownership                        | 所有権
+| panic                            | パニック
+| parameter                        | パラメータ
+| parametric polymorphism          | パラメトリック多相
+| parse                            | パース、パースする
+| partial moves                    | 部分的ムーブ
+| patch                            | パッチ
+| pattern                          | パターン
+| performance                      | パフォーマンス
+| phantom type                     | 幽霊型
+| platform                         | プラットフォーム
+| pointer                          | ポインタ
+| primitive type                   | プリミティブ型
+| private                          | プライベート
+| process                          | プロセス
+| public                           | パブリック
+| r-value                          | 右辺値
+| range                            | レンジ
+| raw pointer                      | 生ポインタ
+| raw identifier                   | 生識別子
+| re-assignment                    | 再代入
+| rebind                           | 再束縛
+| reference count                  | 参照カウント
+| regression                       | リグレッション
+| release                          | リリース
+| return                           | 返す
+| return type                      | リターン型
+| return value                     | 戻り値
+| runtime                          | 実行時
+| safe                             | 安全
+| safety check                     | 安全性検査
+| scope                            | スコープ
+| scoped                           | スコープ化された
+| script                           | スクリプト
+| semantics                        | セマンティクス
+| shadow                           | 覆い隠す
+| shadowing                        | シャドーイング
+| signature                        | シグネチャ
+| signed                           | 符号付き
+| slice                            | スライス
+| slicing                          | スライシング
+| specialized                      | 特殊化された
+| standard library                 | 標準ライブラリ
+| string                           | 文字列
+| string interpolation             | 文字列インターポーレーション
+| struct                           | 構造体
+| structure                        | 構造体
+| sum type                         | 直和型
+| subtrait                         | サブトレイト
+| supertrait                       | スーパートレイト
+| symbol                           | シンボル
+| syntactic sugar                  | 糖衣構文
+| syntax tree                      | 構文木
+| system                           | システム
+| tagged union                     | タグ付き共用体
+| term                             | 項
+| thread-locality                  | スレッドローカル性
+| threadsafe                       | スレッドセーフ
+| tick                             | クオート
+| token trees                      | トークン木
+| trait                            | トレイト
+| transmute                        | トランスミュート
+| tuple                            | タプル
+| tuple struct                     | タプル
+| type alias                       | 型エイリアス
+| type erasure                     | 型消去
+| type family                      | 型族
+| type inference                   | 型推論
+| type parameter                   | 型パラメータ
+| uninstall                        | アンインストール
+| unit  注: `()` の読み            | ユニット
+| unsafe                           | アンセーフ
+| unsigned                         | 符号無し
+| unsized type                     | サイズ不定型
+| unwinding                        | 巻き戻し
+| unwrap                           | アンラップ
+| value constructor                | 値コンストラクタ
+| variable                         | 変数
+| variable binding                 | 変数束縛
+| variant                          | ヴァリアント
+| vector                           | ベクタ
+| version                          | バージョン
+| warning                          | ウォーニング
+| wildcard                         | ワイルドカード
+| wrapper                          | ラッパ

--- a/po/ja.po
+++ b/po/ja.po
@@ -1,0 +1,17231 @@
+msgid ""
+msgstr ""
+"Project-Id-Version: Rust By Example\n"
+"POT-Creation-Date: 2023-12-19T09:54:39+09:00\n"
+"PO-Revision-Date: 2023-12-19 09:55+0900\n"
+"Last-Translator: Naoya Hatta <dalance@gmail.com>\n"
+"Language-Team: Japanese https://github.com/rust-lang-ja/rust-by-example\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"Language: ja\n"
+"Plural-Forms: nplurals=1; plural=0;\n"
+
+#: src/SUMMARY.md:1
+msgid "Summary"
+msgstr "Summary"
+
+#: src/SUMMARY.md:3
+msgid "Introduction"
+msgstr "はじめに"
+
+#: src/SUMMARY.md:5 src/hello.md:1
+msgid "Hello World"
+msgstr "Hello World"
+
+#: src/SUMMARY.md:6 src/hello/comment.md:1
+msgid "Comments"
+msgstr "コメント"
+
+#: src/SUMMARY.md:7 src/hello/print.md:1
+msgid "Formatted print"
+msgstr "フォーマットして出力"
+
+#: src/SUMMARY.md:8 src/hello/print/print_debug.md:1
+msgid "Debug"
+msgstr "Debug"
+
+#: src/SUMMARY.md:9 src/hello/print/print_display.md:1
+msgid "Display"
+msgstr "Display"
+
+#: src/SUMMARY.md:10 src/hello/print/print_display/testcase_list.md:1
+msgid "Testcase: List"
+msgstr "テストケース：リスト"
+
+#: src/SUMMARY.md:11 src/hello/print/fmt.md:1
+msgid "Formatting"
+msgstr "フォーマット"
+
+#: src/SUMMARY.md:13 src/primitives.md:1
+msgid "Primitives"
+msgstr "基本データ型"
+
+#: src/SUMMARY.md:14 src/primitives/literals.md:1
+msgid "Literals and operators"
+msgstr "リテラルと演算子"
+
+#: src/SUMMARY.md:15 src/primitives/tuples.md:1
+msgid "Tuples"
+msgstr "タプル"
+
+#: src/SUMMARY.md:16 src/primitives/array.md:1
+msgid "Arrays and Slices"
+msgstr "配列とスライス"
+
+#: src/SUMMARY.md:18 src/custom_types.md:1
+msgid "Custom Types"
+msgstr "カスタム型"
+
+#: src/SUMMARY.md:19 src/custom_types/structs.md:1
+msgid "Structures"
+msgstr "構造体"
+
+#: src/SUMMARY.md:20 src/custom_types/enum.md:1
+msgid "Enums"
+msgstr "列挙型"
+
+#: src/SUMMARY.md:21 src/custom_types/enum/enum_use.md:1
+msgid "use"
+msgstr "use"
+
+#: src/SUMMARY.md:22 src/custom_types/enum/c_like.md:1
+msgid "C-like"
+msgstr "C言語ライクな列挙型"
+
+#: src/SUMMARY.md:23 src/custom_types/enum/testcase_linked_list.md:1
+msgid "Testcase: linked-list"
+msgstr "テストケース：連結リスト"
+
+#: src/SUMMARY.md:24 src/custom_types/constants.md:1
+msgid "constants"
+msgstr "定数"
+
+#: src/SUMMARY.md:26 src/variable_bindings.md:1
+msgid "Variable Bindings"
+msgstr "変数束縛"
+
+#: src/SUMMARY.md:27 src/SUMMARY.md:120 src/SUMMARY.md:123
+#: src/variable_bindings/mut.md:1 src/scope/move/mut.md:1
+#: src/scope/borrow/mut.md:1
+msgid "Mutability"
+msgstr "ミュータビリティ"
+
+#: src/SUMMARY.md:28 src/variable_bindings/scope.md:1
+msgid "Scope and Shadowing"
+msgstr "スコープとシャドーイング"
+
+#: src/SUMMARY.md:29 src/variable_bindings/declare.md:1
+msgid "Declare first"
+msgstr "前方宣言"
+
+#: src/SUMMARY.md:30 src/variable_bindings/freeze.md:1
+msgid "Freezing"
+msgstr "値の凍結"
+
+#: src/SUMMARY.md:32 src/types.md:1
+msgid "Types"
+msgstr "型"
+
+#: src/SUMMARY.md:33 src/types/cast.md:1
+msgid "Casting"
+msgstr "型キャスト"
+
+#: src/SUMMARY.md:34 src/types/literals.md:1
+msgid "Literals"
+msgstr "リテラル"
+
+#: src/SUMMARY.md:35 src/types/inference.md:1
+msgid "Inference"
+msgstr "型推論"
+
+#: src/SUMMARY.md:36 src/SUMMARY.md:124 src/types/alias.md:1
+#: src/scope/borrow/alias.md:1
+msgid "Aliasing"
+msgstr "エイリアス"
+
+#: src/SUMMARY.md:38 src/conversion.md:1
+msgid "Conversion"
+msgstr "型変換"
+
+#: src/SUMMARY.md:39 src/conversion/from_into.md:1
+msgid "`From` and `Into`"
+msgstr "`From`と`Into`"
+
+#: src/SUMMARY.md:40 src/conversion/try_from_try_into.md:1
+msgid "`TryFrom` and `TryInto`"
+msgstr "`TryFrom`と`TryInto`"
+
+#: src/SUMMARY.md:41
+msgid "To and from `String`s"
+msgstr "`String`との型変換"
+
+#: src/SUMMARY.md:43 src/expression.md:1
+msgid "Expressions"
+msgstr "式"
+
+#: src/SUMMARY.md:45 src/flow_control.md:1
+msgid "Flow of Control"
+msgstr "制御フロー"
+
+#: src/SUMMARY.md:46 src/flow_control/if_else.md:1
+msgid "if/else"
+msgstr "if/else"
+
+#: src/SUMMARY.md:47 src/flow_control/loop.md:1
+msgid "loop"
+msgstr "loop"
+
+#: src/SUMMARY.md:48 src/flow_control/loop/nested.md:1
+msgid "Nesting and labels"
+msgstr "ネストとラベル"
+
+#: src/SUMMARY.md:49 src/flow_control/loop/return.md:1
+msgid "Returning from loops"
+msgstr "loopが返す値"
+
+#: src/SUMMARY.md:50 src/flow_control/while.md:1
+msgid "while"
+msgstr "while"
+
+#: src/SUMMARY.md:51 src/flow_control/for.md:3
+msgid "for and range"
+msgstr "for と range"
+
+#: src/SUMMARY.md:52 src/flow_control/match.md:1
+msgid "match"
+msgstr "match"
+
+#: src/SUMMARY.md:53 src/flow_control/match/destructuring.md:1
+msgid "Destructuring"
+msgstr "デストラクト"
+
+#: src/SUMMARY.md:54
+#: src/flow_control/match/destructuring/destructure_tuple.md:1
+msgid "tuples"
+msgstr "タプル"
+
+#: src/SUMMARY.md:55
+#: src/flow_control/match/destructuring/destructure_slice.md:1
+msgid "arrays/slices"
+msgstr "配列とスライス"
+
+#: src/SUMMARY.md:56 src/flow_control/match/destructuring/destructure_enum.md:1
+msgid "enums"
+msgstr "列挙型"
+
+#: src/SUMMARY.md:57
+#: src/flow_control/match/destructuring/destructure_pointers.md:1
+msgid "pointers/ref"
+msgstr "ポインタとref"
+
+#: src/SUMMARY.md:58
+#: src/flow_control/match/destructuring/destructure_structures.md:1
+msgid "structs"
+msgstr "構造体"
+
+#: src/SUMMARY.md:59 src/flow_control/match/guard.md:1
+msgid "Guards"
+msgstr "ガード"
+
+#: src/SUMMARY.md:60 src/flow_control/match/binding.md:1
+msgid "Binding"
+msgstr "束縛"
+
+#: src/SUMMARY.md:61 src/flow_control/if_let.md:1
+msgid "if let"
+msgstr "if let"
+
+#: src/SUMMARY.md:62 src/flow_control/let_else.md:1
+msgid "let-else"
+msgstr "let-else"
+
+#: src/SUMMARY.md:63 src/flow_control/while_let.md:1
+msgid "while let"
+msgstr "while let"
+
+#: src/SUMMARY.md:65 src/SUMMARY.md:103 src/SUMMARY.md:128 src/fn.md:1
+#: src/generics/gen_fn.md:1 src/scope/lifetime/fn.md:1
+msgid "Functions"
+msgstr "関数"
+
+#: src/SUMMARY.md:66 src/SUMMARY.md:129 src/scope/lifetime/methods.md:1
+msgid "Methods"
+msgstr "メソッド"
+
+#: src/SUMMARY.md:67 src/fn/closures.md:1
+msgid "Closures"
+msgstr "クロージャ"
+
+#: src/SUMMARY.md:68 src/fn/closures/capture.md:1
+msgid "Capturing"
+msgstr "要素の捕捉"
+
+#: src/SUMMARY.md:69 src/fn/closures/input_parameters.md:1
+msgid "As input parameters"
+msgstr "捕捉時の型推論"
+
+#: src/SUMMARY.md:70 src/fn/closures/anonymity.md:1
+msgid "Type anonymity"
+msgstr "匿名型"
+
+#: src/SUMMARY.md:71 src/fn/closures/input_functions.md:1
+msgid "Input functions"
+msgstr "関数を受け取る関数"
+
+#: src/SUMMARY.md:72 src/fn/closures/output_parameters.md:1
+msgid "As output parameters"
+msgstr "クロージャを返す関数"
+
+#: src/SUMMARY.md:73 src/fn/closures/closure_examples.md:1
+msgid "Examples in `std`"
+msgstr "`std`における使用例"
+
+#: src/SUMMARY.md:74 src/fn/closures/closure_examples/iter_any.md:1
+msgid "Iterator::any"
+msgstr "Iterator::any"
+
+#: src/SUMMARY.md:75 src/fn/closures/closure_examples/iter_find.md:1
+msgid "Searching through iterators"
+msgstr "イテレータによる検索"
+
+#: src/SUMMARY.md:76 src/fn/hof.md:1
+msgid "Higher Order Functions"
+msgstr "高階関数"
+
+#: src/SUMMARY.md:77 src/fn/diverging.md:1
+msgid "Diverging functions"
+msgstr "発散する関数"
+
+#: src/SUMMARY.md:79 src/mod.md:1
+msgid "Modules"
+msgstr "モジュール"
+
+#: src/SUMMARY.md:80 src/mod/visibility.md:1
+msgid "Visibility"
+msgstr "可視性"
+
+#: src/SUMMARY.md:81 src/mod/struct_visibility.md:1
+msgid "Struct visibility"
+msgstr "構造体の場合"
+
+#: src/SUMMARY.md:82 src/mod/use.md:1
+msgid "The `use` declaration"
+msgstr "`use`宣言"
+
+#: src/SUMMARY.md:83 src/mod/super.md:1
+msgid "`super` and `self`"
+msgstr "`super`と`self`"
+
+#: src/SUMMARY.md:84 src/mod/split.md:1
+msgid "File hierarchy"
+msgstr "ファイルの階層構造"
+
+#: src/SUMMARY.md:86 src/SUMMARY.md:98 src/crates.md:1 src/attribute/crate.md:1
+#: src/std_misc/arg.md:30
+msgid "Crates"
+msgstr "クレート"
+
+#: src/SUMMARY.md:87 src/crates/lib.md:1
+msgid "Creating a Library"
+msgstr "ライブラリの作成"
+
+#: src/SUMMARY.md:88 src/crates/using_lib.md:1
+msgid "Using a Library"
+msgstr "ライブラリの利用"
+
+#: src/SUMMARY.md:90 src/cargo.md:1
+msgid "Cargo"
+msgstr "Cargo"
+
+#: src/SUMMARY.md:91 src/cargo/deps.md:1
+msgid "Dependencies"
+msgstr "依存関係"
+
+#: src/SUMMARY.md:92 src/cargo/conventions.md:1
+msgid "Conventions"
+msgstr "規約"
+
+#: src/SUMMARY.md:93
+msgid "Tests"
+msgstr "テスト"
+
+#: src/SUMMARY.md:94 src/cargo/build_scripts.md:1
+msgid "Build Scripts"
+msgstr "ビルドスクリプト"
+
+#: src/SUMMARY.md:96 src/attribute.md:1
+msgid "Attributes"
+msgstr "アトリビュート"
+
+#: src/SUMMARY.md:97 src/attribute/unused.md:1
+msgid "`dead_code`"
+msgstr "`dead_code`"
+
+#: src/SUMMARY.md:99 src/attribute/cfg.md:1
+msgid "`cfg`"
+msgstr "`cfg`"
+
+#: src/SUMMARY.md:100 src/attribute/cfg/custom.md:1
+msgid "Custom"
+msgstr "条件の追加"
+
+#: src/SUMMARY.md:102 src/generics.md:1
+msgid "Generics"
+msgstr "ジェネリクス"
+
+#: src/SUMMARY.md:104 src/generics/impl.md:1
+msgid "Implementation"
+msgstr "実装"
+
+#: src/SUMMARY.md:105 src/SUMMARY.md:131 src/SUMMARY.md:137
+#: src/generics/gen_trait.md:1 src/scope/lifetime/trait.md:1 src/trait.md:1
+msgid "Traits"
+msgstr "トレイト"
+
+#: src/SUMMARY.md:106 src/SUMMARY.md:132 src/generics/bounds.md:1
+#: src/scope/lifetime/lifetime_bounds.md:1
+msgid "Bounds"
+msgstr "境界"
+
+#: src/SUMMARY.md:107 src/generics/bounds/testcase_empty.md:1
+msgid "Testcase: empty bounds"
+msgstr "テストケース：空トレイト"
+
+#: src/SUMMARY.md:108 src/generics/multi_bounds.md:1
+msgid "Multiple bounds"
+msgstr "複数の境界"
+
+#: src/SUMMARY.md:109 src/generics/where.md:1
+msgid "Where clauses"
+msgstr "Where句"
+
+#: src/SUMMARY.md:110 src/generics/new_types.md:1
+msgid "New Type Idiom"
+msgstr "ニュータイプイディオム"
+
+#: src/SUMMARY.md:111 src/generics/assoc_items.md:1
+msgid "Associated items"
+msgstr "関連要素"
+
+#: src/SUMMARY.md:112 src/generics/assoc_items/the_problem.md:1
+msgid "The Problem"
+msgstr "関連要素が必要になる状況"
+
+#: src/SUMMARY.md:113 src/generics/assoc_items/types.md:1
+msgid "Associated types"
+msgstr "関連型"
+
+#: src/SUMMARY.md:114 src/generics/phantom.md:1
+msgid "Phantom type parameters"
+msgstr "幽霊型パラメータ"
+
+#: src/SUMMARY.md:115 src/generics/phantom/testcase_units.md:1
+msgid "Testcase: unit clarification"
+msgstr "テストケース：単位を扱う"
+
+#: src/SUMMARY.md:117 src/scope.md:1
+msgid "Scoping rules"
+msgstr "スコープの規則"
+
+#: src/SUMMARY.md:118 src/scope/raii.md:1
+msgid "RAII"
+msgstr "RAII"
+
+#: src/SUMMARY.md:119 src/scope/move.md:1
+msgid "Ownership and moves"
+msgstr "所有権とムーブ"
+
+#: src/SUMMARY.md:121 src/scope/move/partial_move.md:1
+msgid "Partial moves"
+msgstr "部分的ムーブ"
+
+#: src/SUMMARY.md:122 src/scope/borrow.md:1
+msgid "Borrowing"
+msgstr "借用"
+
+#: src/SUMMARY.md:125 src/scope/borrow/ref.md:1
+msgid "The ref pattern"
+msgstr "refパターン"
+
+#: src/SUMMARY.md:126 src/scope/lifetime.md:1
+msgid "Lifetimes"
+msgstr "ライフタイム"
+
+#: src/SUMMARY.md:127 src/scope/lifetime/explicit.md:1
+msgid "Explicit annotation"
+msgstr "明示的アノテーション"
+
+#: src/SUMMARY.md:130 src/scope/lifetime/struct.md:1
+msgid "Structs"
+msgstr "構造体"
+
+#: src/SUMMARY.md:133 src/scope/lifetime/lifetime_coercion.md:1
+msgid "Coercion"
+msgstr "強制"
+
+#: src/SUMMARY.md:134 src/scope/lifetime/static_lifetime.md:1
+msgid "Static"
+msgstr "スタティックライフタイム"
+
+#: src/SUMMARY.md:135 src/scope/lifetime/elision.md:1
+msgid "Elision"
+msgstr "省略"
+
+#: src/SUMMARY.md:138 src/trait/derive.md:1
+msgid "Derive"
+msgstr "導出(Derive)"
+
+#: src/SUMMARY.md:139 src/trait/dyn.md:1
+msgid "Returning Traits with `dyn`"
+msgstr "`dyn`を利用してトレイトを返す"
+
+#: src/SUMMARY.md:140 src/trait/ops.md:1
+msgid "Operator Overloading"
+msgstr "演算子のオーバーロード"
+
+#: src/SUMMARY.md:141 src/trait/drop.md:1
+msgid "Drop"
+msgstr "ドロップ"
+
+#: src/SUMMARY.md:142 src/trait/iter.md:1
+msgid "Iterators"
+msgstr "イテレータ"
+
+#: src/SUMMARY.md:143 src/trait/impl_trait.md:1
+msgid "`impl Trait`"
+msgstr "`impl Trait`"
+
+#: src/SUMMARY.md:144 src/trait/clone.md:1
+msgid "Clone"
+msgstr "クローン"
+
+#: src/SUMMARY.md:145 src/trait/supertraits.md:1
+msgid "Supertraits"
+msgstr "スーパートレイト"
+
+#: src/SUMMARY.md:146 src/trait/disambiguating.md:1
+msgid "Disambiguating overlapping traits"
+msgstr "トレイトの曖昧性解決"
+
+#: src/SUMMARY.md:148 src/macros.md:1
+msgid "macro_rules!"
+msgstr "macro_rules!"
+
+#: src/SUMMARY.md:149 src/macros/syntax.md:1
+msgid "Syntax"
+msgstr "構文"
+
+#: src/SUMMARY.md:150 src/macros/designators.md:1
+msgid "Designators"
+msgstr "識別子"
+
+#: src/SUMMARY.md:151 src/macros/overload.md:1
+msgid "Overload"
+msgstr "オーバーロード"
+
+#: src/SUMMARY.md:152 src/macros/repeat.md:1
+msgid "Repeat"
+msgstr "繰り返し"
+
+#: src/SUMMARY.md:153 src/macros/dry.md:1
+msgid "DRY (Don't Repeat Yourself)"
+msgstr "DRY (Don't Repeat Yourself)"
+
+#: src/SUMMARY.md:154
+msgid "DSL (Domain Specific Languages)"
+msgstr "Domain Specific Languages (ドメイン特化言語、DSLs)"
+
+#: src/SUMMARY.md:155
+msgid "Variadics"
+msgstr "可変個引数"
+
+#: src/SUMMARY.md:157 src/error.md:1
+msgid "Error handling"
+msgstr "エラーハンドリング"
+
+#: src/SUMMARY.md:158 src/error/panic.md:1
+msgid "`panic`"
+msgstr "`panic`"
+
+#: src/SUMMARY.md:159
+msgid "`abort` & `unwind`"
+msgstr "`abort`と`unwind`"
+
+#: src/SUMMARY.md:160 src/error/option_unwrap.md:1
+msgid "`Option` & `unwrap`"
+msgstr "`Option`と`unwrap`"
+
+#: src/SUMMARY.md:161 src/error/option_unwrap/question_mark.md:1
+msgid "Unpacking options with `?`"
+msgstr "`?`による`Option`のアンパック"
+
+#: src/SUMMARY.md:162 src/error/option_unwrap/map.md:1
+msgid "Combinators: `map`"
+msgstr "コンビネータ：`map`"
+
+#: src/SUMMARY.md:163 src/error/option_unwrap/and_then.md:1
+msgid "Combinators: `and_then`"
+msgstr "コンビネータ：`and_then`"
+
+#: src/SUMMARY.md:164
+msgid "Defaults: `or`, `or_else`, `get_or_insert`, `get_or_insert_with`"
+msgstr ""
+
+#: src/SUMMARY.md:165 src/SUMMARY.md:183 src/error/result.md:1
+#: src/std/result.md:1
+msgid "`Result`"
+msgstr "`Result`"
+
+#: src/SUMMARY.md:166 src/error/result/result_map.md:1
+msgid "`map` for `Result`"
+msgstr "`Result`の`map`"
+
+#: src/SUMMARY.md:167 src/error/result/result_alias.md:1
+msgid "aliases for `Result`"
+msgstr "`Result`に対するエイリアス"
+
+#: src/SUMMARY.md:168 src/error/result/early_returns.md:1
+msgid "Early returns"
+msgstr "早期リターン"
+
+#: src/SUMMARY.md:169 src/error/result/enter_question_mark.md:1
+msgid "Introducing `?`"
+msgstr "`?`の導入"
+
+#: src/SUMMARY.md:170 src/error/multiple_error_types.md:1
+msgid "Multiple error types"
+msgstr "複数のエラー型"
+
+#: src/SUMMARY.md:171 src/error/multiple_error_types/option_result.md:1
+msgid "Pulling `Result`s out of `Option`s"
+msgstr "`Option`から`Result`を取り出す"
+
+#: src/SUMMARY.md:172 src/error/multiple_error_types/define_error_type.md:1
+msgid "Defining an error type"
+msgstr "エラー型を定義する"
+
+#: src/SUMMARY.md:173 src/error/multiple_error_types/boxing_errors.md:1
+msgid "`Box`ing errors"
+msgstr "エラーを`Box`する"
+
+#: src/SUMMARY.md:174 src/error/multiple_error_types/reenter_question_mark.md:1
+msgid "Other uses of `?`"
+msgstr "`?`の他の活用法"
+
+#: src/SUMMARY.md:175 src/error/multiple_error_types/wrap_error.md:1
+msgid "Wrapping errors"
+msgstr "エラーをラップする"
+
+#: src/SUMMARY.md:176 src/error/iter_result.md:1
+msgid "Iterating over `Result`s"
+msgstr "`Result`をイテレートする"
+
+#: src/SUMMARY.md:178 src/std.md:1
+msgid "Std library types"
+msgstr "標準ライブラリの型"
+
+#: src/SUMMARY.md:179 src/std/box.md:1
+msgid "Box, stack and heap"
+msgstr "Box、スタックとヒープ"
+
+#: src/SUMMARY.md:180 src/std/vec.md:1
+msgid "Vectors"
+msgstr "ベクタ型"
+
+#: src/SUMMARY.md:181 src/std/str.md:1
+msgid "Strings"
+msgstr "文字列"
+
+#: src/SUMMARY.md:182 src/std/option.md:1
+msgid "`Option`"
+msgstr "`Option`"
+
+#: src/SUMMARY.md:184 src/std/result/question_mark.md:1
+msgid "`?`"
+msgstr "`?`"
+
+#: src/SUMMARY.md:185 src/std/panic.md:1
+msgid "`panic!`"
+msgstr "`panic!`"
+
+#: src/SUMMARY.md:186 src/std/hash.md:1
+msgid "HashMap"
+msgstr "ハッシュマップ"
+
+#: src/SUMMARY.md:187 src/std/hash/alt_key_types.md:1
+msgid "Alternate/custom key types"
+msgstr "キー型の変種"
+
+#: src/SUMMARY.md:188 src/std/hash/hashset.md:1
+msgid "HashSet"
+msgstr "ハッシュ集合"
+
+#: src/SUMMARY.md:189 src/std/rc.md:1
+msgid "`Rc`"
+msgstr "`Rc`"
+
+#: src/SUMMARY.md:190
+msgid "`Arc`"
+msgstr "`Arc`"
+
+#: src/SUMMARY.md:192 src/std_misc.md:1
+msgid "Std misc"
+msgstr "標準ライブラリのその他"
+
+#: src/SUMMARY.md:193 src/std_misc.md:6 src/std_misc/threads.md:1
+msgid "Threads"
+msgstr "スレッド"
+
+#: src/SUMMARY.md:194 src/std_misc/threads/testcase_mapreduce.md:1
+msgid "Testcase: map-reduce"
+msgstr "テストケース：map-reduce"
+
+#: src/SUMMARY.md:195 src/std_misc.md:7 src/std_misc/channels.md:1
+msgid "Channels"
+msgstr "チャネル"
+
+#: src/SUMMARY.md:196 src/std_misc/path.md:1
+msgid "Path"
+msgstr "ファイルパス"
+
+#: src/SUMMARY.md:197 src/std_misc.md:8 src/std_misc/file.md:1
+msgid "File I/O"
+msgstr "ファイル I/O"
+
+#: src/SUMMARY.md:198 src/std_misc/file/open.md:1
+msgid "`open`"
+msgstr "`open`"
+
+#: src/SUMMARY.md:199 src/std_misc/file/create.md:1
+msgid "`create`"
+msgstr "`create`"
+
+#: src/SUMMARY.md:200 src/std_misc/file/read_lines.md:1
+msgid "`read_lines`"
+msgstr "`read lines`"
+
+#: src/SUMMARY.md:201 src/std_misc/process.md:1
+msgid "Child processes"
+msgstr "子プロセス"
+
+#: src/SUMMARY.md:202 src/std_misc/process/pipe.md:1
+msgid "Pipes"
+msgstr "パイプ"
+
+#: src/SUMMARY.md:203 src/std_misc/process/wait.md:1
+msgid "Wait"
+msgstr "ドロップの延期"
+
+#: src/SUMMARY.md:204 src/std_misc/fs.md:1
+msgid "Filesystem Operations"
+msgstr "ファイルシステムとのやり取り"
+
+#: src/SUMMARY.md:205 src/std_misc/arg.md:1
+msgid "Program arguments"
+msgstr "引数処理"
+
+#: src/SUMMARY.md:206 src/std_misc/arg/matching.md:1
+msgid "Argument parsing"
+msgstr "引数のパース"
+
+#: src/SUMMARY.md:207 src/std_misc/ffi.md:1
+msgid "Foreign Function Interface"
+msgstr "他言語関数インターフェイス"
+
+#: src/SUMMARY.md:209 src/cargo/test.md:1 src/testing.md:1
+msgid "Testing"
+msgstr "テスト"
+
+#: src/SUMMARY.md:210 src/testing/unit_testing.md:1
+msgid "Unit testing"
+msgstr "ユニットテスト"
+
+#: src/SUMMARY.md:211 src/testing/doc_testing.md:1
+msgid "Documentation testing"
+msgstr "ドキュメンテーションテスト"
+
+#: src/SUMMARY.md:212 src/testing/integration_testing.md:1
+msgid "Integration testing"
+msgstr "統合テスト"
+
+#: src/SUMMARY.md:213
+msgid "Dev-dependencies"
+msgstr "開発中の依存関係"
+
+#: src/SUMMARY.md:215 src/unsafe.md:1
+msgid "Unsafe Operations"
+msgstr "安全でない操作"
+
+#: src/SUMMARY.md:216 src/unsafe/asm.md:1
+msgid "Inline assembly"
+msgstr "インラインアセンブリ"
+
+#: src/SUMMARY.md:218 src/compatibility.md:1
+msgid "Compatibility"
+msgstr "互換性"
+
+#: src/SUMMARY.md:219 src/compatibility/raw_identifiers.md:1
+msgid "Raw identifiers"
+msgstr "生識別子"
+
+#: src/SUMMARY.md:221 src/meta.md:1
+msgid "Meta"
+msgstr "周辺情報"
+
+#: src/SUMMARY.md:222 src/meta/doc.md:1
+msgid "Documentation"
+msgstr "ドキュメンテーション"
+
+#: src/SUMMARY.md:223 src/meta/playground.md:1
+msgid "Playground"
+msgstr "プレイグラウンド"
+
+#: src/index.md:1
+msgid "Rust by Example"
+msgstr "Rust by Example"
+
+#: src/index.md:3
+msgid ""
+"[Rust](https://www.rust-lang.org/) is a modern systems programming language "
+"focusing on safety, speed, and concurrency. It accomplishes these goals by "
+"being memory safe without using  garbage collection."
+msgstr ""
+"[Rust](https://www.rust-lang.org/) は安全性、速度、並列性にフォーカスした"
+"現代的なシステムプログラミング用のプログラミング言語です。"
+"ガベージコレクション無しでメモリ安全であることが、これを可能にしています。"
+
+#: src/index.md:7
+msgid ""
+"Rust by Example (RBE) is a collection of runnable examples that illustrate "
+"various Rust concepts and standard libraries. To get even more out of these "
+"examples, don't forget to [install Rust locally](https://www.rust-lang.org/"
+"tools/install) and check out the [official docs](https://doc.rust-lang.org/"
+"std/).  Additionally for the curious, you can also [check out the source "
+"code for this site](https://github.com/rust-lang/rust-by-example)."
+msgstr ""
+"Rust by Example(RBE)はRustの実行可能なサンプルスクリプト集で、ここではRustの様々な"
+"コンセプトと標準ライブラリを紹介していきます。"
+"この例をより活用するためには[Rustをローカルにインストール](https://www.rust-lang.org/tools/install)し、"
+"[公式ドキュメント](https://doc.rust-lang.org/std/)をチェックすることをおすすめします。"
+"興味がある方は[このサイト自体のソース](https://github.com/rust-lang/rust-by-example)のチェックもどうぞ。"
+
+#: src/index.md:12
+msgid "Now let's begin!"
+msgstr "それでははじめましょう!"
+
+#: src/index.md:14
+msgid "[Hello World](hello.md) - Start with a traditional Hello World program."
+msgstr "[Hello World](hello.md) - お決まりのHello Worldプログラムから始めましょう。"
+
+#: src/index.md:16
+msgid ""
+"[Primitives](primitives.md) - Learn about signed integers, unsigned integers "
+"and other primitives."
+msgstr "[基本データ型](primitives.md) - 符号付き整数や符号無し整数、その他の基本データ型について学びましょう。"
+
+#: src/index.md:18
+msgid "[Custom Types](custom_types.md) - `struct` and `enum`."
+msgstr "[カスタム型](custom_types.md) - `struct`と`enum`について。"
+
+#: src/index.md:20
+msgid ""
+"[Variable Bindings](variable_bindings.md) - mutable bindings, scope, "
+"shadowing."
+msgstr "[変数の束縛](variable_bindings.md) - ミュータブルな束縛、スコープ、シャドーイングについて。"
+
+#: src/index.md:22
+msgid "[Types](types.md) - Learn about changing and defining types."
+msgstr "[型](types.md) - 型を変更したり定義したりすることを学びましょう。"
+
+#: src/index.md:24
+msgid ""
+"[Conversion](conversion.md) - Convert between different types, such as "
+"strings, integers, and floats."
+msgstr "[型変換](conversion.md) - 文字列や整数、浮動小数点数など様々な型から型への変換について。"
+
+#: src/index.md:26
+msgid ""
+"[Expressions](expression.md) - Learn about Expressions & how to use them."
+msgstr "[式](expression.md) - 式とその使い方について学びましょう。"
+
+#: src/index.md:28
+msgid "[Flow of Control](flow_control.md) - `if`/`else`, `for`, and others."
+msgstr "[制御フロー](flow_control.md) - `if`や`else`、`for`など。"
+
+#: src/index.md:30
+msgid ""
+"[Functions](fn.md) - Learn about Methods, Closures and Higher Order "
+"Functions."
+msgstr "[関数](fn.md) - メソッド、クロージャ、高階関数について。"
+
+#: src/index.md:32
+msgid "[Modules](mod.md) - Organize code using modules"
+msgstr "[モジュール](mod.md) - プログラムをモジュールを使って整理しましょう。"
+
+#: src/index.md:34
+msgid ""
+"[Crates](crates.md) - A crate is a compilation unit in Rust. Learn to create "
+"a library."
+msgstr "[クレート](crates.md) - クレートは、Rustにおいてコンパイルされる単位です。ライブラリの作り方について学びます。"
+
+#: src/index.md:36
+msgid ""
+"[Cargo](cargo.md) - Go through some basic features of the official Rust "
+"package management tool."
+msgstr "[Cargo](cargo.md) - Rustの公式パッケージマネージャの基本的な機能を学びます。"
+
+#: src/index.md:38
+msgid ""
+"[Attributes](attribute.md) - An attribute is metadata applied to some "
+"module, crate or item."
+msgstr "[アトリビュート](attribute.md) - アトリビュートは、モジュールやクレート、要素に適用されるメタデータです。"
+
+#: src/index.md:40
+msgid ""
+"[Generics](generics.md) - Learn about writing a function or data type which "
+"can work for multiple types of arguments."
+msgstr "[ジェネリクス](generics.md) - 様々な型の引数を取れる関数やデータ型を書く方法を学びましょう。"
+
+#: src/index.md:42
+msgid ""
+"[Scoping rules](scope.md) - Scopes play an important part in ownership, "
+"borrowing, and lifetimes."
+msgstr "[スコープの規則](scope.md) - スコープは所有権、借用、ライフタイムにおいて重要な役割を果たします。"
+
+#: src/index.md:44
+msgid ""
+"[Traits](trait.md) - A trait is a collection of methods defined for an "
+"unknown type: `Self`"
+msgstr "[トレイト](trait.md) - トレイトとは、未知の型`Self`に対して定義された一連のメソッドです。"
+
+#: src/index.md:46
+msgid ""
+"[Macros](macros.md) - Macros are a way of writing code that writes other "
+"code, which is known as metaprogramming."
+msgstr "[マクロ](macros.md) - マクロはコードを書くためのコードです。メタプログラミングとしても知られています。"
+
+#: src/index.md:48
+msgid "[Error handling](error.md) - Learn Rust way of handling failures."
+msgstr "[エラーハンドリング](error.md) - 失敗に対処するRust流のやり方を学びましょう。"
+
+#: src/index.md:50
+msgid ""
+"[Std library types](std.md) - Learn about some custom types provided by "
+"`std` library."
+msgstr "[標準ライブラリの型](std.md) - `std`ライブラリによって提供されるいくつかのカスタム型について学びます。"
+
+#: src/index.md:52
+msgid "[Std misc](std_misc.md) - More custom types for file handling, threads."
+msgstr "[標準ライブラリのその他](std_misc.md) - ファイルハンドリングとスレッドのためのカスタム型について。"
+
+#: src/index.md:54
+msgid "[Testing](testing.md) - All sorts of testing in Rust."
+msgstr "[テスト](testing.md) - Rustにおけるテストのすべて。"
+
+#: src/index.md:56
+msgid ""
+"[Unsafe Operations](unsafe.md) - Learn about entering a block of unsafe "
+"operations."
+msgstr "[安全でない操作](unsafe.md) - 安全でない操作について学びましょう。"
+
+#: src/index.md:58
+msgid ""
+"[Compatibility](compatibility.md) - Handling Rust's evolution and potential "
+"compatibility issues."
+msgstr "[互換性](compatibility.md) - Rustの進化と互換性について。"
+
+#: src/index.md:60
+msgid "[Meta](meta.md) - Documentation, Benchmarking."
+msgstr "[周辺情報](meta.md) - ドキュメント、ベンチマークの方法。"
+
+#: src/hello.md:3
+msgid "This is the source code of the traditional Hello World program."
+msgstr "ここでは伝統的な \"Hello World!\" プログラムのソースを紹介します。"
+
+#: src/hello.md:6
+msgid ""
+"// This is a comment, and is ignored by the compiler.\n"
+"// You can test this code by clicking the \"Run\" button over there ->\n"
+"// or if you prefer to use your keyboard, you can use the \"Ctrl + Enter\"\n"
+"// shortcut.\n"
+msgstr ""
+"// これはコメントです。コンパイラによって無視されます。\n"
+"// 右にある「Run」ボタンからこのコードをテストできます。\n"
+"// キーボードを使いたければ「Ctrl + Enter」もOKです。\n"
+
+#: src/hello.md:10
+msgid ""
+"// This code is editable, feel free to hack it!\n"
+"// You can always return to the original code by clicking the \"Reset\" "
+"button ->\n"
+msgstr ""
+"// このコードは編集可能です。ぜひハックしてみましょう！\n"
+"// 「Reset」ボタンでいつでも元のコードに戻すことができます ->\n"
+
+#: src/hello.md:13
+msgid "// This is the main function.\n"
+msgstr "// main関数です。\n"
+
+#: src/hello.md:16
+msgid "// Statements here are executed when the compiled binary is called.\n"
+msgstr "// コンパイルされたバイナリが実行されるとこの関数が呼び出されます。\n"
+
+#: src/hello.md:18
+msgid "// Print text to the console.\n"
+msgstr "// コンソールに文字列を出力します。\n"
+
+#: src/hello.md:19 src/error/result.md:55 src/meta/playground.md:12
+msgid "\"Hello World!\""
+msgstr "\"Hello World!\""
+
+#: src/hello.md:23
+msgid "`println!` is a [_macro_](macros.md) that prints text to the console."
+msgstr "`println!`は文字列をコンソールに出力するための[ *マクロ* ](macros.md)です。"
+
+#: src/hello.md:26
+msgid "A binary can be generated using the Rust compiler: `rustc`."
+msgstr "バイナリファイルは`rustc`と呼ばれるRustコンパイラを用いて生成することができます。"
+
+#: src/hello.md:32
+msgid "`rustc` will produce a `hello` binary that can be executed."
+msgstr "すると`hello`という名前の実行可能なバイナリファイルができます。"
+
+#: src/hello.md:39 src/hello/print/print_display.md:107
+#: src/hello/print/print_display/testcase_list.md:53 src/hello/print/fmt.md:70
+#: src/primitives/tuples.md:64 src/custom_types/structs.md:88
+msgid "Activity"
+msgstr "演習"
+
+#: src/hello.md:41
+msgid ""
+"Click 'Run' above to see the expected output. Next, add a new line with a "
+"second `println!` macro so that the output shows:"
+msgstr ""
+"上に書いている 'Run' をクリックしてアウトプットを見てみましょう。"
+"次に、`println!`マクロをもう一行追加してアウトプットがどうなるか見てみましょう。"
+
+#: src/hello/comment.md:3
+msgid ""
+"Any program requires comments, and Rust supports a few different varieties:"
+msgstr "あらゆるプログラムにはコメントが必要です。Rustには何種類かのコメントがあります"
+
+#: src/hello/comment.md:6
+msgid "_Regular comments_ which are ignored by the compiler:"
+msgstr "*通常のコメント* これはコンパイラによって完全に無視されます。"
+
+#: src/hello/comment.md:7
+msgid "`// Line comments which go to the end of the line.`"
+msgstr "`// 行末までコメントアウト`"
+
+#: src/hello/comment.md:8
+msgid "`/* Block comments which go to the closing delimiter. */`"
+msgstr "`/* ブロックによって囲まれた部分をコメントアウト */`"
+
+#: src/hello/comment.md:9
+msgid ""
+"_Doc comments_ which are parsed into HTML library [documentation](../meta/"
+"doc.md):"
+msgstr "*ドキュメンテーションコメント* ライブラリの[ドキュメンテーション](../meta/doc.md)としてHTMLにパースされます。"
+
+#: src/hello/comment.md:10
+msgid "`/// Generate library docs for the following item.`"
+msgstr "`/// このコメントの下の内容に関するドキュメントとなります。`"
+
+#: src/hello/comment.md:11
+msgid "`//! Generate library docs for the enclosing item.`"
+msgstr "`//! このコメントを含むソースのドキュメントになります。`"
+
+#: src/hello/comment.md:15
+msgid ""
+"// This is an example of a line comment.\n"
+"    // There are two slashes at the beginning of the line.\n"
+"    // And nothing written after these will be read by the compiler.\n"
+msgstr ""
+"// こちらはラインコメントです。\n"
+"    // 一番左にスラッシュが2つある行と、何も書かれていない行は\n"
+"    // どちらもコンパイラによって無視されます。\n"
+
+#: src/hello/comment.md:19
+msgid "// println!(\"Hello, world!\");\n"
+msgstr "// println!(\"Hello, world!\");\n"
+
+#: src/hello/comment.md:21
+msgid "// Run it. See? Now try deleting the two slashes, and run it again.\n"
+msgstr "// でしょ？では次に、左のスラッシュを消去してから実行してください。\n"
+
+#: src/hello/comment.md:23
+msgid ""
+"/*\n"
+"     * This is another type of comment, a block comment. In general,\n"
+"     * line comments are the recommended comment style. But block comments\n"
+"     * are extremely useful for temporarily disabling chunks of code.\n"
+"     * /* Block comments can be /* nested, */ */ so it takes only a few\n"
+"     * keystrokes to comment out everything in this main() function.\n"
+"     * /*/*/* Try it yourself! */*/*/\n"
+"     */"
+msgstr ""
+"/*\n"
+"     * こちらはもう一つのタイプのコメントでブロックコメントと呼ばれます。\n"
+"     * 普通はラインコメントの方が優れているのですが、こちらはコード片を\n"
+"     * 一時的に無効にするときに役立つかもしれません。\n"
+"     * /* ブロックコメントは /* ネストすることができるので */ */\n"
+"     * わずかなキー入力でこのmain関数全体をコメントアウトできます。\n"
+"     * /*/*/* 試してみてください！ */*/*/\n"
+"     */"
+
+#: src/hello/comment.md:32
+msgid ""
+"/*\n"
+"    Note: The previous column of `*` was entirely for style. There's\n"
+"    no actual need for it.\n"
+"    */"
+msgstr ""
+"/*\n"
+"    注: 上のコメントにおける`*`列は見栄えのためでした。実際には必要ありません。\n"
+"    */"
+
+#: src/hello/comment.md:37
+msgid ""
+"// You can manipulate expressions more easily with block comments\n"
+"    // than with line comments. Try deleting the comment delimiters\n"
+"    // to change the result:\n"
+msgstr ""
+"// ではブロックコメントがどのようにデバッグに役立つか見てみましょう。\n"
+"    // 例えば下の例の場合、ブロックコメントがなくなれば結果が変わります。\n"
+
+#: src/hello/comment.md:40
+msgid "/* 90 + */"
+msgstr "/* 90 + */"
+
+#: src/hello/comment.md:41
+msgid "\"Is `x` 10 or 100? x = {}\""
+msgstr "\"Is `x` 10 or 100? x = {}\""
+
+#: src/hello/comment.md:45 src/hello/print.md:104
+#: src/hello/print/print_debug.md:75 src/hello/print/print_display.md:118
+#: src/hello/print/print_display/testcase_list.md:62 src/hello/print/fmt.md:89
+#: src/primitives.md:55 src/custom_types/enum.md:100
+#: src/custom_types/enum/enum_use.md:45 src/custom_types/enum/c_like.md:33
+#: src/custom_types/enum/testcase_linked_list.md:77
+#: src/custom_types/constants.md:35 src/types/alias.md:30
+#: src/flow_control/for.md:121
+#: src/flow_control/match/destructuring/destructure_tuple.md:25
+#: src/flow_control/match/destructuring/destructure_slice.md:46
+#: src/flow_control/match/destructuring/destructure_enum.md:48
+#: src/flow_control/match/destructuring/destructure_pointers.md:63
+#: src/flow_control/match/destructuring/destructure_structures.md:45
+#: src/flow_control/match/guard.md:43 src/flow_control/match/binding.md:49
+#: src/flow_control/if_let.md:122 src/flow_control/let_else.md:57
+#: src/flow_control/while_let.md:54 src/fn/closures/capture.md:110
+#: src/fn/closures/input_parameters.md:84 src/fn/closures/anonymity.md:47
+#: src/fn/closures/input_functions.md:32
+#: src/fn/closures/output_parameters.md:49
+#: src/fn/closures/closure_examples/iter_any.md:50
+#: src/fn/closures/closure_examples/iter_find.md:68
+#: src/mod/struct_visibility.md:53 src/attribute/cfg.md:39 src/generics.md:59
+#: src/generics/gen_fn.md:54 src/generics/impl.md:48
+#: src/generics/gen_trait.md:39 src/generics/bounds.md:73
+#: src/generics/bounds/testcase_empty.md:37 src/generics/multi_bounds.md:32
+#: src/generics/where.md:49 src/generics/new_types.md:54
+#: src/generics/assoc_items.md:10 src/generics/assoc_items/the_problem.md:62
+#: src/generics/phantom.md:56 src/generics/phantom/testcase_units.md:75
+#: src/scope/raii.md:92 src/scope/move/partial_move.md:45
+#: src/scope/borrow/mut.md:56 src/scope/lifetime/explicit.md:68
+#: src/scope/lifetime/fn.md:58 src/scope/lifetime/methods.md:24
+#: src/scope/lifetime/struct.md:41 src/scope/lifetime/trait.md:28
+#: src/scope/lifetime/lifetime_bounds.md:46
+#: src/scope/lifetime/static_lifetime.md:131 src/scope/lifetime/elision.md:39
+#: src/trait/derive.md:64 src/trait/supertraits.md:40
+#: src/trait/disambiguating.md:60 src/error/option_unwrap/map.md:79
+#: src/error/option_unwrap/and_then.md:73
+#: src/error/option_unwrap/defaults.md:113 src/error/result/result_alias.md:41
+#: src/error/multiple_error_types/boxing_errors.md:57
+#: src/error/multiple_error_types/reenter_question_mark.md:74
+#: src/error/multiple_error_types/wrap_error.md:91 src/std.md:12
+#: src/std/rc.md:49 src/std_misc.md:12
+#: src/std_misc/threads/testcase_mapreduce.md:128 src/std_misc/path.md:54
+#: src/std_misc/fs.md:150 src/meta/doc.md:112 src/meta/playground.md:49
+msgid "See also:"
+msgstr "参照"
+
+#: src/hello/comment.md:47
+msgid "[Library documentation](../meta/doc.md)"
+msgstr "[ライブラリドキュメンテーション](../meta/doc.md)"
+
+#: src/hello/print.md:3
+msgid ""
+"Printing is handled by a series of [`macros`](../macros.md) defined in "
+"[`std::fmt`](https://doc.rust-lang.org/std/fmt/) some of which include:"
+msgstr "出力関係の機能は[`std::fmt`](https://doc.rust-lang.org/std/fmt/)で定義される幾つかの[マクロ](../macros.md)で扱うことができます。このマクロには以下が含まれます。"
+
+#: src/hello/print.md:6
+msgid "`format!`: write formatted text to [`String`](../std/str.md)"
+msgstr "`format!`：フォーマットされたテキストを[`String`](../std/str.md)に書き込みます。"
+
+#: src/hello/print.md:7
+msgid ""
+"`print!`: same as `format!` but the text is printed to the console (io::"
+"stdout)."
+msgstr "`print!`：`format!`と同様ですが、コンソール (io::stdout) にそのテキストを出力します。"
+
+#: src/hello/print.md:9
+msgid "`println!`: same as `print!` but a newline is appended."
+msgstr "`println!`：`print!`と同じですが改行が付け加えられます。"
+
+#: src/hello/print.md:10
+msgid ""
+"`eprint!`: same as `print!` but the text is printed to the standard error "
+"(io::stderr)."
+msgstr "`eprint!`：`format!`と同様ですが、標準エラー出力 (io::stderr) にそのテキストを出力します。"
+
+#: src/hello/print.md:12
+msgid "`eprintln!`: same as `eprint!` but a newline is appended."
+msgstr "`eprintln!`：`eprint!`と同じですが改行が付け加えられます。"
+
+#: src/hello/print.md:14
+msgid ""
+"All parse text in the same fashion. As a plus, Rust checks formatting "
+"correctness at compile time."
+msgstr "すべて同じやり方でテキストをパースし、正しくフォーマットできるかコンパイル時にチェックします。"
+
+#: src/hello/print.md:19
+msgid ""
+"// In general, the `{}` will be automatically replaced with any\n"
+"    // arguments. These will be stringified.\n"
+msgstr ""
+"// 一般的に`{}`はどんな引数であろうと自動的に置き換えられます。\n"
+"    // 例えば以下は文字列に変換されます。\n"
+
+#: src/hello/print.md:21
+msgid "\"{} days\""
+msgstr "\"{} days\""
+
+#: src/hello/print.md:23
+msgid ""
+"// Positional arguments can be used. Specifying an integer inside `{}`\n"
+"    // determines which additional argument will be replaced. Arguments "
+"start\n"
+"    // at 0 immediately after the format string.\n"
+msgstr ""
+"// 位置引数を利用できます。\n"
+"    // `{}`の内側に整数を指定することで、どの引数で置換されるかが決まります。\n"
+"    // 引数は0から始まります。\n"
+
+#: src/hello/print.md:26
+msgid "\"{0}, this is {1}. {1}, this is {0}\""
+msgstr "\"{0}, this is {1}. {1}, this is {0}\""
+
+#: src/hello/print.md:26 src/scope/move/partial_move.md:20
+msgid "\"Alice\""
+msgstr "\"Alice\""
+
+#: src/hello/print.md:26 src/flow_control/for.md:65 src/flow_control/for.md:85
+#: src/flow_control/for.md:104
+msgid "\"Bob\""
+msgstr "\"Bob\""
+
+#: src/hello/print.md:28
+msgid "// As can named arguments.\n"
+msgstr "// 名前での指定も可能です。\n"
+
+#: src/hello/print.md:29
+msgid "\"{subject} {verb} {object}\""
+msgstr "\"{subject} {verb} {object}\""
+
+#: src/hello/print.md:30
+msgid "\"the lazy dog\""
+msgstr "\"the lazy dog\""
+
+#: src/hello/print.md:31
+msgid "\"the quick brown fox\""
+msgstr "\"the quick brown fox\""
+
+#: src/hello/print.md:32
+msgid "\"jumps over\""
+msgstr "\"jumps over\""
+
+#: src/hello/print.md:34
+msgid ""
+"// Different formatting can be invoked by specifying the format character\n"
+"    // after a `:`.\n"
+msgstr ""
+"// `:`のあとにフォーマット文字を指定して\n"
+"    // 異なるフォーマットにすることも可能です。\n"
+
+#: src/hello/print.md:36
+msgid "\"Base 10:               {}\""
+msgstr "\"Base 10:               {}\""
+
+#: src/hello/print.md:36
+msgid "// 69420\n"
+msgstr "// 69420\n"
+
+#: src/hello/print.md:37
+msgid "\"Base 2 (binary):       {:b}\""
+msgstr "\"Base 2 (binary):       {:b}\""
+
+#: src/hello/print.md:37
+msgid "// 10000111100101100\n"
+msgstr "// 10000111100101100\n"
+
+#: src/hello/print.md:38
+msgid "\"Base 8 (octal):        {:o}\""
+msgstr "\"Base 8 (octal):        {:o}\""
+
+#: src/hello/print.md:38
+msgid "// 207454\n"
+msgstr "// 207454\n"
+
+#: src/hello/print.md:39
+msgid "\"Base 16 (hexadecimal): {:x}\""
+msgstr "\"Base 16 (hexadecimal): {:x}\""
+
+#: src/hello/print.md:39
+msgid "// 10f2c\n"
+msgstr "// 10f2c\n"
+
+#: src/hello/print.md:40
+msgid "\"Base 16 (hexadecimal): {:X}\""
+msgstr "\"Base 16 (hexadecimal): {:X}\""
+
+#: src/hello/print.md:40
+msgid "// 10F2C\n"
+msgstr "// 10F2C\n"
+
+#: src/hello/print.md:42
+msgid ""
+"// You can right-justify text with a specified width. This will\n"
+"    // output \"    1\". (Four white spaces and a \"1\", for a total width "
+"of 5.)\n"
+msgstr ""
+"// 特定の幅に右詰めすることもできます。この出力は \"    1\" になります。\n"
+"    // （4つの空白と\"1\"で合計幅は5です）\n"
+
+#: src/hello/print.md:44
+msgid "\"{number:>5}\""
+msgstr "\"{number:>5}\""
+
+#: src/hello/print.md:46
+msgid "// You can pad numbers with extra zeroes,\n"
+msgstr "// 数字を0埋めすることもできます。\n"
+
+#: src/hello/print.md:47
+msgid "\"{number:0>5}\""
+msgstr "\"{number:0>5}\""
+
+#: src/hello/print.md:47
+msgid ""
+"// 00001\n"
+"    // and left-adjust by flipping the sign. This will output \"10000\".\n"
+msgstr ""
+"// 00001\n"
+"    // 記号を反対にすると左寄せになり、\"10000\"が出力されます。\n"
+
+#: src/hello/print.md:49
+msgid "\"{number:0<5}\""
+msgstr "\"{number:0<5}\""
+
+#: src/hello/print.md:49
+msgid "// 10000\n"
+msgstr "// 10000\n"
+
+#: src/hello/print.md:51
+msgid ""
+"// You can use named arguments in the format specifier by appending a `$`.\n"
+msgstr "// フォーマット指定子の中に`$`をつけることで名前付き引数を利用できます。\n"
+
+#: src/hello/print.md:52
+msgid "\"{number:0>width$}\""
+msgstr "\"{number:0>width$}\""
+
+#: src/hello/print.md:54
+msgid ""
+"// Rust even checks to make sure the correct number of arguments are used.\n"
+msgstr "// 引数の数が正しいかのチェックも行ってくれます。\n"
+
+#: src/hello/print.md:55
+msgid "\"My name is {0}, {1} {0}\""
+msgstr "\"My name is {0}, {1} {0}\""
+
+#: src/hello/print.md:55
+msgid "\"Bond\""
+msgstr "\"Bond\""
+
+#: src/hello/print.md:56
+msgid "// FIXME ^ Add the missing argument: \"James\"\n"
+msgstr "// FIXME ^ 不足している引数 \"James\" を追加しましょう。\n"
+
+#: src/hello/print.md:58
+msgid ""
+"// Only types that implement fmt::Display can be formatted with `{}`. User-\n"
+"    // defined types do not implement fmt::Display by default.\n"
+msgstr ""
+"// `{}`でフォーマットできるのは、fmt::Displayを実装している型のみです。\n"
+"    // ユーザーが定義した型はデフォルトではfmt::Displayを実装していません。\n"
+
+#: src/hello/print.md:61
+msgid "// disable `dead_code` which warn against unused module\n"
+msgstr "// 未使用モジュールを警告する`dead_code`を無効化。\n"
+
+#: src/hello/print.md:64
+msgid ""
+"// This will not compile because `Structure` does not implement\n"
+"    // fmt::Display.\n"
+"    // println!(\"This struct `{}` won't print...\", Structure(3));\n"
+"    // TODO ^ Try uncommenting this line\n"
+msgstr ""
+"// `Structure`はfmt::Displayを実装していないので、\n"
+"    // 以下はコンパイルできません。\n"
+"    // println!(\"This struct `{}` won't print...\", Structure(3));\n"
+"    // TODO ^ この行をアンコメントしてみましょう。\n"
+
+#: src/hello/print.md:69
+msgid ""
+"// For Rust 1.58 and above, you can directly capture the argument from a\n"
+"    // surrounding variable. Just like the above, this will output\n"
+"    // \"    1\", 4 white spaces and a \"1\".\n"
+msgstr ""
+"// Rust 1.58以上では、周囲の変数から直接引数に取ることができます。\n"
+"    // 上で見たように、以下のコードは4つのスペースと1を、\"    1\" と出力します。\n"
+
+#: src/hello/print.md:74
+msgid "\"{number:>width$}\""
+msgstr "\"{number:>width$}\""
+
+#: src/hello/print.md:78
+msgid ""
+"[`std::fmt`](https://doc.rust-lang.org/std/fmt/) contains many [`traits`]"
+"(https://doc.rust-lang.org/std/fmt/#formatting-traits) which govern the "
+"display of text. The base form of two important ones are listed below:"
+msgstr ""
+"[`std::fmt`](https://doc.rust-lang.org/std/fmt/)はいくつもの[トレイト](https://doc.rust-lang.org/std/fmt/#formatting-traits)を持ち、"
+"それによってどのようにディスプレイに表示されるかが決まります。"
+"特に大事な形式は以下の2つです。"
+
+#: src/hello/print.md:81
+msgid ""
+"`fmt::Debug`: Uses the `{:?}` marker. Format text for debugging purposes."
+msgstr "`fmt::Debug`：`{:?}`というマーカーを使用し、デバッグ目的に使われます。"
+
+#: src/hello/print.md:82
+msgid ""
+"`fmt::Display`: Uses the `{}` marker. Format text in a more elegant, user "
+"friendly fashion."
+msgstr "`fmt::Display`：`{}`というマーカーを使用し、より美しく、ユーザフレンドリーに表示します。"
+
+#: src/hello/print.md:85
+msgid ""
+"Here, we used `fmt::Display` because the std library provides "
+"implementations for these types. To print text for custom types, more steps "
+"are required."
+msgstr ""
+"この例で用いられている型は、標準ライブラリに含まれているため、ここでは`fmt::Display`を使用しています。"
+"カスタム型をテキストとして表示する場合は、さらに手順が必要です。"
+
+#: src/hello/print.md:88
+msgid ""
+"Implementing the `fmt::Display` trait automatically implements the "
+"[`ToString`](https://doc.rust-lang.org/std/string/trait.ToString.html) trait "
+"which allows us to [convert](../conversion/string.md) the type to [`String`]"
+"(../std/str.md)."
+msgstr ""
+"`fmt::Display`トレイトを実装すると、自動的に[`ToString`](https://doc.rust-lang.org/std/string/trait.ToString.html)トレイトが実装されます。"
+"これにより[`String`](../std/str.md)型への[型変換](../conversion/string.md)ができるようになります。"
+
+#: src/hello/print.md:91
+msgid ""
+"In _line 43_, `#[allow(dead_code)]` is an [attribute](../attribute.md) which "
+"only apply to the module after it."
+msgstr "*43行目* の`#[allow(dead_code)]`は、直後のモジュールにのみ適用される[アトリビュート](../attribute.md)です。"
+
+#: src/hello/print.md:93
+msgid "Activities"
+msgstr "演習"
+
+#: src/hello/print.md:95
+msgid ""
+"Fix the issue in the above code (see FIXME) so that it runs without error."
+msgstr "上の例（FIXME を参照）を実行した際に生じるエラーを修復しましょう。"
+
+#: src/hello/print.md:97
+msgid ""
+"Try uncommenting the line that attempts to format the `Structure` struct "
+"(see TODO)"
+msgstr "`Structure`構造体をフォーマットする行をアンコメントしてみましょう。（TODO を参照）"
+
+#: src/hello/print.md:99
+msgid ""
+"Add a `println!` macro call that prints: `Pi is roughly 3.142` by "
+"controlling the number of decimal places shown. For the purposes of this "
+"exercise, use `let pi = 3.141592` as an estimate for pi. (Hint: you may need "
+"to check the [`std::fmt`](https://doc.rust-lang.org/std/fmt/) documentation "
+"for setting the number of decimals to display)"
+msgstr ""
+"`println!`マクロを追加し、表示される小数部の桁数を調整して`Pi is roughly 3.142`という文字列を出力しましょう。"
+"ただし、円周率の値は`let pi = 3.141592`を使ってください。"
+"（ヒント：小数部の桁数を調整する方法については、[`std::fmt`](https://doc.rust-lang.org/std/fmt/)をチェックする必要があるかもしれません。）"
+
+#: src/hello/print.md:106
+msgid ""
+"[`std::fmt`](https://doc.rust-lang.org/std/fmt/), [`macros`](../macros.md), "
+"[`struct`](../custom_types/structs.md), [`traits`](https://doc.rust-lang.org/"
+"std/fmt/#formatting-traits), and [`dead_code`](../attribute/unused.md)"
+msgstr ""
+"[`std::fmt`](https://doc.rust-lang.org/std/fmt/), [マクロ](../macros.md), "
+"[構造体](../custom_types/structs.md), [トレイト](https://doc.rust-lang.org/"
+"std/fmt/#formatting-traits), [`dead_code`](../attribute/unused.md)"
+
+#: src/hello/print/print_debug.md:3
+msgid ""
+"All types which want to use `std::fmt` formatting `traits` require an "
+"implementation to be printable. Automatic implementations are only provided "
+"for types such as in the `std` library. All others _must_ be manually "
+"implemented somehow."
+msgstr "`std::fmt`のフォーマット用`トレイト`を使用したい型は、出力できるように実装されている必要があります。`std`ライブラリの型のように自動で出力可能なものもありますが、他はすべて *手動で実装する必要があります。*"
+
+#: src/hello/print/print_debug.md:8
+msgid ""
+"The `fmt::Debug` `trait` makes this very straightforward. _All_ types can "
+"`derive` (automatically create) the `fmt::Debug` implementation. This is not "
+"true for `fmt::Display` which must be manually implemented."
+msgstr ""
+"`fmt::Debug`という`トレイト`はこれを簡略化します。 *すべての* 型は`fmt::Debug`の実装を`導出(derive)`、（すなわち自動で作成）することができるためです。"
+"`fmt::Display`の場合はやはり手動で実装しなくてはなりません。"
+
+#: src/hello/print/print_debug.md:13
+msgid ""
+"// This structure cannot be printed either with `fmt::Display` or\n"
+"// with `fmt::Debug`.\n"
+msgstr ""
+"// この構造体は`fmt::Display`、`fmt::Debug`のいずれによっても\n"
+"// 出力することができません。\n"
+
+#: src/hello/print/print_debug.md:16
+msgid ""
+"// The `derive` attribute automatically creates the implementation\n"
+"// required to make this `struct` printable with `fmt::Debug`.\n"
+msgstr ""
+"// `derive`アトリビュートは、\n"
+"// この構造体を`fmt::Debug`で出力するための実装を自動で提供します。\n"
+
+#: src/hello/print/print_debug.md:23
+msgid "All `std` library types are automatically printable with `{:?}` too:"
+msgstr "`std`ライブラリの型の場合は、自動的に`{:?}`により出力可能になっています。"
+
+#: src/hello/print/print_debug.md:26
+msgid ""
+"// Derive the `fmt::Debug` implementation for `Structure`. `Structure`\n"
+"// is a structure which contains a single `i32`.\n"
+msgstr ""
+"// `Structure`という構造体のための`fmt::Debug`を導出しています。\n"
+"// `Structure`は単一の`i32`をメンバに持っています。\n"
+
+#: src/hello/print/print_debug.md:30
+msgid ""
+"// Put a `Structure` inside of the structure `Deep`. Make it printable\n"
+"// also.\n"
+msgstr ""
+"// `Deep`という構造体の中に`Structure`を入れ、これを出力可能にしています。\n"
+
+#: src/hello/print/print_debug.md:37
+msgid "// Printing with `{:?}` is similar to with `{}`.\n"
+msgstr "// `{:?}`による出力は`{}`に似ています。\n"
+
+#: src/hello/print/print_debug.md:38
+msgid "\"{:?} months in a year.\""
+msgstr "\"{:?} months in a year.\""
+
+#: src/hello/print/print_debug.md:39
+msgid "\"{1:?} {0:?} is the {actor:?} name.\""
+msgstr "\"{1:?} {0:?} is the {actor:?} name.\""
+
+#: src/hello/print/print_debug.md:40
+msgid "\"Slater\""
+msgstr "\"Slater\""
+
+#: src/hello/print/print_debug.md:41
+msgid "\"Christian\""
+msgstr "\"Christian\""
+
+#: src/hello/print/print_debug.md:42
+msgid "\"actor's\""
+msgstr "\"actor's\""
+
+#: src/hello/print/print_debug.md:44
+msgid "// `Structure` is printable!\n"
+msgstr "// `Structure`は出力可能です！\n"
+
+#: src/hello/print/print_debug.md:45 src/hello/print/print_debug.md:49
+msgid "\"Now {:?} will print!\""
+msgstr "\"Now {:?} will print!\""
+
+#: src/hello/print/print_debug.md:47
+msgid ""
+"// The problem with `derive` is there is no control over how\n"
+"    // the results look. What if I want this to just show a `7`?\n"
+msgstr ""
+"// `derive`を用いることの問題は、結果がどのように見えるか\n"
+"    // コントロールする方法がないことです。\n"
+"    // 出力を`7`だけにするためにはどうしたらよいでしょう？\n"
+
+#: src/hello/print/print_debug.md:53
+msgid ""
+"So `fmt::Debug` definitely makes this printable but sacrifices some "
+"elegance. Rust also provides \"pretty printing\" with `{:#?}`."
+msgstr ""
+"`fmt::Debug`は確実に出力可能にしてくれるのですが、一方である種の美しさを犠牲にしています。"
+"Rustは`{:#?}`による「見栄えの良い出力」も提供します。"
+
+#: src/hello/print/print_debug.md:64 src/custom_types/structs.md:42
+msgid "\"Peter\""
+msgstr "\"Peter\""
+
+#: src/hello/print/print_debug.md:68
+msgid "// Pretty print\n"
+msgstr "// 見栄えのよい出力\n"
+
+#: src/hello/print/print_debug.md:69
+msgid "\"{:#?}\""
+msgstr "\"{:#?}\""
+
+#: src/hello/print/print_debug.md:73
+msgid "One can manually implement `fmt::Display` to control the display."
+msgstr "手動で`fmt::Display`を実装することで出力結果を思い通りにできます。"
+
+#: src/hello/print/print_debug.md:77
+msgid ""
+"[`attributes`](https://doc.rust-lang.org/reference/attributes.html), "
+"[`derive`](../../trait/derive.md), [`std::fmt`](https://doc.rust-lang.org/"
+"std/fmt/), and [`struct`](../../custom_types/structs.md)"
+msgstr ""
+"[アトリビュート](https://doc.rust-lang.org/reference/attributes.html), "
+"[`derive`](../../trait/derive.md), [`std::fmt`](https://doc.rust-lang.org/"
+"std/fmt/), [構造体](../../custom_types/structs.md)"
+
+#: src/hello/print/print_display.md:3
+msgid ""
+"`fmt::Debug` hardly looks compact and clean, so it is often advantageous to "
+"customize the output appearance. This is done by manually implementing "
+"[`fmt::Display`](https://doc.rust-lang.org/std/fmt/), which uses the `{}` "
+"print marker. Implementing it looks like this:"
+msgstr ""
+"`fmt::Debug`はコンパクトでクリーンであるようには見えませんね。"
+"大抵の場合は、アウトプットの見た目をカスタマイズしたほうが好ましいでしょう。"
+"これは`{}`を使用する[`fmt::Display`](https://doc.rust-lang.org/std/fmt/)を手動で実装することで可能です。"
+"実装はこのようになります。"
+
+#: src/hello/print/print_display.md:9
+msgid "// Import (via `use`) the `fmt` module to make it available.\n"
+msgstr "// （`use`を使用し、）`fmt`モジュールをインポートします。\n"
+
+#: src/hello/print/print_display.md:11
+msgid ""
+"// Define a structure for which `fmt::Display` will be implemented. This is\n"
+"// a tuple struct named `Structure` that contains an `i32`.\n"
+msgstr ""
+"// `fmt::Display`を実装するための構造体を定義します。\n"
+"// これは`Structure`と名付けられた、`i32`を含むタプル構造体です。\n"
+
+#: src/hello/print/print_display.md:15
+msgid ""
+"// To use the `{}` marker, the trait `fmt::Display` must be implemented\n"
+"// manually for the type.\n"
+msgstr ""
+"// `{}` というマーカーを使用するためには、\n"
+"// この型専用の`fmt::Display`というトレイトが実装されていなくてはなりません。\n"
+
+#: src/hello/print/print_display.md:19
+msgid "// This trait requires `fmt` with this exact signature.\n"
+msgstr "// このトレイトは`fmt`が正確にこの通りのシグネチャであることを要求します。\n"
+
+#: src/hello/print/print_display.md:21
+msgid ""
+"// Write strictly the first element into the supplied output\n"
+"        // stream: `f`. Returns `fmt::Result` which indicates whether the\n"
+"        // operation succeeded or failed. Note that `write!` uses syntax "
+"which\n"
+"        // is very similar to `println!`.\n"
+msgstr ""
+"// 最初の要素だけを、与えられた出力ストリーム`f`に書き込みます。\n"
+"        // 操作が成功したかどうかを表す`fmt::Result`を返します。\n"
+"        // `write!`は`println!`に非常によく似た文法を使用していることに注目。\n"
+
+#: src/hello/print/print_display.md:25
+#: src/hello/print/print_display/testcase_list.md:13
+#: src/hello/print/print_display/testcase_list.md:39
+#: src/hello/print/print_display/testcase_list.md:49 src/hello/print/fmt.md:53
+#: src/custom_types/enum/testcase_linked_list.md:73 src/conversion/string.md:25
+#: src/flow_control/loop.md:26 src/flow_control/while.md:21
+#: src/flow_control/for.md:23 src/flow_control/for.md:43 src/fn.md:40
+#: src/fn/closures/capture.md:96 src/fn/closures/capture.md:97
+#: src/fn/closures/anonymity.md:41 src/generics/bounds.md:12
+#: src/macros/repeat.md:24 src/macros/repeat.md:25 src/macros/repeat.md:26
+#: src/error/result.md:73 src/std/str.md:92 src/std/str.md:102
+#: src/std/str.md:106 src/std/str.md:111 src/std/result.md:72
+#: src/std/result/question_mark.md:57 src/std/result/question_mark.md:65
+#: src/std_misc/file/read_lines.md:60 src/std_misc/arg/matching.md:9
+#: src/std_misc/arg/matching.md:13
+msgid "\"{}\""
+msgstr "\"{}\""
+
+#: src/hello/print/print_display.md:30
+msgid ""
+"`fmt::Display` may be cleaner than `fmt::Debug` but this presents a problem "
+"for the `std` library. How should ambiguous types be displayed? For example, "
+"if the `std` library implemented a single style for all `Vec<T>`, what style "
+"should it be? Would it be either of these two?"
+msgstr ""
+"`fmt::Display`は`fmt::Debug`より綺麗かもしれませんが、`std`ライブラリの場合は問題が生じます。"
+"曖昧な型はどのように表示すれば良いでしょう？"
+"例えば、`std`ライブラリがあらゆる`Vec<T>`に対して単一のスタイルを提供していた場合、"
+"どのようなスタイルに整形すればよいでしょう？以下の2つのどちらかを選ぶべきでしょうか？"
+
+#: src/hello/print/print_display.md:35
+msgid "`Vec<path>`: `/:/etc:/home/username:/bin` (split on `:`)"
+msgstr "`Vec<path>`: `/:/etc:/home/username:/bin` （`:`で分割）"
+
+#: src/hello/print/print_display.md:36
+msgid "`Vec<number>`: `1,2,3` (split on `,`)"
+msgstr "`Vec<number>`: `1,2,3` （`,`で分割）"
+
+#: src/hello/print/print_display.md:38
+msgid ""
+"No, because there is no ideal style for all types and the `std` library "
+"doesn't presume to dictate one. `fmt::Display` is not implemented for "
+"`Vec<T>` or for any other generic containers. `fmt::Debug` must then be used "
+"for these generic cases."
+msgstr ""
+"答えはNOです。あらゆる型に対して理想的なスタイルなどというものはありませんし、"
+"`std`ライブラリによってそれが提供されているわけでもありません。"
+"`fmt::Display`は`Vec<T>`のようなジェネリックなコンテナ用に定義されているわけではありませんので、"
+"このような場合は`fmt::Debug`を使用するべきです。"
+
+#: src/hello/print/print_display.md:43
+msgid ""
+"This is not a problem though because for any new _container_ type which is "
+"_not_ generic, `fmt::Display` can be implemented."
+msgstr "ジェネリック *でない* コンテナ型の場合は、このような問題は生じませんので問題なく`fmt::Display`を実装することができます。"
+
+#: src/hello/print/print_display.md:47
+msgid "// Import `fmt`\n"
+msgstr "// `fmt`のインポート\n"
+
+#: src/hello/print/print_display.md:48
+msgid ""
+"// A structure holding two numbers. `Debug` will be derived so the results "
+"can\n"
+"// be contrasted with `Display`.\n"
+msgstr ""
+"// 2つの数字を扱うための構造体です。出力を`Display`と比較するため`Debug`\n"
+"// を導出しています。\n"
+
+#: src/hello/print/print_display.md:53
+msgid "// Implement `Display` for `MinMax`.\n"
+msgstr "// `MinMax`用の`Display`を実装しています。\n"
+
+#: src/hello/print/print_display.md:57
+msgid "// Use `self.number` to refer to each positional data point.\n"
+msgstr "// `self.number`でそれぞれのデータポイントを参照できます。\n"
+
+#: src/hello/print/print_display.md:58
+msgid "\"({}, {})\""
+msgstr "\"({}, {})\""
+
+#: src/hello/print/print_display.md:61
+msgid "// Define a structure where the fields are nameable for comparison.\n"
+msgstr "// 比較のため、フィールドに名前をつけられる様な構造体を定義しましょう。\n"
+
+#: src/hello/print/print_display.md:68
+msgid "// Similarly, implement `Display` for `Point2D`.\n"
+msgstr "// 先程と同様にして、`Point2D`用の`Display`を実装しています。\n"
+
+#: src/hello/print/print_display.md:72
+msgid "// Customize so only `x` and `y` are denoted.\n"
+msgstr "// `x`と`y`のみが明示的になるようにカスタマイズ。\n"
+
+#: src/hello/print/print_display.md:73
+msgid "\"x: {}, y: {}\""
+msgstr "\"x: {}, y: {}\""
+
+#: src/hello/print/print_display.md:80
+msgid "\"Compare structures:\""
+msgstr "\"Compare structures:\""
+
+#: src/hello/print/print_display.md:81 src/hello/print/print_display.md:94
+msgid "\"Display: {}\""
+msgstr "\"Display: {}\""
+
+#: src/hello/print/print_display.md:82 src/hello/print/print_display.md:95
+msgid "\"Debug: {:?}\""
+msgstr "\"Debug: {:?}\""
+
+#: src/hello/print/print_display.md:87
+msgid "\"The big range is {big} and the small is {small}\""
+msgstr "\"The big range is {big} and the small is {small}\""
+
+#: src/hello/print/print_display.md:93
+msgid "\"Compare points:\""
+msgstr "\"Compare points:\""
+
+#: src/hello/print/print_display.md:97
+msgid ""
+"// Error. Both `Debug` and `Display` were implemented, but `{:b}`\n"
+"    // requires `fmt::Binary` to be implemented. This will not work.\n"
+"    // println!(\"What does Point2D look like in binary: {:b}?\", point);\n"
+msgstr ""
+"// `Debug`と`Display`は実装されていますが、`fmt::Binary`はされていないため\n"
+"    // `{:b}`使用している以下の例はエラーになります。\n"
+"    // println!(\"What does Point2D look like in binary: {:b}?\", point);\n"
+
+#: src/hello/print/print_display.md:103
+msgid ""
+"So, `fmt::Display` has been implemented but `fmt::Binary` has not, and "
+"therefore cannot be used. `std::fmt` has many such [`traits`](https://doc."
+"rust-lang.org/std/fmt/#formatting-traits) and each requires its own "
+"implementation. This is detailed further in [`std::fmt`](https://doc.rust-"
+"lang.org/std/fmt/)."
+msgstr ""
+"`fmt::Display`は実装されていますが、`fmt::Binary`はされていないので使用できません。"
+"`std::fmt`にはそのような[トレイト](https://doc.rust-lang.org/std/fmt/#formatting-traits)が数多くあり、"
+"それぞれに独自の実装が必要です。詳しくは[`std::fmt`](https://doc.rust-lang.org/std/fmt/)を参照してください。"
+
+#: src/hello/print/print_display.md:109
+msgid ""
+"After checking the output of the above example, use the `Point2D` struct as "
+"a guide to add a `Complex` struct to the example. When printed in the same "
+"way, the output should be:"
+msgstr ""
+"上記の例のアウトプットを確認し、`Point2D`構造体を参考として、複素数を格納するための`Complex`構造体を定義しましょう。"
+"うまく行けば以下のように出力されるはずです。"
+
+#: src/hello/print/print_display.md:120
+msgid ""
+"[`derive`](../../trait/derive.md), [`std::fmt`](https://doc.rust-lang.org/"
+"std/fmt/), [`macros`](../../macros.md), [`struct`](../../custom_types/"
+"structs.md), [`trait`](https://doc.rust-lang.org/std/fmt/#formatting-"
+"traits), and [`use`](../../mod/use.md)"
+msgstr ""
+"[導出](../../trait/derive.md), [`std::fmt`](https://doc.rust-lang.org/"
+"std/fmt/), [マクロ](../../macros.md), [構造体](../../custom_types/"
+"structs.md), [トレイト](https://doc.rust-lang.org/std/fmt/#formatting-"
+"traits), [`use`](../../mod/use.md)"
+
+#: src/hello/print/print_display/testcase_list.md:3
+msgid ""
+"Implementing `fmt::Display` for a structure where the elements must each be "
+"handled sequentially is tricky. The problem is that each `write!` generates "
+"a `fmt::Result`. Proper handling of this requires dealing with _all_ the "
+"results. Rust provides the `?` operator for exactly this purpose."
+msgstr ""
+"構造体のそれぞれの要素を別々に扱う`fmt::Display`を実装するのはトリッキーです。"
+"というのも、それぞれの`write!`が別々の`fmt::Result`を生成するためです。"
+"適切に処理するためには *すべての* 結果に対して処理を書かなくてはなりません。"
+"このような場合は`?`演算子が使えます。"
+
+#: src/hello/print/print_display/testcase_list.md:8
+msgid "Using `?` on `write!` looks like this:"
+msgstr "以下のように`?`を`write!`に対して使用します。"
+
+#: src/hello/print/print_display/testcase_list.md:11
+msgid ""
+"// Try `write!` to see if it errors. If it errors, return\n"
+"// the error. Otherwise continue.\n"
+msgstr "// `write!`を実行し、エラーが生じた場合はエラーを返します。そうでなければ実行を継続します。\n"
+
+#: src/hello/print/print_display/testcase_list.md:16
+msgid ""
+"With `?` available, implementing `fmt::Display` for a `Vec` is "
+"straightforward:"
+msgstr "`?`を使用すれば、`Vec`用の`fmt::Display`はより簡単に実装できます。"
+
+#: src/hello/print/print_display/testcase_list.md:20
+msgid "// Import the `fmt` module.\n"
+msgstr "// `fmt`モジュールのインポート\n"
+
+#: src/hello/print/print_display/testcase_list.md:21
+msgid "// Define a structure named `List` containing a `Vec`.\n"
+msgstr "// `Vec`を含む`List`という名の構造体を定義。\n"
+
+#: src/hello/print/print_display/testcase_list.md:27
+msgid ""
+"// Extract the value using tuple indexing,\n"
+"        // and create a reference to `vec`.\n"
+msgstr ""
+"// タプルインデックスを使って値を取り出し、それへの参照`vec`を作ります。\n"
+
+#: src/hello/print/print_display/testcase_list.md:31
+msgid "\"[\""
+msgstr "\"[\""
+
+#: src/hello/print/print_display/testcase_list.md:33
+msgid ""
+"// Iterate over `v` in `vec` while enumerating the iteration\n"
+"        // count in `count`.\n"
+msgstr ""
+"// `v`を介して`vec`をイテレートし、同時にカウントを\n"
+"        // `enumerate`で取得します。\n"
+
+#: src/hello/print/print_display/testcase_list.md:36
+msgid ""
+"// For every element except the first, add a comma.\n"
+"            // Use the ? operator to return on errors.\n"
+msgstr ""
+"// 先頭以外の全要素にカンマを付けます。\n"
+"            // ?演算子を使ってエラーを返します。\n"
+
+#: src/hello/print/print_display/testcase_list.md:38 src/std/str.md:36
+msgid "\", \""
+msgstr "\", \""
+
+#: src/hello/print/print_display/testcase_list.md:42
+msgid "// Close the opened bracket and return a fmt::Result value.\n"
+msgstr "// 開きっぱなしのブラケットを閉じて、`fmt::Result`の値を返します。\n"
+
+#: src/hello/print/print_display/testcase_list.md:43
+msgid "\"]\""
+msgstr "\"]\""
+
+#: src/hello/print/print_display/testcase_list.md:55
+msgid ""
+"Try changing the program so that the index of each element in the vector is "
+"also printed. The new output should look like this:"
+msgstr ""
+"上記のプログラムを変更して、ベクタの各要素のインデックスも表示するようにしてみましょう。"
+"変更後の出力は次のようになります。"
+
+#: src/hello/print/print_display/testcase_list.md:64
+msgid ""
+"[`for`](../../../flow_control/for.md), [`ref`](../../../scope/borrow/ref."
+"md), [`Result`](../../../std/result.md), [`struct`](../../../custom_types/"
+"structs.md), [`?`](../../../std/result/question_mark.md), and [`vec!`]"
+"(../../../std/vec.md)"
+msgstr ""
+"[`for`](../../../flow_control/for.md), [`ref`](../../../scope/borrow/ref."
+"md), [`Result`](../../../std/result.md), [構造体](../../../custom_types/"
+"structs.md), [`?`](../../../std/result/question_mark.md), [`vec!`]"
+"(../../../std/vec.md)"
+
+#: src/hello/print/fmt.md:3
+msgid "We've seen that formatting is specified via a _format string_:"
+msgstr "これまで、文字列がどのようにフォーマットされるかは *フォーマット文字列* によって決まるということを見てきました 。"
+
+#: src/hello/print/fmt.md:5
+msgid "`format!(\"{}\", foo)` -> `\"3735928559\"`"
+msgstr "`format!(\"{}\", foo)` -> `\"3735928559\"`"
+
+#: src/hello/print/fmt.md:6
+msgid ""
+"`format!(\"0x{:X}\", foo)` -> [`\"0xDEADBEEF\"`](https://en.wikipedia.org/"
+"wiki/Deadbeef#Magic_debug_values)"
+msgstr ""
+"`format!(\"0x{:X}\", foo)` -> [`\"0xDEADBEEF\"`](https://en.wikipedia.org/"
+"wiki/Deadbeef#Magic_debug_values)"
+
+#: src/hello/print/fmt.md:7
+msgid "`format!(\"0o{:o}\", foo)` -> `\"0o33653337357\"`"
+msgstr "`format!(\"0o{:o}\", foo)` -> `\"0o33653337357\"`"
+
+#: src/hello/print/fmt.md:9
+msgid ""
+"The same variable (`foo`) can be formatted differently depending on which "
+"_argument type_ is used: `X` vs `o` vs _unspecified_."
+msgstr "ここでは（`foo`）という単一の変数が`X`、`o`、 *指定なし* 、という様々な *引数タイプ* に応じてフォーマットされています。"
+
+#: src/hello/print/fmt.md:12
+msgid ""
+"This formatting functionality is implemented via traits, and there is one "
+"trait for each argument type. The most common formatting trait is `Display`, "
+"which handles cases where the argument type is left unspecified: `{}` for "
+"instance."
+msgstr ""
+"フォーマットの機能はそれぞれの引数タイプごとに個別のトレイトを用いて実装されています。"
+"最も一般的なトレイトは`Display`で、これは引数タイプが未指定（たとえば`{}`）の時に呼び出されます。"
+
+#: src/hello/print/fmt.md:21
+msgid "// Latitude\n"
+msgstr "// 緯度\n"
+
+#: src/hello/print/fmt.md:23
+msgid "// Longitude\n"
+msgstr "// 経度\n"
+
+#: src/hello/print/fmt.md:28
+msgid ""
+"// `f` is a buffer, and this method must write the formatted string into "
+"it.\n"
+msgstr ""
+"// `f`はバッファです。このメソッドは\n"
+"    // ここにフォーマットされた文字列を書き込みます。\n"
+
+#: src/hello/print/fmt.md:30
+msgid "'N'"
+msgstr "'N'"
+
+#: src/hello/print/fmt.md:30
+msgid "'S'"
+msgstr "'S'"
+
+#: src/hello/print/fmt.md:31
+msgid "'E'"
+msgstr "'E'"
+
+#: src/hello/print/fmt.md:31
+msgid "'W'"
+msgstr "'W'"
+
+#: src/hello/print/fmt.md:33
+msgid ""
+"// `write!` is like `format!`, but it will write the formatted string\n"
+"        // into a buffer (the first argument).\n"
+msgstr ""
+"// `write!`は`format!`に似ていますが、フォーマットされた文字列を\n"
+"        // バッファ（第一引数）に書き込みます。\n"
+
+#: src/hello/print/fmt.md:35
+msgid "\"{}: {:.3}°{} {:.3}°{}\""
+msgstr "\"{}: {:.3}°{} {:.3}°{}\""
+
+#: src/hello/print/fmt.md:49
+msgid "\"Dublin\""
+msgstr "\"Dublin\""
+
+#: src/hello/print/fmt.md:50
+msgid "\"Oslo\""
+msgstr "\"Oslo\""
+
+#: src/hello/print/fmt.md:51
+msgid "\"Vancouver\""
+msgstr "\"Vancouver\""
+
+#: src/hello/print/fmt.md:60
+msgid ""
+"// Switch this to use {} once you've added an implementation\n"
+"        // for fmt::Display.\n"
+msgstr "// fmt::Displayに実装を追加したら、 {} を使用するように変更してください。\n"
+
+#: src/hello/print/fmt.md:62 src/primitives/tuples.md:60
+#: src/custom_types/structs.md:47 src/types/inference.md:23
+#: src/generics/bounds.md:49 src/generics/where.md:38 src/std/str.md:137
+#: src/std/result.md:59 src/std/result.md:61 src/std/result.md:63
+#: src/std/arc.md:26 src/std_misc/channels.md:53
+msgid "\"{:?}\""
+msgstr "\"{:?}\""
+
+#: src/hello/print/fmt.md:67
+msgid ""
+"You can view a [full list of formatting traits](https://doc.rust-lang.org/"
+"std/fmt/#formatting-traits) and their argument types in the [`std::fmt`]"
+"(https://doc.rust-lang.org/std/fmt/) documentation."
+msgstr ""
+"フォーマット用トレイトの全リストは[こちら](https://doc.rust-lang.org/std/fmt/#formatting-traits)から、"
+"引数タイプについては[`std::fmt`のドキュメンテーション](https://doc.rust-lang.org/std/fmt/)から参照できます。"
+
+#: src/hello/print/fmt.md:72
+msgid ""
+"Add an implementation of the `fmt::Display` trait for the `Color` struct "
+"above so that the output displays as:"
+msgstr ""
+"上にあるソースコード中の`Color`という構造体のための`fmt::Display`トレイトの実装を追加しましょう。"
+"出力は以下のようになるはずです。"
+
+#: src/hello/print/fmt.md:81
+msgid "Three hints if you get stuck:"
+msgstr "詰まったら以下の3つがヒントになります。"
+
+#: src/hello/print/fmt.md:83
+msgid ""
+"The formula for calculating a color in the RGB color space is: `RGB = "
+"(R*65536)+(G*256)+B , (when R is RED, G is GREEN and B is BLUE)`. For more "
+"see [RGB color format & calculation](https://www.rapidtables.com/web/color/"
+"RGB_Color.html#rgb-format)."
+msgstr ""
+"RGB色空間で色を計算する式は`RGB = (R*65536)+(G*256)+B （R は RED, G は GREEN and B は BLUE）`です。"
+"詳細は[RGB color format & calculation](https://www.rapidtables.com/web/color/RGB_Color.html#rgb-format)を参照。"
+
+#: src/hello/print/fmt.md:86
+msgid ""
+"You [may need to list each color more than once](https://doc.rust-lang.org/"
+"std/fmt/#named-parameters)."
+msgstr "[それぞれの色を2回以上記述する必要があるかもしれません。](https://doc.rust-lang.org/std/fmt/#named-parameters)"
+
+#: src/hello/print/fmt.md:87
+msgid ""
+"You can [pad with zeros to a width of 2](https://doc.rust-lang.org/std/fmt/"
+"#width) with `:0>2`."
+msgstr "`:0>2`で、[幅を2に指定し、空白を0で埋める事ができます。](https://doc.rust-lang.org/std/fmt/#width)"
+
+#: src/hello/print/fmt.md:91
+msgid "[`std::fmt`](https://doc.rust-lang.org/std/fmt/)"
+msgstr "[`std::fmt`](https://doc.rust-lang.org/std/fmt/)"
+
+#: src/primitives.md:3
+msgid ""
+"Rust provides access to a wide variety of `primitives`. A sample includes:"
+msgstr "Rustは様々な基本データ型の使用をサポートしています。以下がその例です。"
+
+#: src/primitives.md:5
+msgid "Scalar Types"
+msgstr "スカラー型"
+
+#: src/primitives.md:7
+msgid ""
+"Signed integers: `i8`, `i16`, `i32`, `i64`, `i128` and `isize` (pointer size)"
+msgstr "符号付き整数：`i8`, `i16`, `i32`, `i64`, `i128`, `isize`（ポインタのサイズ）"
+
+#: src/primitives.md:8
+msgid ""
+"Unsigned integers: `u8`, `u16`, `u32`, `u64`, `u128` and `usize` (pointer "
+"size)"
+msgstr "符号無し整数：`u8`, `u16`, `u32`, `u64`, `u128`, `usize`（ポインタのサイズ）"
+
+#: src/primitives.md:10
+msgid "Floating point: `f32`, `f64`"
+msgstr "浮動小数点数：`f32`, `f64`"
+
+#: src/primitives.md:11
+msgid "`char` Unicode scalar values like `'a'`, `'α'` and `'∞'` (4 bytes each)"
+msgstr "`char`：`'a'`, `'α'`, `'∞'`などのUnicodeのスカラー値（それぞれ4バイト）"
+
+#: src/primitives.md:12
+msgid "`bool` either `true` or `false`"
+msgstr "`bool`：`true`または`false`"
+
+#: src/primitives.md:13
+msgid "The unit type `()`, whose only possible value is an empty tuple: `()`"
+msgstr "ユニット型 `()`：唯一の値として空のタプル`()`を持つ"
+
+#: src/primitives.md:15
+msgid ""
+"Despite the value of a unit type being a tuple, it is not considered a "
+"compound type because it does not contain multiple values."
+msgstr "ユニット型はその値がタプルですが、複合型とはみなされません。内部に複数の値を含んでいるわけではないからです。"
+
+#: src/primitives.md:18
+msgid "Compound Types"
+msgstr "複合型"
+
+#: src/primitives.md:20
+msgid "Arrays like `[1, 2, 3]`"
+msgstr "配列： 例えば`[1, 2, 3]`"
+
+#: src/primitives.md:21
+msgid "Tuples like `(1, true)`"
+msgstr "タプル：例えば`(1, true)`"
+
+#: src/primitives.md:23
+msgid ""
+"Variables can always be _type annotated_. Numbers may additionally be "
+"annotated via a _suffix_ or _by default_. Integers default to `i32` and "
+"floats to `f64`. Note that Rust can also infer types from context."
+msgstr ""
+"変数は常に *型指定* できます。数値型の場合はさらにサフィックスでの指定も可能です。"
+"指定しない場合デフォルトになります。整数は`i32`が、浮動小数点は`f64`がデフォルトです。"
+"また、Rustは文脈から型を推論することもできます。"
+
+#: src/primitives.md:29
+msgid "// Variables can be type annotated.\n"
+msgstr "// 変数に型を指定。\n"
+
+#: src/primitives.md:32
+msgid "// Regular annotation\n"
+msgstr "// 通常の型指定\n"
+
+#: src/primitives.md:33
+msgid "// Suffix annotation\n"
+msgstr "// サフィックスによる型指定\n"
+
+#: src/primitives.md:35
+msgid "// Or a default will be used.\n"
+msgstr "// サフィックスを指定しない場合、デフォルトを選択。\n"
+
+#: src/primitives.md:36
+msgid "// `f64`\n"
+msgstr "// `f64`\n"
+
+#: src/primitives.md:37
+msgid "// `i32`\n"
+msgstr "// `i32`\n"
+
+#: src/primitives.md:39
+msgid "// A type can also be inferred from context.\n"
+msgstr "// 型を文脈から推論することも可能。\n"
+
+#: src/primitives.md:40
+msgid "// Type i64 is inferred from another line.\n"
+msgstr "// 型 i64 は次行の内容に基づいて推論。\n"
+
+#: src/primitives.md:43
+msgid "// A mutable variable's value can be changed.\n"
+msgstr "// ミュータブルな変数は値を変更できます。\n"
+
+#: src/primitives.md:44
+msgid "// Mutable `i32`\n"
+msgstr "// ミュータブルな`i32`\n"
+
+#: src/primitives.md:47
+msgid "// Error! The type of a variable can't be changed.\n"
+msgstr "// エラー！ミュータブルな変数でも型は不変。\n"
+
+#: src/primitives.md:50
+msgid "// Variables can be overwritten with shadowing.\n"
+msgstr "// 変数はシャドーイングによって上書きできます。\n"
+
+#: src/primitives.md:57
+msgid ""
+"[the `std` library](https://doc.rust-lang.org/std/), [`mut`]"
+"(variable_bindings/mut.md), [`inference`](types/inference.md), and "
+"[`shadowing`](variable_bindings/scope.md)"
+msgstr ""
+"[`std` ライブラリ](https://doc.rust-lang.org/std/), [`mut`]"
+"(variable_bindings/mut.md), [型推論](types/inference.md), "
+"[シャドーイング](variable_bindings/scope.md)"
+
+#: src/primitives/literals.md:3
+msgid ""
+"Integers `1`, floats `1.2`, characters `'a'`, strings `\"abc\"`, booleans "
+"`true` and the unit type `()` can be expressed using literals."
+msgstr ""
+"整数`1`、浮動小数点数`1.2`、文字`'a'`、文字列`\"abc\"`、ブーリアン`true`、"
+"ユニット`()`は、リテラルを使って表すことが可能です。"
+
+#: src/primitives/literals.md:6
+msgid ""
+"Integers can, alternatively, be expressed using hexadecimal, octal or binary "
+"notation using these prefixes respectively: `0x`, `0o` or `0b`."
+msgstr "また整数型の場合、プレフィックスに`0x`、`0o`、`0b`を指定することでそれぞれ16進数、8進数、2進数を使って表すことができます。"
+
+#: src/primitives/literals.md:9
+msgid ""
+"Underscores can be inserted in numeric literals to improve readability, e.g. "
+"`1_000` is the same as `1000`, and `0.000_001` is the same as `0.000001`."
+msgstr ""
+"可読性のため、`_`（アンダースコア）を数値リテラルの間に挿入することができます。"
+"例えば`1_000`は`1000`と、`0.000_001`は`0.000001`とそれぞれ同一です。"
+
+#: src/primitives/literals.md:12
+msgid ""
+"Rust also supports scientific [E-notation](https://en.wikipedia.org/wiki/"
+"Scientific_notation#E_notation), e.g. `1e6`, `7.6e-4`. The associated type "
+"is `f64`."
+msgstr ""
+"また、Rustは`1e6`や`7.6e-4`などの科学的な[E表記](https://en.wikipedia.org/wiki/Scientific_notation#E_notation)をサポートしています。"
+"この表記は`f64`になります。"
+
+#: src/primitives/literals.md:15
+msgid ""
+"We need to tell the compiler the type of the literals we use. For now, we'll "
+"use the `u32` suffix to indicate that the literal is an unsigned 32-bit "
+"integer, and the `i32` suffix to indicate that it's a signed 32-bit integer."
+msgstr ""
+"コンパイラに、リテラルの型を伝えたい場合があります。"
+"現在の仕様では、リテラルが32ビット符号無し整数であることを伝える場合、"
+"`u32`サフィックスを、符号付き32ビット整数であれば`i32`サフィックスを使用します。"
+
+#: src/primitives/literals.md:19
+msgid ""
+"The operators available and their precedence [in Rust](https://doc.rust-lang."
+"org/reference/expressions.html#expression-precedence) are similar to other "
+"[C-like languages](https://en.wikipedia.org/wiki/"
+"Operator_precedence#Programming_languages)."
+msgstr ""
+"Rustで使用可能な[演算子とその優先順位](https://doc.rust-lang.org/reference/expressions.html#expression-precedence)"
+"は、[Cなどの言語のもの](https://en.wikipedia.org/wiki/Operator_precedence#Programming_languages)とほぼ同じです。"
+
+#: src/primitives/literals.md:24
+msgid "// Integer addition\n"
+msgstr "// 整数の足し算\n"
+
+#: src/primitives/literals.md:25
+msgid "\"1 + 2 = {}\""
+msgstr "\"1 + 2 = {}\""
+
+#: src/primitives/literals.md:27
+msgid "// Integer subtraction\n"
+msgstr "// 整数の引き算\n"
+
+#: src/primitives/literals.md:28
+msgid "\"1 - 2 = {}\""
+msgstr "\"1 - 2 = {}\""
+
+#: src/primitives/literals.md:29
+msgid ""
+"// TODO ^ Try changing `1i32` to `1u32` to see why the type is important\n"
+msgstr "// TODO ^ 型が重要であることを実感するため`1i32`を`1u32`に変更してみましょう。\n"
+
+#: src/primitives/literals.md:31
+msgid "// Scientific notation\n"
+msgstr "// 科学的表記\n"
+
+#: src/primitives/literals.md:32
+msgid "\"1e4 is {}, -2.5e-3 is {}\""
+msgstr "\"1e4 is {}, -2.5e-3 is {}\""
+
+#: src/primitives/literals.md:34
+msgid "// Short-circuiting boolean logic\n"
+msgstr "// 短絡評価できる論理演算子\n"
+
+#: src/primitives/literals.md:35
+msgid "\"true AND false is {}\""
+msgstr "\"true AND false is {}\""
+
+#: src/primitives/literals.md:36
+msgid "\"true OR false is {}\""
+msgstr "\"true OR false is {}\""
+
+#: src/primitives/literals.md:37
+msgid "\"NOT true is {}\""
+msgstr "\"NOT true is {}\""
+
+#: src/primitives/literals.md:39
+msgid "// Bitwise operations\n"
+msgstr "// ビットワイズ演算\n"
+
+#: src/primitives/literals.md:40
+msgid "\"0011 AND 0101 is {:04b}\""
+msgstr "\"0011 AND 0101 is {:04b}\""
+
+#: src/primitives/literals.md:41
+msgid "\"0011 OR 0101 is {:04b}\""
+msgstr "\"0011 OR 0101 is {:04b}\""
+
+#: src/primitives/literals.md:42
+msgid "\"0011 XOR 0101 is {:04b}\""
+msgstr "\"0011 XOR 0101 is {:04b}\""
+
+#: src/primitives/literals.md:43
+msgid "\"1 << 5 is {}\""
+msgstr "\"1 << 5 is {}\""
+
+#: src/primitives/literals.md:44
+msgid "\"0x80 >> 2 is 0x{:x}\""
+msgstr "\"0x80 >> 2 is 0x{:x}\""
+
+#: src/primitives/literals.md:46
+msgid "// Use underscores to improve readability!\n"
+msgstr "// 可読性のための`_`（アンダースコア）の使用\n"
+
+#: src/primitives/literals.md:47
+msgid "\"One million is written as {}\""
+msgstr "\"One million is written as {}\""
+
+#: src/primitives/tuples.md:3
+msgid ""
+"A tuple is a collection of values of different types. Tuples are constructed "
+"using parentheses `()`, and each tuple itself is a value with type signature "
+"`(T1, T2, ...)`, where `T1`, `T2` are the types of its members. Functions "
+"can use tuples to return multiple values, as tuples can hold any number of "
+"values."
+msgstr ""
+"タプルは異なる型の値の集合です。括弧`()`を用いて生成します。"
+"タプル自体がそのメンバに対する型シグネチャを保持していますので、"
+"明示すると`(T1, T2, ...)`のようになります。"
+"タプルは大きさに制限がありませんので、関数が複数の値を返したい時に使われます。"
+
+#: src/primitives/tuples.md:9
+msgid "// Tuples can be used as function arguments and as return values.\n"
+msgstr "// タプルを関数の引数と返り値として使用しています。\n"
+
+#: src/primitives/tuples.md:11
+msgid "// `let` can be used to bind the members of a tuple to variables.\n"
+msgstr "// `let`でタプルの中の値を別の変数に束縛することができます。\n"
+
+#: src/primitives/tuples.md:16
+msgid "// The following struct is for the activity.\n"
+msgstr "// 以下の構造体は後ほど「演習」で用います。\n"
+
+#: src/primitives/tuples.md:22
+msgid "// A tuple with a bunch of different types.\n"
+msgstr "// 様々な型を値に持つタプル\n"
+
+#: src/primitives/tuples.md:26 src/generics.md:50 src/generics.md:55
+#: src/generics/gen_fn.md:47
+msgid "'a'"
+msgstr "'a'"
+
+#: src/primitives/tuples.md:28
+msgid "// Values can be extracted from the tuple using tuple indexing.\n"
+msgstr "// インデックスを用いて、タプル内の要素を参照できます。\n"
+
+#: src/primitives/tuples.md:29
+msgid "\"Long tuple first value: {}\""
+msgstr "\"Long tuple first value: {}\""
+
+#: src/primitives/tuples.md:30
+msgid "\"Long tuple second value: {}\""
+msgstr "\"Long tuple second value: {}\""
+
+#: src/primitives/tuples.md:32
+msgid "// Tuples can be tuple members.\n"
+msgstr "// タプルはタプルのメンバになれます。\n"
+
+#: src/primitives/tuples.md:35
+msgid "// Tuples are printable.\n"
+msgstr "// タプルは出力できます。\n"
+
+#: src/primitives/tuples.md:36
+msgid "\"tuple of tuples: {:?}\""
+msgstr "\"tuple of tuples: {:?}\""
+
+#: src/primitives/tuples.md:38
+msgid ""
+"// But long Tuples (more than 12 elements) cannot be printed.\n"
+"    //let too_long_tuple = (1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13);\n"
+"    //println!(\"Too long tuple: {:?}\", too_long_tuple);\n"
+"    // TODO ^ Uncomment the above 2 lines to see the compiler error\n"
+msgstr ""
+"// しかし長すぎるタプル（12要素より多いもの）は出力できません。\n"
+"    //let too_long_tuple = (1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13);\n"
+"    //println!(\"Too long tuple: {:?}\", too_long_tuple);\n"
+"    // TODO ^ 上記2行のコメントを外して、コンパイルエラーを確認しましょう。\n"
+
+#: src/primitives/tuples.md:44
+msgid "\"Pair is {:?}\""
+msgstr "\"Pair is {:?}\""
+
+#: src/primitives/tuples.md:46
+msgid "\"The reversed pair is {:?}\""
+msgstr "\"The reversed pair is {:?}\""
+
+#: src/primitives/tuples.md:48
+msgid ""
+"// To create one element tuples, the comma is required to tell them apart\n"
+"    // from a literal surrounded by parentheses.\n"
+msgstr ""
+"// 要素を1つしか持たないタプルを作成する場合、括弧で囲まれたただのリテラル\n"
+"    // と区別するため、カンマが必要になります。\n"
+
+#: src/primitives/tuples.md:50
+msgid "\"One element tuple: {:?}\""
+msgstr "\"One element tuple: {:?}\""
+
+#: src/primitives/tuples.md:51
+msgid "\"Just an integer: {:?}\""
+msgstr "\"Just an integer: {:?}\""
+
+#: src/primitives/tuples.md:53
+msgid "// Tuples can be destructured to create bindings.\n"
+msgstr "// タプルを分解して別の変数にそれぞれの値を代入。\n"
+
+#: src/primitives/tuples.md:54 src/conversion/from_into.md:17
+#: src/fn/closures/input_parameters.md:52 src/std_misc/fs.md:51
+msgid "\"hello\""
+msgstr "\"hello\""
+
+#: src/primitives/tuples.md:57
+msgid "\"{:?}, {:?}, {:?}, {:?}\""
+msgstr "\"{:?}, {:?}, {:?}, {:?}\""
+
+#: src/primitives/tuples.md:66
+msgid ""
+"_Recap_: Add the `fmt::Display` trait to the `Matrix` struct in the above "
+"example, so that if you switch from printing the debug format `{:?}` to the "
+"display format `{}`, you see the following output:"
+msgstr ""
+"*復習* ：上にある`Matrix`という構造体に、`fmt::Display`トレイトを追加しましょう。"
+"デバッグフォーマット`{:?}`ではなくディスプレイフォーマット`{}`で出力すれば次のようになるはずです。"
+
+#: src/primitives/tuples.md:75
+msgid ""
+"You may want to refer back to the example for [print display](../hello/print/"
+"print_display.md)."
+msgstr "必要に応じて[ディスプレイのページ](../hello/print/print_display.md)に戻りましょう。"
+
+#: src/primitives/tuples.md:76
+msgid ""
+"Add a `transpose` function using the `reverse` function as a template, which "
+"accepts a matrix as an argument, and returns a matrix in which two elements "
+"have been swapped. For example:"
+msgstr "`reverse`関数を雛形にした`transpose`関数を実装してください。この関数は`Matrix`を引数として受け取り、要素のうち2つを入れ替えたものを返します。つまり"
+
+#: src/primitives/tuples.md:81
+msgid "\"Matrix:\\n{}\""
+msgstr "\"Matrix:\\n{}\""
+
+#: src/primitives/tuples.md:82
+msgid "\"Transpose:\\n{}\""
+msgstr "\"Transpose:\\n{}\""
+
+#: src/primitives/tuples.md:85
+msgid "Results in the output:"
+msgstr "は以下の様な出力になります。"
+
+#: src/primitives/array.md:3
+msgid ""
+"An array is a collection of objects of the same type `T`, stored in "
+"contiguous memory. Arrays are created using brackets `[]`, and their length, "
+"which is known at compile time, is part of their type signature `[T; "
+"length]`."
+msgstr ""
+"配列は`T`という単一の型のオブジェクトの集合です。それらのオブジェクトはメモリ上の連続した領域に保存されます。"
+"配列は`[]`を用いて生成されます。長さはコンパイル時には決定されていて、`[T; length]`という形で指定できます。"
+
+#: src/primitives/array.md:7
+msgid ""
+"Slices are similar to arrays, but their length is not known at compile time. "
+"Instead, a slice is a two-word object; the first word is a pointer to the "
+"data, the second word is the length of the slice. The word size is the same "
+"as usize, determined by the processor architecture, e.g. 64 bits on an "
+"x86-64. Slices can be used to borrow a section of an array and have the type "
+"signature `&[T]`."
+msgstr ""
+"スライスは配列に似ていますが、コンパイル時に長さが決定されていません。"
+"スライスは2ワードからなるオブジェクトであり、最初のワードがデータへのポインタ、2番目のワードがスライスの長さです。"
+"ワード長は`usize`と同一で、プロセッサのアーキテクチャによって決まります。"
+"例えばx86-64では64ビットです。スライスは配列の一部を借用するのに使用され、`&[T]`という型シグネチャを持ちます。"
+
+#: src/primitives/array.md:15
+msgid "// This function borrows a slice.\n"
+msgstr "// この関数はスライスを借用します。\n"
+
+#: src/primitives/array.md:18
+msgid "\"First element of the slice: {}\""
+msgstr "\"First element of the slice: {}\""
+
+#: src/primitives/array.md:19
+msgid "\"The slice has {} elements\""
+msgstr "\"The slice has {} elements\""
+
+#: src/primitives/array.md:23
+msgid "// Fixed-size array (type signature is superfluous).\n"
+msgstr "// 固定長の配列（型シグネチャは冗長なので、なくても可）\n"
+
+#: src/primitives/array.md:26
+msgid "// All elements can be initialized to the same value.\n"
+msgstr "// すべての要素を同じ値で初期化する場合\n"
+
+#: src/primitives/array.md:29
+msgid "// Indexing starts at 0.\n"
+msgstr "// インデックスは0から。\n"
+
+#: src/primitives/array.md:30
+msgid "\"First element of the array: {}\""
+msgstr "\"First element of the array: {}\""
+
+#: src/primitives/array.md:31
+msgid "\"Second element of the array: {}\""
+msgstr "\"Second element of the array: {}\""
+
+#: src/primitives/array.md:33
+msgid "// `len` returns the count of elements in the array.\n"
+msgstr "// `len`は配列の要素数を返します。\n"
+
+#: src/primitives/array.md:34
+msgid "\"Number of elements in array: {}\""
+msgstr "\"Number of elements in array: {}\""
+
+#: src/primitives/array.md:36
+msgid "// Arrays are stack allocated.\n"
+msgstr "// 配列はスタック上に置かれます。\n"
+
+#: src/primitives/array.md:37
+msgid "\"Array occupies {} bytes\""
+msgstr "\"Array occupies {} bytes\""
+
+#: src/primitives/array.md:39
+msgid "// Arrays can be automatically borrowed as slices.\n"
+msgstr "// 配列は自動的にスライスとして借用されます。\n"
+
+#: src/primitives/array.md:40
+msgid "\"Borrow the whole array as a slice.\""
+msgstr "\"Borrow the whole array as a slice.\""
+
+#: src/primitives/array.md:43
+msgid ""
+"// Slices can point to a section of an array.\n"
+"    // They are of the form [starting_index..ending_index].\n"
+"    // `starting_index` is the first position in the slice.\n"
+"    // `ending_index` is one more than the last position in the slice.\n"
+msgstr ""
+"// スライスは配列の一部を指すことができます。\n"
+"    // [starting_index..ending_index] の形をとり、\n"
+"    // `starting_index`はスライスの先頭の位置を表し、\n"
+"    // `ending_index`はスライスの末尾の1つ先の位置を表します。\n"
+
+#: src/primitives/array.md:47
+msgid "\"Borrow a section of the array as a slice.\""
+msgstr "\"Borrow a section of the array as a slice.\""
+
+#: src/primitives/array.md:50
+msgid "// Example of empty slice `&[]`:\n"
+msgstr "// 空のスライス`&[]`の例：\n"
+
+#: src/primitives/array.md:53
+msgid "// Same but more verbose\n"
+msgstr "// 同じ意味だがより冗長な書き方\n"
+
+#: src/primitives/array.md:55
+msgid ""
+"// Arrays can be safely accessed using `.get`, which returns an\n"
+"    // `Option`. This can be matched as shown below, or used with\n"
+"    // `.expect()` if you would like the program to exit with a nice\n"
+"    // message instead of happily continue.\n"
+msgstr ""
+"// 配列は、`Option`を返す`.get`で安全にアクセスできます。\n"
+"    // `Option`は以下のようにマッチさせることもできるし、\n"
+"    // 運よく処理を続ける代わりに、`.expect()`で素敵なメッセージとともに\n"
+"    // プログラムを終了することもできます。\n"
+
+#: src/primitives/array.md:59
+msgid "// Oops, one element too far!\n"
+msgstr "// おっと、1要素余分！\n"
+
+#: src/primitives/array.md:61
+msgid "\"{}: {}\""
+msgstr "\"{}: {}\""
+
+#: src/primitives/array.md:62
+msgid "\"Slow down! {} is too far!\""
+msgstr "\"Slow down! {} is too far!\""
+
+#: src/primitives/array.md:66
+msgid ""
+"// Out of bound indexing on array causes compile time error.\n"
+"    //println!(\"{}\", xs[5]);\n"
+"    // Out of bound indexing on slice causes runtime error.\n"
+"    //println!(\"{}\", xs[..][5]);\n"
+msgstr ""
+"// 配列のインデックスが範囲外のときはコンパイルエラー。\n"
+"    //println!(\"{}\", xs[5]);\n"
+"    // スライスのインデックスが範囲外のときはランタイムエラー。\n"
+"    //println!(\"{}\", xs[..][5]);\n"
+
+#: src/custom_types.md:3
+msgid "Rust custom data types are formed mainly through the two keywords:"
+msgstr "Rustでのカスタムデータ型の作成は主に以下の2つのキーワードを介して行われます。"
+
+#: src/custom_types.md:5
+msgid "`struct`: define a structure"
+msgstr "`struct`：構造体を定義する"
+
+#: src/custom_types.md:6
+msgid "`enum`: define an enumeration"
+msgstr "`enum`：列挙型を定義する"
+
+#: src/custom_types.md:8
+msgid "Constants can also be created via the `const` and `static` keywords."
+msgstr "`const`、あるいは`static`というキーワードによって定数を定義することもできます。"
+
+#: src/custom_types/structs.md:3
+msgid ""
+"There are three types of structures (\"structs\") that can be created using "
+"the `struct` keyword:"
+msgstr "`struct`というキーワードを用いて作成できる構造体には3種類あります。"
+
+#: src/custom_types/structs.md:6
+msgid "Tuple structs, which are, basically, named tuples."
+msgstr "タプル構造体。（すなわちタプルに名前が付いたようなもの）"
+
+#: src/custom_types/structs.md:7
+msgid ""
+"The classic [C structs](https://en.wikipedia.org/wiki/"
+"Struct_(C_programming_language))"
+msgstr "クラシックな[C言語スタイルの構造体。](https://en.wikipedia.org/wiki/Struct_(C_programming_language))"
+
+#: src/custom_types/structs.md:8
+msgid "Unit structs, which are field-less, are useful for generics."
+msgstr "ユニット構造体。これはフィールドを持たず、ジェネリック型を扱う際に有効です。"
+
+#: src/custom_types/structs.md:11 src/custom_types/enum/enum_use.md:6
+#: src/custom_types/enum/c_like.md:6
+msgid "// An attribute to hide warnings for unused code.\n"
+msgstr "// 使用されていないコードよる警告を隠すアトリビュート\n"
+
+#: src/custom_types/structs.md:19
+msgid "// A unit struct\n"
+msgstr "// ユニット構造体\n"
+
+#: src/custom_types/structs.md:22
+msgid "// A tuple struct\n"
+msgstr "// タプル構造体\n"
+
+#: src/custom_types/structs.md:25
+msgid "// A struct with two fields\n"
+msgstr "// 2つのフィールドを持つ（クラシックな）構造体\n"
+
+#: src/custom_types/structs.md:31
+msgid "// Structs can be reused as fields of another struct\n"
+msgstr "// 構造体は他の構造体のフィールドになることができます。\n"
+
+#: src/custom_types/structs.md:34
+msgid ""
+"// A rectangle can be specified by where the top left and bottom right\n"
+"    // corners are in space.\n"
+msgstr "// 長方形は座標空間上における左上隅と右下隅の位置によって指定できます。\n"
+
+#: src/custom_types/structs.md:41
+msgid "// Create struct with field init shorthand\n"
+msgstr "// 構造体をフィールド初期化の簡略記法で生成。\n"
+
+#: src/custom_types/structs.md:46
+msgid "// Print debug struct\n"
+msgstr "// 構造体のデバッグ表示\n"
+
+#: src/custom_types/structs.md:49
+msgid "// Instantiate a `Point`\n"
+msgstr "// `Point`のインスタンス化\n"
+
+#: src/custom_types/structs.md:52
+msgid "// Access the fields of the point\n"
+msgstr "// pointのフィールドにアクセスします。\n"
+
+#: src/custom_types/structs.md:53
+msgid "\"point coordinates: ({}, {})\""
+msgstr "\"point coordinates: ({}, {})\""
+
+#: src/custom_types/structs.md:55
+msgid ""
+"// Make a new point by using struct update syntax to use the fields of our\n"
+"    // other one\n"
+msgstr ""
+"// 構造体の更新記法を用いて、別の構造体のフィールドの値を基に\n"
+"    // 新たなpointを生成。\n"
+
+#: src/custom_types/structs.md:59
+msgid ""
+"// `bottom_right.y` will be the same as `point.y` because we used that "
+"field\n"
+"    // from `point`\n"
+msgstr ""
+"// `bottom_right.y`の値は`point.y`と同一ですが、\n"
+"    // これは`point`のフィールドの値を用いて生成したためです。\n"
+
+#: src/custom_types/structs.md:61
+msgid "\"second point: ({}, {})\""
+msgstr "\"second point: ({}, {})\""
+
+#: src/custom_types/structs.md:63
+msgid "// Destructure the point using a `let` binding\n"
+msgstr "// `let`を使用してpointをデストラクトします。\n"
+
+#: src/custom_types/structs.md:67
+msgid "// struct instantiation is an expression too\n"
+msgstr "// 構造体の定義とインスタンスの作成を同時に行います。\n"
+
+#: src/custom_types/structs.md:72
+msgid "// Instantiate a unit struct\n"
+msgstr "// ユニット構造体のインスタンス化\n"
+
+#: src/custom_types/structs.md:75
+msgid "// Instantiate a tuple struct\n"
+msgstr "// タプル構造体のインスタンス化\n"
+
+#: src/custom_types/structs.md:78
+msgid "// Access the fields of a tuple struct\n"
+msgstr "// タプル構造体のフィールドにアクセス\n"
+
+#: src/custom_types/structs.md:79 src/custom_types/structs.md:84
+msgid "\"pair contains {:?} and {:?}\""
+msgstr "\"pair contains {:?} and {:?}\""
+
+#: src/custom_types/structs.md:81
+msgid "// Destructure a tuple struct\n"
+msgstr "// タプル構造体のデストラクト\n"
+
+#: src/custom_types/structs.md:90
+msgid ""
+"Add a function `rect_area` which calculates the area of a `Rectangle` (try "
+"using nested destructuring)."
+msgstr "`Rectangle`の面積を計算する`rect_area`関数を追加してください。ネストしたデストラクトを使ってみましょう。"
+
+#: src/custom_types/structs.md:92
+msgid ""
+"Add a function `square` which takes a `Point` and a `f32` as arguments, and "
+"returns a `Rectangle` with its top left corner on the point, and a width and "
+"height corresponding to the `f32`."
+msgstr ""
+"`Point`と`f32`を引数とし、`Rectangle`を返す`square`関数を追加してください。"
+"`Rectangle`の左上の点が`Point`になり、`f32`が`Rectangle`の幅と高さになります。"
+
+#: src/custom_types/structs.md:96
+msgid "See also"
+msgstr "参照"
+
+#: src/custom_types/structs.md:98
+msgid ""
+"[`attributes`](../attribute.md), and [destructuring](../flow_control/match/"
+"destructuring.md)"
+msgstr ""
+"[アトリビュート](../attribute.md), [デストラクト](../flow_control/match/"
+"destructuring.md)"
+
+#: src/custom_types/enum.md:3
+msgid ""
+"The `enum` keyword allows the creation of a type which may be one of a few "
+"different variants. Any variant which is valid as a `struct` is also valid "
+"in an `enum`."
+msgstr ""
+"列挙型（`enum`）はいくつかの異なる要素型の中から1つを選ぶような場合に使用します。"
+"構造体（`struct`）の定義を満たすものならば何でも`enum` の要素型として使用できます。"
+
+#: src/custom_types/enum.md:8
+msgid ""
+"// Create an `enum` to classify a web event. Note how both\n"
+"// names and type information together specify the variant:\n"
+"// `PageLoad != PageUnload` and `KeyPress(char) != Paste(String)`.\n"
+"// Each is different and independent.\n"
+msgstr ""
+"// `enum`を作成してwebイベントを分類します。\n"
+"// 名前と型情報を併せたものが要素型になっていることに注意。\n"
+"// `PageLoad != PageUnload`、\n"
+"// `KeyPress(char) != Paste(String)`です。\n"
+"// 要素型は互いに異なり、互いに非依存です。\n"
+
+#: src/custom_types/enum.md:13
+msgid "// An `enum` variant may either be `unit-like`,\n"
+msgstr "// `enum`要素型はユニット風でも構いません。\n"
+
+#: src/custom_types/enum.md:16
+msgid "// like tuple structs,\n"
+msgstr "// タプル構造体風\n"
+
+#: src/custom_types/enum.md:19
+msgid "// or c-like structures.\n"
+msgstr "// C言語スタイルの構造体風\n"
+
+#: src/custom_types/enum.md:22
+msgid ""
+"// A function which takes a `WebEvent` enum as an argument and\n"
+"// returns nothing.\n"
+msgstr "// 引数として`WebEvent`列挙型をとり、何も返さない関数\n"
+
+#: src/custom_types/enum.md:27
+msgid "\"page loaded\""
+msgstr "\"page loaded\""
+
+#: src/custom_types/enum.md:28
+msgid "\"page unloaded\""
+msgstr "\"page unloaded\""
+
+#: src/custom_types/enum.md:29
+msgid "// Destructure `c` from inside the `enum` variant.\n"
+msgstr "// `enum`の要素型から`c`をデストラクトします。\n"
+
+#: src/custom_types/enum.md:30
+msgid "\"pressed '{}'.\""
+msgstr "\"pressed '{}'.\""
+
+#: src/custom_types/enum.md:31
+msgid "\"pasted \\\"{}\\\".\""
+msgstr "\"pasted \\\"{}\\\".\""
+
+#: src/custom_types/enum.md:32
+msgid "// Destructure `Click` into `x` and `y`.\n"
+msgstr "// `Click`を`x`と`y`にデストラクトします。\n"
+
+#: src/custom_types/enum.md:34
+msgid "\"clicked at x={}, y={}.\""
+msgstr "\"clicked at x={}, y={}.\""
+
+#: src/custom_types/enum.md:40
+msgid "'x'"
+msgstr "'x'"
+
+#: src/custom_types/enum.md:41
+msgid "// `to_owned()` creates an owned `String` from a string slice.\n"
+msgstr "// `to_owned()`は文字列スライスから所有権のある`String`を作成します。\n"
+
+#: src/custom_types/enum.md:42
+msgid "\"my text\""
+msgstr "\"my text\""
+
+#: src/custom_types/enum.md:56
+msgid "Type aliases"
+msgstr "型エイリアス"
+
+#: src/custom_types/enum.md:58
+msgid ""
+"If you use a type alias, you can refer to each enum variant via its alias. "
+"This might be useful if the enum's name is too long or too generic, and you "
+"want to rename it."
+msgstr ""
+"型エイリアスを用いると、列挙型の要素型を別名で参照できます。"
+"これは列挙型の名前があまりに長かったり、あまりに一般的だったりで改名したい場合に役立ちます。"
+
+#: src/custom_types/enum.md:67
+msgid "// Creates a type alias\n"
+msgstr "// 型エイリアスを作成します。\n"
+
+#: src/custom_types/enum.md:72
+msgid ""
+"// We can refer to each variant via its alias, not its long and "
+"inconvenient\n"
+"    // name.\n"
+msgstr "// 長くて不便な列挙型の名前ではなく、別名を使って要素型を参照できます。\n"
+
+#: src/custom_types/enum.md:78
+msgid ""
+"The most common place you'll see this is in `impl` blocks using the `Self` "
+"alias."
+msgstr "このやり方がもっともよく見られるのは、`impl`ブロックで`Self`という別名を使用する場合です。"
+
+#: src/custom_types/enum.md:96
+msgid ""
+"To learn more about enums and type aliases, you can read the [stabilization "
+"report](https://github.com/rust-lang/rust/pull/61682/"
+"#issuecomment-502472847) from when this feature was stabilized into Rust."
+msgstr ""
+"列挙型や型エイリアスについて詳しく学びたい人は、この機能が安定してRustに取り込まれたときの"
+"[stabilization report](https://github.com/rust-lang/rust/pull/61682/#issuecomment-502472847)を読んでください。"
+
+#: src/custom_types/enum.md:102
+msgid ""
+"[`match`](../flow_control/match.md), [`fn`](../fn.md), and [`String`](../std/"
+"str.md), [\"Type alias enum variants\" RFC](https://rust-lang.github.io/"
+"rfcs/2338-type-alias-enum-variants.html)"
+msgstr ""
+"[`match`](../flow_control/match.md), [関数](../fn.md), [文字列](../std/"
+"str.md), [\"Type alias enum variants\" RFC](https://rust-lang.github.io/"
+"rfcs/2338-type-alias-enum-variants.html)"
+
+#: src/custom_types/enum/enum_use.md:3
+msgid "The `use` declaration can be used so manual scoping isn't needed:"
+msgstr "`use`を使用すれば変数のスコープを絶対名で指定する必要がなくなります。"
+
+#: src/custom_types/enum/enum_use.md:20
+msgid ""
+"// Explicitly `use` each name so they are available without\n"
+"    // manual scoping.\n"
+msgstr "// `use`することで絶対名でなくとも使用可能になります。\n"
+
+#: src/custom_types/enum/enum_use.md:23
+msgid "// Automatically `use` each name inside `Work`.\n"
+msgstr "// `Work`の中の名前をすべて`use`します。\n"
+
+#: src/custom_types/enum/enum_use.md:26
+msgid "// Equivalent to `Status::Poor`.\n"
+msgstr "// `use`しているため、`Status::Poor`と同じです。\n"
+
+#: src/custom_types/enum/enum_use.md:28
+msgid "// Equivalent to `Work::Civilian`.\n"
+msgstr "// `Work::Civilian`と同じ\n"
+
+#: src/custom_types/enum/enum_use.md:32
+msgid "// Note the lack of scoping because of the explicit `use` above.\n"
+msgstr "// `use`しているのでスコープを明示していません。\n"
+
+#: src/custom_types/enum/enum_use.md:33
+msgid "\"The rich have lots of money!\""
+msgstr "\"The rich have lots of money!\""
+
+#: src/custom_types/enum/enum_use.md:34
+msgid "\"The poor have no money...\""
+msgstr "\"The poor have no money...\""
+
+#: src/custom_types/enum/enum_use.md:38
+msgid "// Note again the lack of scoping.\n"
+msgstr "// こちらも同じ\n"
+
+#: src/custom_types/enum/enum_use.md:39
+msgid "\"Civilians work!\""
+msgstr "\"Civilians work!\""
+
+#: src/custom_types/enum/enum_use.md:40
+msgid "\"Soldiers fight!\""
+msgstr "\"Soldiers fight!\""
+
+#: src/custom_types/enum/enum_use.md:47
+msgid "[`match`](../../flow_control/match.md) and [`use`](../../mod/use.md) "
+msgstr "[`match`](../../flow_control/match.md), [`use`](../../mod/use.md) "
+
+#: src/custom_types/enum/c_like.md:3
+msgid "`enum` can also be used as C-like enums."
+msgstr "列挙型はC言語の列挙型のような使い方をする事もできます。"
+
+#: src/custom_types/enum/c_like.md:8
+msgid "// enum with implicit discriminator (starts at 0)\n"
+msgstr "// 値を明示しない場合、0から整数が順に入ります。\n"
+
+#: src/custom_types/enum/c_like.md:15
+msgid "// enum with explicit discriminator\n"
+msgstr "// 値を明示する場合\n"
+
+#: src/custom_types/enum/c_like.md:24
+msgid "// `enums` can be cast as integers.\n"
+msgstr "// 列挙型の中身は整数としてキャストできます。\n"
+
+#: src/custom_types/enum/c_like.md:25
+msgid "\"zero is {}\""
+msgstr "\"zero is {}\""
+
+#: src/custom_types/enum/c_like.md:26
+msgid "\"one is {}\""
+msgstr "\"one is {}\""
+
+#: src/custom_types/enum/c_like.md:28
+msgid "\"roses are #{:06x}\""
+msgstr "\"roses are #{:06x}\""
+
+#: src/custom_types/enum/c_like.md:29
+msgid "\"violets are #{:06x}\""
+msgstr "\"violets are #{:06x}\""
+
+#: src/custom_types/enum/c_like.md:35
+msgid "[casting](../../types/cast.md)"
+msgstr "[キャスト](../../types/cast.md)"
+
+#: src/custom_types/enum/testcase_linked_list.md:3
+msgid "A common way to implement a linked-list is via `enums`:"
+msgstr "`enum`の使用が適切なパターンのひとつに、連結リストを作成する場合があります。"
+
+#: src/custom_types/enum/testcase_linked_list.md:9
+msgid ""
+"// Cons: Tuple struct that wraps an element and a pointer to the next node\n"
+msgstr "// Cons：要素をラップし、次の要素へのポインタを保持するタプル構造体\n"
+
+#: src/custom_types/enum/testcase_linked_list.md:11
+msgid "// Nil: A node that signifies the end of the linked list\n"
+msgstr "// Nil：連結リストの終端であることを示すノード\n"
+
+#: src/custom_types/enum/testcase_linked_list.md:14
+msgid "// Methods can be attached to an enum\n"
+msgstr "// 列挙型にはメソッドを付与することができます。\n"
+
+#: src/custom_types/enum/testcase_linked_list.md:17
+msgid "// Create an empty list\n"
+msgstr "// 空リストの作成\n"
+
+#: src/custom_types/enum/testcase_linked_list.md:19
+msgid "// `Nil` has type `List`\n"
+msgstr "// `Nil`は`List`型を持ちます。\n"
+
+#: src/custom_types/enum/testcase_linked_list.md:23
+msgid ""
+"// Consume a list, and return the same list with a new element at its front\n"
+msgstr "// リストを受け取り、その始端に新しい要素を付加したものを返す関数\n"
+
+#: src/custom_types/enum/testcase_linked_list.md:25
+msgid "// `Cons` also has type List\n"
+msgstr "// この`Cons`自体も、その第2要素もどちらもList型です。\n"
+
+#: src/custom_types/enum/testcase_linked_list.md:29
+msgid "// Return the length of the list\n"
+msgstr "// リストの長さを返すメソッド\n"
+
+#: src/custom_types/enum/testcase_linked_list.md:31
+msgid ""
+"// `self` has to be matched, because the behavior of this method\n"
+"        // depends on the variant of `self`\n"
+"        // `self` has type `&List`, and `*self` has type `List`, matching on "
+"a\n"
+"        // concrete type `T` is preferred over a match on a reference `&T`\n"
+"        // after Rust 2018 you can use self here and tail (with no ref) "
+"below as well,\n"
+"        // rust will infer &s and ref tail. \n"
+"        // See https://doc.rust-lang.org/edition-guide/rust-2018/ownership-"
+"and-lifetimes/default-match-bindings.html\n"
+msgstr ""
+"// このメソッドは、`self`の状態によって振る舞いが\n"
+"        // 変化するため、matchをする必要があります。\n"
+"        // `self`の型は`&List`なので、`*self`は`List`になります。マッチングは\n"
+"        // 参照（`&T`）ではなく実体（`T`）に対して行うのが好ましいです。\n"
+"        // Rust 2018以降ではここでselfと（refのない）tailを使うことができ、\n"
+"        // &selfとref tailが推論されます。\n"
+"        // 参照 https://doc.rust-lang.org/edition-guide/rust-2018/ownership-"
+"and-lifetimes/default-match-bindings.html\n"
+
+#: src/custom_types/enum/testcase_linked_list.md:39
+msgid ""
+"// Can't take ownership of the tail, because `self` is borrowed;\n"
+"            // instead take a reference to the tail\n"
+msgstr ""
+"// `self`をすでに借用しているので、tailの所有権を取ることができません。\n"
+"            // 代わりに参照を使用します。\n"
+
+#: src/custom_types/enum/testcase_linked_list.md:42
+msgid "// Base Case: An empty list has zero length\n"
+msgstr "// 空リストならば長さは0\n"
+
+#: src/custom_types/enum/testcase_linked_list.md:47
+msgid "// Return representation of the list as a (heap allocated) string\n"
+msgstr "// リストをヒープ上の文字列として表したものを返すメソッド\n"
+
+#: src/custom_types/enum/testcase_linked_list.md:51
+msgid ""
+"// `format!` is similar to `print!`, but returns a heap\n"
+"                // allocated string instead of printing to the console\n"
+msgstr ""
+"// `format!`は`print!`に似ていますが、コンソール上に出力\n"
+"                // する代わりに、ヒープ上の文字列を返します。\n"
+
+#: src/custom_types/enum/testcase_linked_list.md:53 src/generics/impl.md:44
+msgid "\"{}, {}\""
+msgstr "\"{}, {}\""
+
+#: src/custom_types/enum/testcase_linked_list.md:56
+msgid "\"Nil\""
+msgstr "\"Nil\""
+
+#: src/custom_types/enum/testcase_linked_list.md:63
+msgid "// Create an empty linked list\n"
+msgstr "// 空の連結リストを作成。\n"
+
+#: src/custom_types/enum/testcase_linked_list.md:66
+msgid "// Prepend some elements\n"
+msgstr "// 要素を追加。\n"
+
+#: src/custom_types/enum/testcase_linked_list.md:71
+msgid "// Show the final state of the list\n"
+msgstr "// 追加後の状態を表示。\n"
+
+#: src/custom_types/enum/testcase_linked_list.md:72
+msgid "\"linked list has length: {}\""
+msgstr "\"linked list has length: {}\""
+
+#: src/custom_types/enum/testcase_linked_list.md:79
+msgid "[`Box`](../../std/box.md) and [methods](../../fn/methods.md)"
+msgstr "[`Box`](../../std/box.md), [メソッド](../../fn/methods.md)"
+
+#: src/custom_types/constants.md:3
+msgid ""
+"Rust has two different types of constants which can be declared in any scope "
+"including global. Both require explicit type annotation:"
+msgstr "Rustには2種類の定数があり、いずれもグローバルスコープを含む任意のスコープで宣言することができます。また、いずれも型を明示しなくてはなりません。"
+
+#: src/custom_types/constants.md:6
+msgid "`const`: An unchangeable value (the common case)."
+msgstr "`const`：不変の値（通常はこちらを使用します）"
+
+#: src/custom_types/constants.md:7
+msgid ""
+"`static`: A possibly mutable variable with [`'static`](../scope/lifetime/"
+"static_lifetime.md) lifetime. The static lifetime is inferred and does not "
+"have to be specified. Accessing or modifying a mutable static variable is "
+"[`unsafe`](../unsafe.md)."
+msgstr ""
+"`static`：[`'static`](../scope/lifetime/static_lifetime.md)ライフタイムを持つ変更可能な値。"
+"スタティックライフタイムは推論され、明示する必要はありません。"
+"可変なスタティック値へのアクセスや変更は[安全ではありません](../unsafe.md)。"
+
+#: src/custom_types/constants.md:12
+msgid "// Globals are declared outside all other scopes.\n"
+msgstr "// グローバル変数はあらゆるスコープの外で宣言します。\n"
+
+#: src/custom_types/constants.md:13
+msgid "\"Rust\""
+msgstr "\"Rust\""
+
+#: src/custom_types/constants.md:17
+msgid "// Access constant in some function\n"
+msgstr "// 関数内から定数を参照。\n"
+
+#: src/custom_types/constants.md:24
+msgid "// Access constant in the main thread\n"
+msgstr "// main 関数の中から定数を参照。\n"
+
+#: src/custom_types/constants.md:25
+msgid "\"This is {}\""
+msgstr "\"This is {}\""
+
+#: src/custom_types/constants.md:26
+msgid "\"The threshold is {}\""
+msgstr "\"The threshold is {}\""
+
+#: src/custom_types/constants.md:27
+msgid "\"{} is {}\""
+msgstr "\"{} is {}\""
+
+#: src/custom_types/constants.md:27
+msgid "\"big\""
+msgstr "\"big\""
+
+#: src/custom_types/constants.md:27
+msgid "\"small\""
+msgstr "\"small\""
+
+#: src/custom_types/constants.md:29
+msgid "// Error! Cannot modify a `const`.\n"
+msgstr "// エラー！const`は変更できません。\n"
+
+#: src/custom_types/constants.md:31 src/variable_bindings/scope.md:21
+#: src/variable_bindings/declare.md:25 src/variable_bindings/freeze.md:16
+#: src/types/cast.md:19 src/types/cast.md:28 src/flow_control/for.md:95
+#: src/scope/borrow.md:41 src/scope/borrow/mut.md:52 src/std/vec.md:31
+#: src/std/vec.md:44 src/std/hash/hashset.md:48
+msgid "// FIXME ^ Comment out this line\n"
+msgstr "// FIXME ^ この行をコメントアウトしましょう\n"
+
+#: src/custom_types/constants.md:37
+msgid ""
+"[The `const`/`static` RFC](https://github.com/rust-lang/rfcs/blob/master/"
+"text/0246-const-vs-static.md), [`'static` lifetime](../scope/lifetime/"
+"static_lifetime.md)"
+msgstr ""
+"[`const`/`static` のRFC](https://github.com/rust-lang/rfcs/blob/master/"
+"text/0246-const-vs-static.md), [`'static` ライフタイム](../scope/lifetime/"
+"static_lifetime.md)"
+
+#: src/variable_bindings.md:3
+msgid ""
+"Rust provides type safety via static typing. Variable bindings can be type "
+"annotated when declared. However, in most cases, the compiler will be able "
+"to infer the type of the variable from the context, heavily reducing the "
+"annotation burden."
+msgstr ""
+"Rustは静的な型付けによる型安全性を提供します。変数束縛は宣言時に型を指定できます。"
+"とはいえたいていの場合は、コンパイラは変数の型をコンテキストから推測することができますので、型指定の負担を大幅に軽減できます。"
+
+#: src/variable_bindings.md:8
+msgid ""
+"Values (like literals) can be bound to variables, using the `let` binding."
+msgstr "値（リテラルなど）は`let`を用いて変数に束縛することができます。"
+
+#: src/variable_bindings.md:16
+msgid "// copy `an_integer` into `copied_integer`\n"
+msgstr "// `an_integer`を`copied_integer`へとコピー。\n"
+
+#: src/variable_bindings.md:19
+msgid "\"An integer: {:?}\""
+msgstr "\"An integer: {:?}\""
+
+#: src/variable_bindings.md:20
+msgid "\"A boolean: {:?}\""
+msgstr "\"A boolean: {:?}\""
+
+#: src/variable_bindings.md:21
+msgid "\"Meet the unit value: {:?}\""
+msgstr "\"Meet the unit value: {:?}\""
+
+#: src/variable_bindings.md:23
+msgid ""
+"// The compiler warns about unused variable bindings; these warnings can\n"
+"    // be silenced by prefixing the variable name with an underscore\n"
+msgstr ""
+"// 使用されていない変数があると、コンパイラは警告を出します。\n"
+"    // 変数名の頭に`_`（アンダーバー）を付けると警告を消すことができます。\n"
+
+#: src/variable_bindings.md:28
+msgid ""
+"// FIXME ^ Prefix with an underscore to suppress the warning\n"
+"    // Please note that warnings may not be shown in a browser\n"
+msgstr ""
+"// FIXME ^ 頭にアンダーバーを付けて、警告を抑えましょう。\n"
+"    // 警告はブラウザ上では表示されないかもしれません。\n"
+
+#: src/variable_bindings/mut.md:3
+msgid ""
+"Variable bindings are immutable by default, but this can be overridden using "
+"the `mut` modifier."
+msgstr "変数はデフォルトでイミュータブル（変更不可能）ですが`mut`構文を使用することで変更可能になります。"
+
+#: src/variable_bindings/mut.md:11
+msgid "\"Before mutation: {}\""
+msgstr "\"Before mutation: {}\""
+
+#: src/variable_bindings/mut.md:13
+msgid "// Ok\n"
+msgstr "// 問題ありません。\n"
+
+#: src/variable_bindings/mut.md:16
+msgid "\"After mutation: {}\""
+msgstr "\"After mutation: {}\""
+
+#: src/variable_bindings/mut.md:18
+msgid "// Error! Cannot assign a new value to an immutable variable\n"
+msgstr "// エラー！イミュータブルな変数に新しい値を代入することはできません。\n"
+
+#: src/variable_bindings/mut.md:23
+msgid "The compiler will throw a detailed diagnostic about mutability errors."
+msgstr "コンパイラはミュータビリティに関するエラーの詳細を出してくれます。"
+
+#: src/variable_bindings/scope.md:3
+msgid ""
+"Variable bindings have a scope, and are constrained to live in a _block_. A "
+"block is a collection of statements enclosed by braces `{}`. "
+msgstr "変数はスコープを持つため、 **ブロック** の中に閉じ込められています。ブロックとは`{}`で囲まれた領域のことです。"
+
+#: src/variable_bindings/scope.md:7
+msgid "// This binding lives in the main function\n"
+msgstr "// この変数はmain関数の間、生存しています。\n"
+
+#: src/variable_bindings/scope.md:10
+msgid "// This is a block, and has a smaller scope than the main function\n"
+msgstr "// ここから下がmain関数より小さいスコープを持つブロックとなります。\n"
+
+#: src/variable_bindings/scope.md:12
+msgid "// This binding only exists in this block\n"
+msgstr "// この変数はこのブロック内のみに存在します。\n"
+
+#: src/variable_bindings/scope.md:15
+msgid "\"inner short: {}\""
+msgstr "\"inner short: {}\""
+
+#: src/variable_bindings/scope.md:17
+msgid "// End of the block\n"
+msgstr "// ブロックの終わり\n"
+
+#: src/variable_bindings/scope.md:19
+msgid "// Error! `short_lived_binding` doesn't exist in this scope\n"
+msgstr "// エラー！`short_lived_binding`はこのスコープ内には存在しません。\n"
+
+#: src/variable_bindings/scope.md:20
+msgid "\"outer short: {}\""
+msgstr "\"outer short: {}\""
+
+#: src/variable_bindings/scope.md:23
+msgid "\"outer long: {}\""
+msgstr "\"outer long: {}\""
+
+#: src/variable_bindings/scope.md:26
+msgid ""
+"Also, [variable shadowing](https://en.wikipedia.org/wiki/Variable_shadowing) "
+"is allowed."
+msgstr "[変数のシャドーイング](https://en.wikipedia.org/wiki/Variable_shadowing)も可能です。"
+
+#: src/variable_bindings/scope.md:32
+msgid "\"before being shadowed: {}\""
+msgstr "\"before being shadowed: {}\""
+
+#: src/variable_bindings/scope.md:34
+msgid "// This binding *shadows* the outer one\n"
+msgstr "// この変数はスコープ外の同名の変数を *シャドーイング* します。\n"
+
+#: src/variable_bindings/scope.md:35
+msgid "\"abc\""
+msgstr "\"abc\""
+
+#: src/variable_bindings/scope.md:37
+msgid "\"shadowed in inner block: {}\""
+msgstr "\"shadowed in inner block: {}\""
+
+#: src/variable_bindings/scope.md:39
+msgid "\"outside inner block: {}\""
+msgstr "\"outside inner block: {}\""
+
+#: src/variable_bindings/scope.md:41
+msgid "// This binding *shadows* the previous binding\n"
+msgstr "// この変数束縛は以前に定義した変数を *シャドーイング* します。\n"
+
+#: src/variable_bindings/scope.md:43
+msgid "\"shadowed in outer block: {}\""
+msgstr "\"shadowed in outer block: {}\""
+
+#: src/variable_bindings/declare.md:3
+msgid ""
+"It's possible to declare variable bindings first, and initialize them later. "
+"However, this form is seldom used, as it may lead to the use of "
+"uninitialized variables."
+msgstr ""
+"変数の宣言だけを行っておき、初期化をのちに行うことも可能です。"
+"しかし、最後まで初期化されない変数が生じる可能性があるため、ふつうは同時に行われます。"
+
+#: src/variable_bindings/declare.md:9
+msgid "// Declare a variable binding\n"
+msgstr "// 変数を宣言。\n"
+
+#: src/variable_bindings/declare.md:15
+msgid "// Initialize the binding\n"
+msgstr "// 変数を初期化。\n"
+
+#: src/variable_bindings/declare.md:19
+msgid "\"a binding: {}\""
+msgstr "\"a binding: {}\""
+
+#: src/variable_bindings/declare.md:23
+msgid "// Error! Use of uninitialized binding\n"
+msgstr "// エラー！初期化していない変数の使用\n"
+
+#: src/variable_bindings/declare.md:24 src/variable_bindings/declare.md:29
+msgid "\"another binding: {}\""
+msgstr "\"another binding: {}\""
+
+#: src/variable_bindings/declare.md:33
+msgid ""
+"The compiler forbids use of uninitialized variables, as this would lead to "
+"undefined behavior."
+msgstr "未初期化の変数があると予期せぬ動作をする場合があるため、コンパイラは変数を初期化してから使用するよう強制します。"
+
+#: src/variable_bindings/freeze.md:3
+msgid ""
+"When data is bound by the same name immutably, it also _freezes_. _Frozen_ "
+"data can't be  modified until the immutable binding goes out of scope:"
+msgstr "データを同じ名前のイミュータブルな変数に束縛しなおすと、データは*凍結*されます。*凍結*したデータは、イミュータブルな束縛がスコープ外になるまで変更できません。"
+
+#: src/variable_bindings/freeze.md:11
+msgid "// Shadowing by immutable `_mutable_integer`\n"
+msgstr "// イミュータブルな`_mutable_integer`でシャドーイングします。\n"
+
+#: src/variable_bindings/freeze.md:14
+msgid "// Error! `_mutable_integer` is frozen in this scope\n"
+msgstr "// エラー！`_mutable_integer`はこのスコープでは凍結しています。\n"
+
+#: src/variable_bindings/freeze.md:18
+msgid "// `_mutable_integer` goes out of scope\n"
+msgstr "// `_mutable_integer`はスコープを抜けます。\n"
+
+#: src/variable_bindings/freeze.md:21
+msgid "// Ok! `_mutable_integer` is not frozen in this scope\n"
+msgstr "// OK！`_mutable_integer`はこのスコープでは凍結していません。\n"
+
+#: src/types.md:3
+msgid ""
+"Rust provides several mechanisms to change or define the type of primitive "
+"and user defined types. The following sections cover:"
+msgstr ""
+"Rustには、基本データ型やユーザ定義型を定義したり変換したりする様々な方法があります。"
+"この章は以下の内容を扱います。"
+
+#: src/types.md:5
+msgid "[Casting](types/cast.md) between primitive types"
+msgstr "基本データ型の間で[キャスト](types/cast.md)を行う。"
+
+#: src/types.md:6
+msgid "Specifying the desired type of [literals](types/literals.md)"
+msgstr "[リテラル](types/literals.md)の型をどれにしたいか指定する。"
+
+#: src/types.md:7
+msgid "Using [type inference](types/inference.md)"
+msgstr "[型推論](types/inference.md)を使う。"
+
+#: src/types.md:8
+msgid "[Aliasing](types/alias.md) types"
+msgstr "型を[エイリアス](types/alias.md)する。"
+
+#: src/types/cast.md:3
+msgid ""
+"Rust provides no implicit type conversion (coercion) between primitive "
+"types. But, explicit type conversion (casting) can be performed using the "
+"`as` keyword."
+msgstr ""
+"Rustは基本データ型について暗黙的な型変換（`coerction`）を行うことはありません。"
+"しかし明示的な型変換（`casting`）は可能です。その場合`as`キーワードを使用します。"
+
+#: src/types/cast.md:6
+msgid ""
+"Rules for converting between integral types follow C conventions generally, "
+"except in cases where C has undefined behavior. The behavior of all casts "
+"between integral types is well defined in Rust."
+msgstr ""
+"整数型から整数型へ型変換する場合、C言語で可能なケースの場合はC言語と同じです。"
+"C言語で未定義の場合の挙動も、Rustでは完全に定義されています。"
+
+#: src/types/cast.md:11
+msgid "// Suppress all warnings from casts which overflow.\n"
+msgstr "// オーバーフローを起こすようなキャストによる警告を無視します。\n"
+
+#: src/types/cast.md:17
+msgid "// Error! No implicit conversion\n"
+msgstr "// エラー！暗黙的な型変換はできません。\n"
+
+#: src/types/cast.md:21
+msgid "// Explicit conversion\n"
+msgstr "// 明示的な型変換\n"
+
+#: src/types/cast.md:25
+msgid ""
+"// Error! There are limitations in conversion rules.\n"
+"    // A float cannot be directly converted to a char.\n"
+msgstr ""
+"// エラー！変換ルールには制限があります。\n"
+"    // 浮動小数点数を文字に直接変換することはできません。\n"
+
+#: src/types/cast.md:30
+msgid "\"Casting: {} -> {} -> {}\""
+msgstr "\"Casting: {} -> {} -> {}\""
+
+#: src/types/cast.md:32
+msgid ""
+"// when casting any value to an unsigned type, T,\n"
+"    // T::MAX + 1 is added or subtracted until the value\n"
+"    // fits into the new type\n"
+msgstr ""
+"// 何らかの値を符号なしの型（仮にTとする）へキャストすると\n"
+"    // 値がTに収まるまで、T::MAX + 1 が加算あるいは減算されます。\n"
+
+#: src/types/cast.md:36
+msgid "// 1000 already fits in a u16\n"
+msgstr "// 1000はすでにu16に収まっているため変化しません。\n"
+
+#: src/types/cast.md:37
+msgid "\"1000 as a u16 is: {}\""
+msgstr "\"1000 as a u16 is: {}\""
+
+#: src/types/cast.md:39
+msgid ""
+"// 1000 - 256 - 256 - 256 = 232\n"
+"    // Under the hood, the first 8 least significant bits (LSB) are kept,\n"
+"    // while the rest towards the most significant bit (MSB) get truncated.\n"
+msgstr ""
+"// 1000 - 256 - 256 - 256 = 232\n"
+"    // 詳しく見てみると、最下位ビットから8bitが保持され、\n"
+"    // 残りの上位ビットが切り取られる形になります。\n"
+
+#: src/types/cast.md:42 src/types/cast.md:61
+msgid "\"1000 as a u8 is : {}\""
+msgstr "\"1000 as a u8 is : {}\""
+
+#: src/types/cast.md:43
+msgid "// -1 + 256 = 255\n"
+msgstr "// -1 + 256 = 255\n"
+
+#: src/types/cast.md:44
+msgid "\"  -1 as a u8 is : {}\""
+msgstr "\"  -1 as a u8 is : {}\""
+
+#: src/types/cast.md:46
+msgid "// For positive numbers, this is the same as the modulus\n"
+msgstr "// 正の数では、これは剰余と同じです。\n"
+
+#: src/types/cast.md:47
+msgid "\"1000 mod 256 is : {}\""
+msgstr "\"1000 mod 256 is : {}\""
+
+#: src/types/cast.md:49
+msgid ""
+"// When casting to a signed type, the (bitwise) result is the same as\n"
+"    // first casting to the corresponding unsigned type. If the most "
+"significant\n"
+"    // bit of that value is 1, then the value is negative.\n"
+msgstr ""
+"// 符号付きの型にキャストする場合、（ビットとして見た）結果は対応する\n"
+"    // 符号無し型へのキャストを行った結果と同じです。\n"
+"    // 最上位ビットが1であれば、その値は負であることを示しています。\n"
+
+#: src/types/cast.md:53
+msgid "// Unless it already fits, of course.\n"
+msgstr "// すでに収まっている場合はそのままです。\n"
+
+#: src/types/cast.md:54
+msgid "\" 128 as a i16 is: {}\""
+msgstr "\" 128 as a i16 is: {}\""
+
+#: src/types/cast.md:56
+msgid ""
+"// In boundary case 128 value in 8-bit two's complement representation is "
+"-128\n"
+msgstr "// 境界値のケースを考えると、128の8ビットにおける2の補数は -128です。\n"
+
+#: src/types/cast.md:57
+msgid "\" 128 as a i8 is : {}\""
+msgstr "\" 128 as a i8 is : {}\""
+
+#: src/types/cast.md:59
+msgid ""
+"// repeating the example above\n"
+"    // 1000 as u8 -> 232\n"
+msgstr ""
+"// 上で示した例を繰り返すと\n"
+"    // 1000 as u8 -> 232\n"
+
+#: src/types/cast.md:62
+msgid ""
+"// and the value of 232 in 8-bit two's complement representation is -24\n"
+msgstr "// 232の8ビットにおける補数は -24。\n"
+
+#: src/types/cast.md:63
+msgid "\" 232 as a i8 is : {}\""
+msgstr "\" 232 as a i8 is : {}\""
+
+#: src/types/cast.md:65
+msgid ""
+"// Since Rust 1.45, the `as` keyword performs a *saturating cast*\n"
+"    // when casting from float to int. If the floating point value exceeds\n"
+"    // the upper bound or is less than the lower bound, the returned value\n"
+"    // will be equal to the bound crossed.\n"
+msgstr ""
+"// Rust 1.45以降、浮動小数点数を整数にキャストするとき、\n"
+"    // `as`キーワードが *飽和的キャスト* を行います。\n"
+"    // 浮動小数点数の値が上限を超えたり下限を下回ったりする場合は、\n"
+"    // 戻り値は越えられた境界の値となります。\n"
+
+#: src/types/cast.md:70
+msgid "// 300.0 as u8 is 255\n"
+msgstr "// 300.0 as u8 は 255\n"
+
+#: src/types/cast.md:71 src/types/cast.md:82
+msgid "\" 300.0 as u8 is : {}\""
+msgstr "\" 300.0 as u8 is : {}\""
+
+#: src/types/cast.md:72
+msgid "// -100.0 as u8 is 0\n"
+msgstr "// -100.0 as u8 は 0\n"
+
+#: src/types/cast.md:73 src/types/cast.md:84
+msgid "\"-100.0 as u8 is : {}\""
+msgstr "\"-100.0 as u8 is : {}\""
+
+#: src/types/cast.md:74 src/types/cast.md:85
+msgid "// nan as u8 is 0\n"
+msgstr "// nan as u8 は 0\n"
+
+#: src/types/cast.md:75 src/types/cast.md:86
+msgid "\"   nan as u8 is : {}\""
+msgstr "\"   nan as u8 is : {}\""
+
+#: src/types/cast.md:77
+msgid ""
+"// This behavior incurs a small runtime cost and can be avoided\n"
+"    // with unsafe methods, however the results might overflow and\n"
+"    // return **unsound values**. Use these methods wisely:\n"
+msgstr ""
+"// この挙動は実行時にややコストがかかるため、安全でない方法で回避できます。\n"
+"    // ただし、結果はオーバーフローしたり *不正確な値* を返す場合があります。\n"
+"    // この方法は賢く使いましょう。\n"
+
+#: src/types/cast.md:81
+msgid "// 300.0 as u8 is 44\n"
+msgstr "// 300.0 as u8 は 44\n"
+
+#: src/types/cast.md:83
+msgid "// -100.0 as u8 is 156\n"
+msgstr "// -100.0 as u8 は 156\n"
+
+#: src/types/literals.md:3
+msgid ""
+"Numeric literals can be type annotated by adding the type as a suffix. As an "
+"example,  to specify that the literal `42` should have the type `i32`, write "
+"`42i32`."
+msgstr ""
+"数値型リテラルはサフィックスにより型を指定することが可能です。"
+"例えば、`42`というリテラルに対して`i32`型を指定するには`42i32`とします。"
+
+#: src/types/literals.md:6
+msgid ""
+"The type of unsuffixed numeric literals will depend on how they are used. If "
+"no constraint exists, the compiler will use `i32` for integers, and `f64` "
+"for floating-point numbers."
+msgstr ""
+"サフィックスを指定しない数値型リテラルの場合、その型がどのように使用されるかに依存して決められます。"
+"デフォルトでは整数型の場合`i32`が、浮動小数点数型には`f64`が使われます。"
+
+#: src/types/literals.md:12
+msgid "// Suffixed literals, their types are known at initialization\n"
+msgstr "// サフィックスを指定したリテラル。型は初期化とともに確定します。\n"
+
+#: src/types/literals.md:17
+msgid "// Unsuffixed literals, their types depend on how they are used\n"
+msgstr "// サフィックスを指定しないリテラル。型は使用方法に依存します。\n"
+
+#: src/types/literals.md:21
+msgid "// `size_of_val` returns the size of a variable in bytes\n"
+msgstr "// `size_of_val`関数は変数のサイズをバイトで返します。\n"
+
+#: src/types/literals.md:22
+msgid "\"size of `x` in bytes: {}\""
+msgstr "\"size of `x` in bytes: {}\""
+
+#: src/types/literals.md:23
+msgid "\"size of `y` in bytes: {}\""
+msgstr "\"size of `y` in bytes: {}\""
+
+#: src/types/literals.md:24
+msgid "\"size of `z` in bytes: {}\""
+msgstr "\"size of `z` in bytes: {}\""
+
+#: src/types/literals.md:25
+msgid "\"size of `i` in bytes: {}\""
+msgstr "\"size of `i` in bytes: {}\""
+
+#: src/types/literals.md:26
+msgid "\"size of `f` in bytes: {}\""
+msgstr "\"size of `f` in bytes: {}\""
+
+#: src/types/literals.md:30
+msgid ""
+"There are some concepts used in the previous code that haven't been "
+"explained yet, here's a brief explanation for the impatient readers:"
+msgstr ""
+"上のコードには現時点では解説していない考えがいくつか使用されています。"
+"気になる方のために簡単に説明をしておきましょう。"
+
+#: src/types/literals.md:33
+msgid ""
+"`std::mem::size_of_val` is a function, but called with its _full path_. Code "
+"can be split in logical units called _modules_. In this case, the "
+"`size_of_val` function is defined in the `mem` module, and the `mem` module "
+"is defined in the `std` _crate_. For more details, see [modules](../mod.md) "
+"and [crates](../crates.md)."
+msgstr ""
+"`std::mem::size_of_val`は関数ですが、 *絶対パス* で呼び出されています。"
+"ソースコードは論理的に区切られた *モジュール* と呼ばれるものにわけられることができます。"
+"今回の場合は`size_of_val`関数は`mem`モジュール内で定義されており、`mem`モジュールは`std` *クレート* 内で定義されています。"
+"より詳しくは[モジュール](../mod.md)と[クレート](../crates.md)を参照してください。"
+
+#: src/types/inference.md:3
+msgid ""
+"The type inference engine is pretty smart. It does more than looking at the "
+"type of the value expression during an initialization. It also looks at how "
+"the variable is used afterwards  to infer its type. Here's an advanced "
+"example of type inference:"
+msgstr ""
+"Rustの型推論エンジンはなかなか賢くできています。"
+"初期化の際に評価値の型をチェックするだけでなく、その後にどのような使われ方をしているかを見て推論します。"
+"以下がその例です。"
+
+#: src/types/inference.md:10
+msgid ""
+"// Because of the annotation, the compiler knows that `elem` has type u8.\n"
+msgstr "// アノテーションのおかげで、コンパイラは`elem`がu8型であることがわかります。\n"
+
+#: src/types/inference.md:13
+msgid "// Create an empty vector (a growable array).\n"
+msgstr "// 空のベクタ（可変長の配列）を生成。\n"
+
+#: src/types/inference.md:15
+msgid ""
+"// At this point the compiler doesn't know the exact type of `vec`, it\n"
+"    // just knows that it's a vector of something (`Vec<_>`).\n"
+msgstr ""
+"// この時点でコンパイラは`vec`の型を知りませんが、\n"
+"    // 何らかの値のベクタ（`Vec<_>`）であるということだけは把握しています。\n"
+
+#: src/types/inference.md:18
+msgid "// Insert `elem` in the vector.\n"
+msgstr "// `elem`をベクタに挿入。\n"
+
+#: src/types/inference.md:20
+msgid ""
+"// Aha! Now the compiler knows that `vec` is a vector of `u8`s (`Vec<u8>`)\n"
+"    // TODO ^ Try commenting out the `vec.push(elem)` line\n"
+msgstr ""
+"// よし！これでコンパイラは`vec`が`u8`のベクタ（`Vec<u8>`）\n"
+"    // であることを把握しました。\n"
+"    // TODO ^ 上の`vec.push(elem)`をコメントアウトしてみましょう。\n"
+
+#: src/types/inference.md:27
+msgid ""
+"No type annotation of variables was needed, the compiler is happy and so is "
+"the programmer!"
+msgstr "このように、変数の型アノテーションは必要ありません。これでコンパイラもプログラマもハッピーですね！"
+
+#: src/types/alias.md:3
+msgid ""
+"The `type` statement can be used to give a new name to an existing type. "
+"Types must have `UpperCamelCase` names, or the compiler will raise a "
+"warning. The exception to this rule are the primitive types: `usize`, `f32`, "
+"etc."
+msgstr ""
+"`type`文を使用することで既存の型に新しい名前を付けることができます。"
+"その場合、名前は`UpperCamelCase`でなくてはなりません。さもなくばコンパイラがエラーを出します。"
+"唯一の例外は`usize`や`f32`のような基本データ型です。"
+
+#: src/types/alias.md:8
+msgid "// `NanoSecond`, `Inch`, and `U64` are new names for `u64`.\n"
+msgstr "// `NanoSecond` `Inch` `U64` を`u64`の別名として使用します。\n"
+
+#: src/types/alias.md:14
+msgid "// `NanoSecond` = `Inch` = `U64` = `u64`.\n"
+msgstr "// `NanoSecond` = `Inch` = `U64` = `u64`\n"
+
+#: src/types/alias.md:18
+msgid ""
+"// Note that type aliases *don't* provide any extra type safety, because\n"
+"    // aliases are *not* new types\n"
+msgstr ""
+"// 型のエイリアスは、元の型をより型安全する **わけではない** ことに注意。\n"
+"    // なぜならば、エイリアスは新たな型を定義している **わけではない** からです。\n"
+
+#: src/types/alias.md:20
+msgid "\"{} nanoseconds + {} inches = {} unit?\""
+msgstr "\"{} nanoseconds + {} inches = {} unit?\""
+
+#: src/types/alias.md:27
+msgid ""
+"The main use of aliases is to reduce boilerplate; for example the `io::"
+"Result<T>` type is an alias for the `Result<T, io::Error>` type."
+msgstr ""
+"このようにエイリアスを付ける一番の理由はボイラープレートを減らすことです。"
+"例えば`io::Result<T>`型は`Result<T, io::Error>`の別名です。"
+
+#: src/types/alias.md:32
+msgid "[Attributes](../attribute.md)"
+msgstr "[アトリビュート](../attribute.md)"
+
+#: src/conversion.md:3
+msgid ""
+"Primitive types can be converted to each other through [casting](types/cast."
+"md)."
+msgstr "基本データ型同士は[キャスト](types/cast.md)を用いて変換できます。"
+
+#: src/conversion.md:5
+msgid ""
+"Rust addresses conversion between custom types (i.e., `struct` and `enum`) "
+"by the use of [traits](trait.md). The generic conversions will use the "
+"[`From`](https://doc.rust-lang.org/std/convert/trait.From.html) and [`Into`]"
+"(https://doc.rust-lang.org/std/convert/trait.Into.html) traits. However "
+"there are more specific ones for the more common cases, in particular when "
+"converting to and from `String`s."
+msgstr ""
+"Rustはカスタム型（例えば`struct`や`enum`）間の変換を[トレイト](trait.md)を用いて行います。"
+"ジェネリックな型変換には[`From`](https://doc.rust-lang.org/std/convert/trait.From.html)および"
+"[`Into`](https://doc.rust-lang.org/std/convert/trait.Into.html)トレイトを使用します。"
+"しかし、よくあるケースにおいて、特に`String`との相互の型変換では、特殊なトレイトが使用されます。"
+
+#: src/conversion/from_into.md:3
+msgid ""
+"The [`From`](https://doc.rust-lang.org/std/convert/trait.From.html) and "
+"[`Into`](https://doc.rust-lang.org/std/convert/trait.Into.html) traits are "
+"inherently linked, and this is actually part of its implementation. If you "
+"are able to convert type A from type B, then it should be easy to believe "
+"that we should be able to convert type B to type A."
+msgstr ""
+"[`From`](https://doc.rust-lang.org/std/convert/trait.From.html)トレイトと"
+"[`Into`](https://doc.rust-lang.org/std/convert/trait.Into.html)トレイトは本質的に結びついており、"
+"そのことが実際の実装に反映されています。"
+"もし型Aが型Bからの型変換をサポートしているのであれば、型Bは型Aへの型変換ができると思うのが自然です。"
+
+#: src/conversion/from_into.md:7
+msgid "`From`"
+msgstr "`From`"
+
+#: src/conversion/from_into.md:9
+msgid ""
+"The [`From`](https://doc.rust-lang.org/std/convert/trait.From.html) trait "
+"allows for a type to define how to create itself from another type, hence "
+"providing a very simple mechanism for converting between several types. "
+"There are numerous implementations of this trait within the standard library "
+"for conversion of primitive and common types."
+msgstr ""
+"[`From`](https://doc.rust-lang.org/std/convert/trait.From.html)トレイトは、"
+"ある型に対し、別の型からその型を作る方法を定義できるようにするものです。"
+"そのため、複数の型の間で型変換を行うための非常にシンプルな仕組みを提供しています。"
+"標準ライブラリでは、基本データ型やよく使われる型に対して、このトレイトが多数実装されています。"
+
+#: src/conversion/from_into.md:14
+msgid "For example we can easily convert a `str` into a `String`"
+msgstr "例えば、`str`から`String`への型変換は簡単です。"
+
+#: src/conversion/from_into.md:21
+msgid "We can do similar for defining a conversion for our own type."
+msgstr "自作の型に対しても、型変換を定義すれば同じように行えます。"
+
+#: src/conversion/from_into.md:39 src/conversion/from_into.md:71
+msgid "\"My number is {:?}\""
+msgstr "\"My number is {:?}\""
+
+#: src/conversion/from_into.md:43
+msgid "`Into`"
+msgstr "`Into`"
+
+#: src/conversion/from_into.md:45
+msgid ""
+"The [`Into`](https://doc.rust-lang.org/std/convert/trait.Into.html) trait is "
+"simply the reciprocal of the `From` trait. That is, if you have implemented "
+"the `From` trait for your type, `Into` will call it when necessary."
+msgstr ""
+"[`Into`](https://doc.rust-lang.org/std/convert/trait.Into.html)トレイトは、"
+"単に`From`トレイトの逆の働きをします。"
+"もし自作の型に`From`トレイトが実装されていたら、`Into`は必要に応じてそれを呼び出します。"
+
+#: src/conversion/from_into.md:49
+msgid ""
+"Using the `Into` trait will typically require specification of the type to "
+"convert into as the compiler is unable to determine this most of the time. "
+"However this is a small trade-off considering we get the functionality for "
+"free."
+msgstr ""
+"`Into`トレイトを使用すると、ほとんどの場合、コンパイラが型を決定することができないため、"
+"変換する型を指定する必要があります。"
+"しかし、この機能を無料で得られることを考えれば、これは小さなトレードオフです。"
+
+#: src/conversion/from_into.md:69
+msgid "// Try removing the type annotation\n"
+msgstr "// ここの型アノテーションを消してみましょう。\n"
+
+#: src/conversion/try_from_try_into.md:3
+msgid ""
+"Similar to [`From` and `Into`](from_into.html), [`TryFrom`](https://doc.rust-"
+"lang.org/std/convert/trait.TryFrom.html) and [`TryInto`](https://doc.rust-"
+"lang.org/std/convert/trait.TryInto.html) are generic traits for converting "
+"between types. Unlike `From`/`Into`, the `TryFrom`/`TryInto` traits are used "
+"for fallible conversions, and as such, return [`Result`](https://doc.rust-"
+"lang.org/std/result/enum.Result.html)s."
+msgstr ""
+"[`From`と`Into`](from_into.html)と同様に、[`TryFrom`](https://doc.rust-lang.org/std/convert/trait.TryFrom.html)"
+"と[`TryInto`](https://doc.rust-lang.org/std/convert/trait.TryInto.html)"
+"も型変換を行うジェネリックなトレイトです。"
+"`From`/`Into`と異なり、`TryFrom`/`TryInto`トレイトは失敗する可能性のある型変換に用いられるので、"
+"[`Result`](https://doc.rust-lang.org/std/result/enum.Result.html)を返します。"
+
+#: src/conversion/try_from_try_into.md:33
+msgid "// TryFrom\n"
+msgstr "// TryFrom\n"
+
+#: src/conversion/try_from_try_into.md:38
+msgid "// TryInto\n"
+msgstr "// TryInto\n"
+
+#: src/conversion/string.md:1
+msgid "To and from Strings"
+msgstr "Stringとの型変換"
+
+#: src/conversion/string.md:3
+msgid "Converting to String"
+msgstr "Stringへの型変換"
+
+#: src/conversion/string.md:5
+msgid ""
+"To convert any type to a `String` is as simple as implementing the "
+"[`ToString`](https://doc.rust-lang.org/std/string/trait.ToString.html) trait "
+"for the type. Rather than doing so directly, you should implement the [`fmt::"
+"Display`](https://doc.rust-lang.org/std/fmt/trait.Display.html) trait which "
+"automagically provides [`ToString`](https://doc.rust-lang.org/std/string/"
+"trait.ToString.html) and also allows printing the type as discussed in the "
+"section on [`print!`](../hello/print.md)."
+msgstr ""
+"任意の型を`String`に変換するのは簡単で、その型に[`ToString`](https://doc.rust-lang.org/std/string/trait.ToString.html)トレイトを実装するだけです。"
+"これを直接実装するよりも、[`fmt::Display`](https://doc.rust-lang.org/std/fmt/trait.Display.html)トレイトを実装するのがよいでしょう。"
+"そうすることで自動的に[`ToString`](https://doc.rust-lang.org/std/string/trait.ToString.html)が提供されるだけでなく、"
+"[`print!`](../hello/print.md)の章で説明したように、その型を表示できるようにもなります。"
+
+#: src/conversion/string.md:19
+msgid "\"Circle of radius {}\""
+msgstr "\"Circle of radius {}\""
+
+#: src/conversion/string.md:29
+msgid "Parsing a String"
+msgstr "Stringの解析"
+
+#: src/conversion/string.md:31
+msgid ""
+"One of the more common types to convert a string into is a number. The "
+"idiomatic approach to this is to use the [`parse`](https://doc.rust-lang.org/"
+"std/primitive.str.html#method.parse) function and either to arrange for type "
+"inference or to specify the type to parse using the 'turbofish' syntax. Both "
+"alternatives are shown in the following example."
+msgstr ""
+"文字列からの型変換において、数値への型変換はよく行われるものの一つです。"
+"これを行うイディオムは[`parse`](https://doc.rust-lang.org/std/primitive.str.html#method.parse)"
+"関数を使用することですが、このときに型を推論できるようにするか、"
+"もしくはターボフィッシュ構文（`::<>`）を使用して型を指定するかのいずれかを行います。"
+"以下の例では、どちらの方法も紹介しています。"
+
+#: src/conversion/string.md:36
+msgid ""
+"This will convert the string into the type specified as long as the "
+"[`FromStr`](https://doc.rust-lang.org/std/str/trait.FromStr.html) trait is "
+"implemented for that type. This is implemented for numerous types within the "
+"standard library. To obtain this functionality on a user defined type simply "
+"implement the [`FromStr`](https://doc.rust-lang.org/std/str/trait.FromStr."
+"html) trait for that type."
+msgstr ""
+"`parse`関数は、指定された型に[`FromStr`](https://doc.rust-lang.org/std/str/trait.FromStr.html)"
+"トレイトが実装されていれば、文字列をその型に変換します。"
+"このトレイトは標準ライブラリの多くの型に対して実装されています。"
+"ユーザー定義の型でこの機能を利用するには、その型に対して"
+"[`FromStr`](https://doc.rust-lang.org/std/str/trait.FromStr.html)トレイトを実装するだけです。"
+
+#: src/conversion/string.md:43 src/std_misc/process/wait.md:10
+msgid "\"5\""
+msgstr "\"5\""
+
+#: src/conversion/string.md:44 src/error/result.md:33 src/error/result.md:68
+#: src/error/result/result_map.md:42 src/error/result/result_map.md:75
+#: src/error/result/result_alias.md:36 src/error/result/early_returns.md:36
+#: src/error/result/enter_question_mark.md:34
+#: src/error/result/enter_question_mark.md:67
+msgid "\"10\""
+msgstr "\"10\""
+
+#: src/conversion/string.md:47
+msgid "\"Sum: {:?}\""
+msgstr "\"Sum: {:?}\""
+
+#: src/expression.md:3
+msgid "A Rust program is (mostly) made up of a series of statements:"
+msgstr "Rustのプログラムは（ほとんどの場合）文の連続でできています"
+
+#: src/expression.md:7
+msgid ""
+"// statement\n"
+"    // statement\n"
+"    // statement\n"
+msgstr ""
+"// statement\n"
+"    // statement\n"
+"    // statement\n"
+
+#: src/expression.md:13
+msgid ""
+"There are a few kinds of statements in Rust. The most common two are "
+"declaring a variable binding, and using a `;` with an expression:"
+msgstr ""
+"文にはいくつかの種類があります。最も一般的なのは変数の束縛と`;`付きの式です。"
+
+#: src/expression.md:18
+msgid "// variable binding\n"
+msgstr "// 変数束縛\n"
+
+#: src/expression.md:21
+msgid "// expression;\n"
+msgstr "// 式;\n"
+
+#: src/expression.md:28
+msgid ""
+"Blocks are expressions too, so they can be used as values in assignments. "
+"The last expression in the block will be assigned to the place expression "
+"such as a local variable. However, if the last expression of the block ends "
+"with a semicolon, the return value will be `()`."
+msgstr ""
+"コードブロックも式の一種です。よってブロックを丸ごと値として扱うことができます。"
+"その場合ブロック内の最後の式が場所を表す式（例えばローカル変数）に代入されます。"
+"ただし、ブロック内の最後の式が`;`で終わる場合は返り値は`()`になります。"
+
+#: src/expression.md:41
+msgid "// This expression will be assigned to `y`\n"
+msgstr "// この式は`y`に代入されます。\n"
+
+#: src/expression.md:46
+msgid ""
+"// The semicolon suppresses this expression and `()` is assigned to `z`\n"
+msgstr "// セミコロンがあるので`z`には`()`が入ります。\n"
+
+#: src/expression.md:50
+msgid "\"x is {:?}\""
+msgstr "\"x is {:?}\""
+
+#: src/expression.md:51
+msgid "\"y is {:?}\""
+msgstr "\"y is {:?}\""
+
+#: src/expression.md:52
+msgid "\"z is {:?}\""
+msgstr "\"z is {:?}\""
+
+#: src/flow_control.md:3
+msgid ""
+"An integral part of any programming language are ways to modify control "
+"flow: `if`/`else`, `for`, and others. Let's talk about them in Rust."
+msgstr ""
+"処理の流れをコントロールすることはあらゆるプログラミング言語において重要な要素です。"
+"`if`/`else`、`for`等です。Rustの文法を見ていきましょう。"
+
+#: src/flow_control/if_else.md:3
+msgid ""
+"Branching with `if`\\-`else` is similar to other languages. Unlike many of "
+"them, the boolean condition doesn't need to be surrounded by parentheses, "
+"and each condition is followed by a block. `if`\\-`else` conditionals are "
+"expressions, and, all branches must return the same type."
+msgstr ""
+"`if`\\-`else`を用いた条件分岐は他の言語に似ています。"
+"多くの言語では条件式の中を括弧でくくる必要がありますが、Rustではその必要はありません。"
+"条件式の直後にはブロックが続きます。`if`\\-`else`は式の一種で、いずれの分岐先でも返り値の型は同一でなくてはなりません。"
+
+#: src/flow_control/if_else.md:13
+msgid "\"{} is negative\""
+msgstr "\"{} is negative\""
+
+#: src/flow_control/if_else.md:15
+msgid "\"{} is positive\""
+msgstr "\"{} is positive\""
+
+#: src/flow_control/if_else.md:17
+msgid "\"{} is zero\""
+msgstr "\"{} is zero\""
+
+#: src/flow_control/if_else.md:22
+msgid "\", and is a small number, increase ten-fold\""
+msgstr "\", and is a small number, increase ten-fold\""
+
+#: src/flow_control/if_else.md:24
+msgid "// This expression returns an `i32`.\n"
+msgstr "// この式は`i32`を返します。\n"
+
+#: src/flow_control/if_else.md:27
+msgid "\", and is a big number, halve the number\""
+msgstr "\", and is a big number, halve the number\""
+
+#: src/flow_control/if_else.md:29
+msgid "// This expression must return an `i32` as well.\n"
+msgstr "// ここでも返り値の型は`i32`でなくてはなりません。\n"
+
+#: src/flow_control/if_else.md:31
+msgid "// TODO ^ Try suppressing this expression with a semicolon.\n"
+msgstr "// TODO ^ セミコロン`;`をつけて返り値を返さないようにしてみましょう\n"
+
+#: src/flow_control/if_else.md:33
+msgid ""
+"//   ^ Don't forget to put a semicolon here! All `let` bindings need it.\n"
+msgstr ""
+"//   ^ ここにセミコロンを付けるのを忘れないように！\n"
+"    //   `let`による変数束縛の際には必ず必要です。\n"
+
+#: src/flow_control/if_else.md:35 src/flow_control/match.md:35
+msgid "\"{} -> {}\""
+msgstr "\"{} -> {}\""
+
+#: src/flow_control/loop.md:3
+msgid "Rust provides a `loop` keyword to indicate an infinite loop."
+msgstr "Rustには`loop`というキーワードが存在します。これは無限ループを作成するのに使用します。"
+
+#: src/flow_control/loop.md:5
+msgid ""
+"The `break` statement can be used to exit a loop at anytime, whereas the "
+"`continue` statement can be used to skip the rest of the iteration and start "
+"a new one."
+msgstr "ループから抜けだす時は`break`、即座に次のループに移るときは`continue`が使用できます。"
+
+#: src/flow_control/loop.md:13
+msgid "\"Let's count until infinity!\""
+msgstr "\"Let's count until infinity!\""
+
+#: src/flow_control/loop.md:15
+msgid "// Infinite loop\n"
+msgstr "// 無限ループ\n"
+
+#: src/flow_control/loop.md:20
+msgid "\"three\""
+msgstr "\"three\""
+
+#: src/flow_control/loop.md:22
+msgid "// Skip the rest of this iteration\n"
+msgstr "// 残りの処理をスキップ。\n"
+
+#: src/flow_control/loop.md:29
+msgid "\"OK, that's enough\""
+msgstr "\"OK, that's enough\""
+
+#: src/flow_control/loop.md:31
+msgid "// Exit this loop\n"
+msgstr "// ループを抜ける。\n"
+
+#: src/flow_control/loop/nested.md:3
+msgid ""
+"It's possible to `break` or `continue` outer loops when dealing with nested "
+"loops. In these cases, the loops must be annotated with some `'label`, and "
+"the label must be passed to the `break`/`continue` statement."
+msgstr ""
+"ネストしたループを回している時に外側のループを`break`または`continue`したい場合があります。"
+"こういった場合には`'label`を用いてループにラベルを貼り、`break`/`continue`にそのラベルを渡します。"
+
+#: src/flow_control/loop/nested.md:12
+msgid "\"Entered the outer loop\""
+msgstr "\"Entered the outer loop\""
+
+#: src/flow_control/loop/nested.md:15
+msgid "\"Entered the inner loop\""
+msgstr "\"Entered the inner loop\""
+
+#: src/flow_control/loop/nested.md:17
+msgid ""
+"// This would break only the inner loop\n"
+"            //break;\n"
+msgstr ""
+"// これは内側のループのみを中断します。\n"
+"            //break;\n"
+
+#: src/flow_control/loop/nested.md:20
+msgid "// This breaks the outer loop\n"
+msgstr "// こちらは外側を中断します。\n"
+
+#: src/flow_control/loop/nested.md:24
+msgid "\"This point will never be reached\""
+msgstr "\"This point will never be reached\""
+
+#: src/flow_control/loop/nested.md:27
+msgid "\"Exited the outer loop\""
+msgstr "\"Exited the outer loop\""
+
+#: src/flow_control/loop/return.md:3
+msgid ""
+"One of the uses of a `loop` is to retry an operation until it succeeds. If "
+"the operation returns a value though, you might need to pass it to the rest "
+"of the code: put it after the `break`, and it will be returned by the `loop` "
+"expression."
+msgstr ""
+"`loop`の用途のひとつに「成功するまである処理を再試行する」ことがあります。"
+"もしその処理が値を返すならば、それをコードの他の部分に渡す必要があるでしょう。"
+"`break`の後に値を置くと、それが`loop`式の値として返されます。"
+
+#: src/flow_control/while.md:3
+msgid ""
+"The `while` keyword can be used to run a loop while a condition is true."
+msgstr "`while`キーワードは条件が真である限り実行され続けるループのために使用します。"
+
+#: src/flow_control/while.md:5
+msgid ""
+"Let's write the infamous [FizzBuzz](https://en.wikipedia.org/wiki/Fizz_buzz) "
+"using a `while` loop."
+msgstr "悪名高い[FizzBuzz問題](https://en.wikipedia.org/wiki/Fizz_buzz)を`while`を用いて解いてみましょう。"
+
+#: src/flow_control/while.md:9
+msgid "// A counter variable\n"
+msgstr "// カウンタとなる変数\n"
+
+#: src/flow_control/while.md:12
+msgid "// Loop while `n` is less than 101\n"
+msgstr "// `n`が101より小さい場合のループ\n"
+
+#: src/flow_control/while.md:15 src/flow_control/for.md:17
+#: src/flow_control/for.md:37 src/fn.md:34
+msgid "\"fizzbuzz\""
+msgstr "\"fizzbuzz\""
+
+#: src/flow_control/while.md:17 src/flow_control/for.md:19
+#: src/flow_control/for.md:39 src/fn.md:36
+msgid "\"fizz\""
+msgstr "\"fizz\""
+
+#: src/flow_control/while.md:19 src/flow_control/for.md:21
+#: src/flow_control/for.md:41 src/fn.md:38
+msgid "\"buzz\""
+msgstr "\"buzz\""
+
+#: src/flow_control/while.md:24
+msgid "// Increment counter\n"
+msgstr "// カウンタに1を追加。\n"
+
+#: src/flow_control/for.md:1
+msgid "for loops"
+msgstr "forループ"
+
+#: src/flow_control/for.md:5
+msgid ""
+"The `for in` construct can be used to iterate through an `Iterator`. One of "
+"the easiest ways to create an iterator is to use the range notation `a..b`. "
+"This yields values from `a` (inclusive) to `b` (exclusive) in steps of one."
+msgstr ""
+"`for in`構文を用いることで、イテレータのそれぞれの要素に対して処理をすることが可能です。"
+"イテレータを作る最も単純な方法は`a..b`のような範囲記法です。"
+"これは「`a`」から「`b`のひとつ前」までの要素を順に生成します。"
+
+#: src/flow_control/for.md:10
+msgid "Let's write FizzBuzz using `for` instead of `while`."
+msgstr "では`while`の代わりに`for`を用いてFizzBuzzを書いてみましょう。"
+
+#: src/flow_control/for.md:14 src/flow_control/for.md:34
+msgid "// `n` will take the values: 1, 2, ..., 100 in each iteration\n"
+msgstr "// `n`は1, 2, ...., 100のそれぞれの値を取ります。\n"
+
+#: src/flow_control/for.md:29
+msgid ""
+"Alternatively, `a..=b` can be used for a range that is inclusive on both "
+"ends. The above can be written as:"
+msgstr "上記の代わりに`a..=b`を用いると、両端の値を含む範囲を指定できます。上記の例は次のように書けます。"
+
+#: src/flow_control/for.md:49
+msgid "for and iterators"
+msgstr "forとイテレータ"
+
+#: src/flow_control/for.md:51
+msgid ""
+"The `for in` construct is able to interact with an `Iterator` in several "
+"ways. As discussed in the section on the [Iterator](../trait/iter.md) trait, "
+"by default the `for` loop will apply the `into_iter` function to the "
+"collection. However, this is not the only means of converting collections "
+"into iterators."
+msgstr ""
+"`for in`構文はイテレータとさまざまな方法でやり取りできます。"
+"[Iterator](../trait/iter.md)トレイトの章で説明したように、"
+"デフォルトでは`for`ループにおいて`into_iter`関数がコレクションに対して適用されます。"
+"しかし、コレクションをイテレータに変換する方法はこれだけではありません。"
+
+#: src/flow_control/for.md:56
+msgid ""
+"`into_iter`, `iter` and `iter_mut` all handle the conversion of a collection "
+"into an iterator in different ways, by providing different views on the data "
+"within."
+msgstr ""
+"`into_iter`、`iter`、`iter_mut`はいずれもコレクションのイテレータへの変換を行いますが、"
+"データの「見せ方」の違いにより、そのやり方はそれぞれ異なります。"
+
+#: src/flow_control/for.md:60
+msgid ""
+"`iter` - This borrows each element of the collection through each iteration. "
+"Thus leaving the collection untouched and available for reuse after the loop."
+msgstr ""
+"`iter` - この関数は、各周回においてコレクションの要素を借用します。"
+"よってコレクションには手を加えないので、ループの実行後もコレクションを再利用できます。"
+
+#: src/flow_control/for.md:65 src/flow_control/for.md:85
+#: src/flow_control/for.md:104
+msgid "\"Frank\""
+msgstr "\"Frank\""
+
+#: src/flow_control/for.md:65 src/flow_control/for.md:69
+#: src/flow_control/for.md:85 src/flow_control/for.md:89
+#: src/flow_control/for.md:104 src/flow_control/for.md:108
+msgid "\"Ferris\""
+msgstr "\"Ferris\""
+
+#: src/flow_control/for.md:69 src/flow_control/for.md:89
+#: src/flow_control/for.md:108
+msgid "\"There is a rustacean among us!\""
+msgstr "\"There is a rustacean among us!\""
+
+#: src/flow_control/for.md:70
+msgid "// TODO ^ Try deleting the & and matching just \"Ferris\"\n"
+msgstr ""
+
+#: src/flow_control/for.md:71 src/flow_control/for.md:90
+msgid "\"Hello {}\""
+msgstr "\"Hello {}\""
+
+#: src/flow_control/for.md:75 src/flow_control/for.md:94
+#: src/flow_control/for.md:113
+msgid "\"names: {:?}\""
+msgstr "\"names: {:?}\""
+
+#: src/flow_control/for.md:79
+msgid ""
+"`into_iter` - This consumes the collection so that on each iteration the "
+"exact data is provided. Once the collection has been consumed it is no "
+"longer available for reuse as it has been 'moved' within the loop."
+msgstr ""
+"`into_iter` - この関数はコレクションからデータを取り出すので、"
+"各周回において要素のデータそのものが提供されます。"
+"データを取り出してしまうと、データはループ内に「移動」してしまうので、"
+"ループ実行後にコレクションを再利用することはできません。"
+
+#: src/flow_control/for.md:99
+msgid ""
+"`iter_mut` - This mutably borrows each element of the collection, allowing "
+"for the collection to be modified in place."
+msgstr "`iter_mut` - この関数はコレクションの各要素をミュータブル（変更可能）で借用するので、コレクションの要素をその場で変更できます。"
+
+#: src/flow_control/for.md:109
+msgid "\"Hello\""
+msgstr "\"Hello\""
+
+#: src/flow_control/for.md:117
+msgid ""
+"In the above snippets note the type of `match` branch, that is the key "
+"difference in the types of iteration. The difference in type then of course "
+"implies differing actions that are able to be performed."
+msgstr ""
+"上記に示した3つのコードにおいて、`match`の選択肢の型の違いに注意してください。"
+"ここがそれぞれの方法の違いを生む鍵になっています。"
+"型が異なれば、当然ながらそれに対して行える処理も変わります。"
+
+#: src/flow_control/for.md:123
+msgid "[Iterator](../trait/iter.md)"
+msgstr "[イテレータ](../trait/iter.md)"
+
+#: src/flow_control/match.md:3
+msgid ""
+"Rust provides pattern matching via the `match` keyword, which can be used "
+"like a C `switch`. The first matching arm is evaluated and all possible "
+"values must be covered."
+msgstr ""
+"Rustは`match`を用いて、C言語における`switch`のようなパターンマッチングを行うことができます。"
+"マッチする最初のアームが評価され、取りうるすべての値はカバーされていなければなりません。"
+
+#: src/flow_control/match.md:10
+msgid "// TODO ^ Try different values for `number`\n"
+msgstr "// TODO ^ `number` の値を変えて試してみましょう。\n"
+
+#: src/flow_control/match.md:12
+msgid "\"Tell me about {}\""
+msgstr "\"Tell me about {}\""
+
+#: src/flow_control/match.md:14
+msgid "// Match a single value\n"
+msgstr "// 単一の値とのマッチをチェック。\n"
+
+#: src/flow_control/match.md:15
+msgid "\"One!\""
+msgstr "\"One!\""
+
+#: src/flow_control/match.md:16
+msgid "// Match several values\n"
+msgstr "// いくつかの値とのマッチをチェック。\n"
+
+#: src/flow_control/match.md:17
+msgid "\"This is a prime\""
+msgstr "\"This is a prime\""
+
+#: src/flow_control/match.md:18
+msgid ""
+"// TODO ^ Try adding 13 to the list of prime values\n"
+"        // Match an inclusive range\n"
+msgstr ""
+"// TODO ^ 素数のリストに13を加えてみましょう。\n"
+"        // 特定の範囲の値とのマッチをチェック。\n"
+
+#: src/flow_control/match.md:20
+msgid "\"A teen\""
+msgstr "\"A teen\""
+
+#: src/flow_control/match.md:21
+msgid "// Handle the rest of cases\n"
+msgstr "// その他の場合の処理\n"
+
+#: src/flow_control/match.md:22
+msgid "\"Ain't special\""
+msgstr "\"Ain't special\""
+
+#: src/flow_control/match.md:23
+msgid "// TODO ^ Try commenting out this catch-all arm\n"
+msgstr "// TODO ^ この全てをキャッチするアームをコメントアウトしてみましょう。\n"
+
+#: src/flow_control/match.md:27
+msgid "// Match is an expression too\n"
+msgstr "// マッチは式でもあります。\n"
+
+#: src/flow_control/match.md:29
+msgid "// The arms of a match must cover all the possible values\n"
+msgstr "// マッチは全ての可能な値をカバーしなくてはなりません。\n"
+
+#: src/flow_control/match.md:32
+msgid "// TODO ^ Try commenting out one of these arms\n"
+msgstr "// TODO ^ 試しに片方をコメントアウトしてみましょう。\n"
+
+#: src/flow_control/match/destructuring.md:3
+msgid "A `match` block can destructure items in a variety of ways."
+msgstr "`match`は値をさまざまなやり方でデストラクトすることができます。"
+
+#: src/flow_control/match/destructuring.md:5
+msgid "[Destructuring Tuples](destructuring/destructure_tuple.md)"
+msgstr "[タプルのデストラクト](destructuring/destructure_tuple.md)"
+
+#: src/flow_control/match/destructuring.md:6
+msgid "[Destructuring Arrays and Slices](destructuring/destructure_slice.md)"
+msgstr "[配列とスライスのデストラクト](destructuring/destructure_slice.md)"
+
+#: src/flow_control/match/destructuring.md:7
+msgid "[Destructuring Enums](destructuring/destructure_enum.md)"
+msgstr "[列挙型のデストラクト](destructuring/destructure_enum.md)"
+
+#: src/flow_control/match/destructuring.md:8
+msgid "[Destructuring Pointers](destructuring/destructure_pointers.md)"
+msgstr "[ポインタのデストラクト](destructuring/destructure_pointers.md)"
+
+#: src/flow_control/match/destructuring.md:9
+msgid "[Destructuring Structures](destructuring/destructure_structures.md)"
+msgstr "[構造体のデストラクト](destructuring/destructure_structures.md)"
+
+#: src/flow_control/match/destructuring/destructure_tuple.md:3
+msgid "Tuples can be destructured in a `match` as follows:"
+msgstr "以下のように、タプルは`match`を用いてデストラクトすることができます。"
+
+#: src/flow_control/match/destructuring/destructure_tuple.md:8
+msgid "// TODO ^ Try different values for `triple`\n"
+msgstr "// TODO ^ `triple`に別の値を入れてみましょう。\n"
+
+#: src/flow_control/match/destructuring/destructure_tuple.md:10
+msgid "\"Tell me about {:?}\""
+msgstr "\"Tell me about {:?}\""
+
+#: src/flow_control/match/destructuring/destructure_tuple.md:11
+msgid "// Match can be used to destructure a tuple\n"
+msgstr "// `match`を用いてタプルをデストラクトしてみましょう。\n"
+
+#: src/flow_control/match/destructuring/destructure_tuple.md:13
+msgid "// Destructure the second and third elements\n"
+msgstr "// 2つ目と3つ目の要素をデストラクト。\n"
+
+#: src/flow_control/match/destructuring/destructure_tuple.md:14
+msgid "\"First is `0`, `y` is {:?}, and `z` is {:?}\""
+msgstr "\"First is `0`, `y` is {:?}, and `z` is {:?}\""
+
+#: src/flow_control/match/destructuring/destructure_tuple.md:15
+msgid "\"First is `1` and the rest doesn't matter\""
+msgstr "\"First is `1` and the rest doesn't matter\""
+
+#: src/flow_control/match/destructuring/destructure_tuple.md:16
+msgid "\"last is `2` and the rest doesn't matter\""
+msgstr "\"last is `2` and the rest doesn't matter\""
+
+#: src/flow_control/match/destructuring/destructure_tuple.md:17
+msgid "\"First is `3`, last is `4`, and the rest doesn't matter\""
+msgstr "\"First is `3`, last is `4`, and the rest doesn't matter\""
+
+#: src/flow_control/match/destructuring/destructure_tuple.md:18
+msgid "// `..` can be used to ignore the rest of the tuple\n"
+msgstr "// `..`を使うと、タプルの残りの部分を無視できます。\n"
+
+#: src/flow_control/match/destructuring/destructure_tuple.md:19
+msgid "\"It doesn't matter what they are\""
+msgstr "\"It doesn't matter what they are\""
+
+#: src/flow_control/match/destructuring/destructure_tuple.md:20
+msgid "// `_` means don't bind the value to a variable\n"
+msgstr "// ここでは`_`は、値を変数に束縛しないことを意味します。\n"
+
+#: src/flow_control/match/destructuring/destructure_tuple.md:27
+msgid "[Tuples](../../../primitives/tuples.md)"
+msgstr "[タプル](../../../primitives/tuples.md)"
+
+#: src/flow_control/match/destructuring/destructure_slice.md:3
+msgid "Like tuples, arrays and slices can be destructured this way:"
+msgstr "タプル同様、配列とスライスも以下のようにデストラクトできます。"
+
+#: src/flow_control/match/destructuring/destructure_slice.md:7
+msgid "// Try changing the values in the array, or make it a slice!\n"
+msgstr "// 配列中の値を変更してみましょう。または、スライスにしてみましょう。\n"
+
+#: src/flow_control/match/destructuring/destructure_slice.md:11
+msgid ""
+"// Binds the second and the third elements to the respective variables\n"
+msgstr "// 2番目と3番目の要素を変数に束縛します。\n"
+
+#: src/flow_control/match/destructuring/destructure_slice.md:13
+msgid "\"array[0] = 0, array[1] = {}, array[2] = {}\""
+msgstr "\"array[0] = 0, array[1] = {}, array[2] = {}\""
+
+#: src/flow_control/match/destructuring/destructure_slice.md:15
+msgid "// Single values can be ignored with _\n"
+msgstr "// _で値を無視できます。\n"
+
+#: src/flow_control/match/destructuring/destructure_slice.md:17
+msgid "\"array[0] = 1, array[2] = {} and array[1] was ignored\""
+msgstr "\"array[0] = 1, array[2] = {} and array[1] was ignored\""
+
+#: src/flow_control/match/destructuring/destructure_slice.md:21
+msgid "// You can also bind some and ignore the rest\n"
+msgstr "// いくつかの値を束縛して残りを無視できます。\n"
+
+#: src/flow_control/match/destructuring/destructure_slice.md:23
+msgid "\"array[0] = -1, array[1] = {} and all the other ones were ignored\""
+msgstr "\"array[0] = -1, array[1] = {} and all the other ones were ignored\""
+
+#: src/flow_control/match/destructuring/destructure_slice.md:26
+msgid ""
+"// The code below would not compile\n"
+"        // [-1, second] => ...\n"
+msgstr ""
+"// 以下のコードはコンパイルできません。\n"
+"        // [-1, second] => ...\n"
+
+#: src/flow_control/match/destructuring/destructure_slice.md:29
+msgid ""
+"// Or store them in another array/slice (the type depends on\n"
+"        // that of the value that is being matched against)\n"
+msgstr ""
+"// 別の配列やスライスに値を持たせることもできます。\n"
+"        // (配列かスライスかは、マッチする値の型により異なります)\n"
+
+#: src/flow_control/match/destructuring/destructure_slice.md:32
+msgid "\"array[0] = 3, array[1] = {} and the other elements were {:?}\""
+msgstr "\"array[0] = 3, array[1] = {} and the other elements were {:?}\""
+
+#: src/flow_control/match/destructuring/destructure_slice.md:36
+msgid ""
+"// Combining these patterns, we can, for example, bind the first and\n"
+"        // last values, and store the rest of them in a single array\n"
+msgstr ""
+"// 例えば、これらのパターンを組み合わせて、\n"
+"        // 最初と最後の値を束縛し、残りの値を配列に持たせることもできます。\n"
+
+#: src/flow_control/match/destructuring/destructure_slice.md:39
+msgid "\"array[0] = {}, middle = {:?}, array[2] = {}\""
+msgstr "\"array[0] = {}, middle = {:?}, array[2] = {}\""
+
+#: src/flow_control/match/destructuring/destructure_slice.md:48
+msgid ""
+"[Arrays and Slices](../../../primitives/array.md) and [Binding](../binding."
+"md) for `@` sigil"
+msgstr ""
+"[配列とスライス](../../../primitives/array.md), @マークについては[束縛](../binding.md)"
+
+#: src/flow_control/match/destructuring/destructure_enum.md:3
+msgid "An `enum` is destructured similarly:"
+msgstr "列挙型も似たやり方でデストラクトすることができます。"
+
+#: src/flow_control/match/destructuring/destructure_enum.md:6
+msgid ""
+"// `allow` required to silence warnings because only\n"
+"// one variant is used.\n"
+msgstr "// `allow`は値を一つだけ使用したことによる警告を抑えるために存在します。\n"
+
+#: src/flow_control/match/destructuring/destructure_enum.md:10
+msgid "// These 3 are specified solely by their name.\n"
+msgstr "// これら3つの値は名前のみで扱うことができます。\n"
+
+#: src/flow_control/match/destructuring/destructure_enum.md:14
+msgid "// These likewise tie `u32` tuples to different names: color models.\n"
+msgstr ""
+"// 以下の値は名前と`u32`のタプルをペアにしています。\n"
+"    // カラーモデルと呼ばれます。\n"
+
+#: src/flow_control/match/destructuring/destructure_enum.md:24
+msgid "// TODO ^ Try different variants for `color`\n"
+msgstr "// TODO ^ `color`に別の値を入れてみましょう。\n"
+
+#: src/flow_control/match/destructuring/destructure_enum.md:26
+msgid "\"What color is it?\""
+msgstr "\"What color is it?\""
+
+#: src/flow_control/match/destructuring/destructure_enum.md:27
+msgid "// An `enum` can be destructured using a `match`.\n"
+msgstr "// `enum`は`match`を利用してデストラクトすることができます。\n"
+
+#: src/flow_control/match/destructuring/destructure_enum.md:29
+msgid "\"The color is Red!\""
+msgstr "\"The color is Red!\""
+
+#: src/flow_control/match/destructuring/destructure_enum.md:30
+msgid "\"The color is Blue!\""
+msgstr "\"The color is Blue!\""
+
+#: src/flow_control/match/destructuring/destructure_enum.md:31
+msgid "\"The color is Green!\""
+msgstr "\"The color is Green!\""
+
+#: src/flow_control/match/destructuring/destructure_enum.md:33
+msgid "\"Red: {}, green: {}, and blue: {}!\""
+msgstr "\"Red: {}, green: {}, and blue: {}!\""
+
+#: src/flow_control/match/destructuring/destructure_enum.md:35
+msgid "\"Hue: {}, saturation: {}, value: {}!\""
+msgstr "\"Hue: {}, saturation: {}, value: {}!\""
+
+#: src/flow_control/match/destructuring/destructure_enum.md:37
+msgid "\"Hue: {}, saturation: {}, lightness: {}!\""
+msgstr "\"Hue: {}, saturation: {}, lightness: {}!\""
+
+#: src/flow_control/match/destructuring/destructure_enum.md:39
+msgid "\"Cyan: {}, magenta: {}, yellow: {}!\""
+msgstr "\"Cyan: {}, magenta: {}, yellow: {}!\""
+
+#: src/flow_control/match/destructuring/destructure_enum.md:41
+msgid "\"Cyan: {}, magenta: {}, yellow: {}, key (black): {}!\""
+msgstr "\"Cyan: {}, magenta: {}, yellow: {}, key (black): {}!\""
+
+#: src/flow_control/match/destructuring/destructure_enum.md:43
+msgid "// Don't need another arm because all variants have been examined\n"
+msgstr "// 全ての値を列挙したのでその他の場合の処理は必要ありません。\n"
+
+#: src/flow_control/match/destructuring/destructure_enum.md:50
+msgid ""
+"[`#[allow(...)]`](../../../attribute/unused.md), [color models](https://en."
+"wikipedia.org/wiki/Color_model) and [`enum`](../../../custom_types/enum.md)"
+msgstr ""
+"[`#[allow(...)]`](../../../attribute/unused.md), [カラーモデル](https://en."
+"wikipedia.org/wiki/Color_model), [列挙型](../../../custom_types/enum.md)"
+
+#: src/flow_control/match/destructuring/destructure_pointers.md:3
+msgid ""
+"For pointers, a distinction needs to be made between destructuring and "
+"dereferencing as they are different concepts which are used differently from "
+"languages like C/C++."
+msgstr "Rustのポインタは、C/C++のポインタとは異なる概念なので、デストラクトとデリファレンスを同じようなやり方で扱うことはできません。"
+
+#: src/flow_control/match/destructuring/destructure_pointers.md:7
+msgid "Dereferencing uses `*`"
+msgstr "デリファレンスには`*`を用います。"
+
+#: src/flow_control/match/destructuring/destructure_pointers.md:8
+msgid "Destructuring uses `&`, `ref`, and `ref mut`"
+msgstr "デストラクトには`&`, `ref`, `ref mut`を用います。"
+
+#: src/flow_control/match/destructuring/destructure_pointers.md:12
+msgid ""
+"// Assign a reference of type `i32`. The `&` signifies there\n"
+"    // is a reference being assigned.\n"
+msgstr ""
+"// `i32`型への参照を代入します。\n"
+"    // `&`によって参照であることを明示しています。\n"
+
+#: src/flow_control/match/destructuring/destructure_pointers.md:17
+msgid ""
+"// If `reference` is pattern matched against `&val`, it results\n"
+"        // in a comparison like:\n"
+"        // `&i32`\n"
+"        // `&val`\n"
+"        // ^ We see that if the matching `&`s are dropped, then the `i32`\n"
+"        // should be assigned to `val`.\n"
+msgstr ""
+"// 上で定義した`reference`という変数が`&val`とのパターンマッチ\n"
+"        // に用いられた場合、以下の2つの値が比較されていることになります。\n"
+"        // `&i32`\n"
+"        // `&val`\n"
+"        // ^ よって`&`を落とせば、`i32`が`val`に代入されることがわかります。\n"
+
+#: src/flow_control/match/destructuring/destructure_pointers.md:23
+msgid "\"Got a value via destructuring: {:?}\""
+msgstr "\"Got a value via destructuring: {:?}\""
+
+#: src/flow_control/match/destructuring/destructure_pointers.md:26
+msgid "// To avoid the `&`, you dereference before matching.\n"
+msgstr "// `&`を使用したくない場合は、マッチングの前にデリファレンスします。\n"
+
+#: src/flow_control/match/destructuring/destructure_pointers.md:28
+msgid "\"Got a value via dereferencing: {:?}\""
+msgstr "\"Got a value via dereferencing: {:?}\""
+
+#: src/flow_control/match/destructuring/destructure_pointers.md:31
+msgid ""
+"// What if you don't start with a reference? `reference` was a `&`\n"
+"    // because the right side was already a reference. This is not\n"
+"    // a reference because the right side is not one.\n"
+msgstr ""
+"// いきなり参照を変数に代入するのではない場合はどうでしょう。\n"
+"    // 先ほどは右辺値が`&`で始まっていたので参照でしたが、\n"
+"    // これは違います。\n"
+
+#: src/flow_control/match/destructuring/destructure_pointers.md:36
+msgid ""
+"// Rust provides `ref` for exactly this purpose. It modifies the\n"
+"    // assignment so that a reference is created for the element; this\n"
+"    // reference is assigned.\n"
+msgstr ""
+"// このような場合、Rustでは変数束縛時に`ref`を宣言します。\n"
+"    // 要素の参照が作られて、それが束縛対象になります。\n"
+
+#: src/flow_control/match/destructuring/destructure_pointers.md:41
+msgid ""
+"// Accordingly, by defining 2 values without references, references\n"
+"    // can be retrieved via `ref` and `ref mut`.\n"
+msgstr ""
+"// 同様にミュータブルな値の場合`ref mut`を使用することで参照を\n"
+"    // 取得できます。イミュータブルの場合と合わせてみていきましょう。\n"
+
+#: src/flow_control/match/destructuring/destructure_pointers.md:46
+msgid "// Use `ref` keyword to create a reference.\n"
+msgstr "// `ref`を使用して参照を作成。\n"
+
+#: src/flow_control/match/destructuring/destructure_pointers.md:48
+msgid "\"Got a reference to a value: {:?}\""
+msgstr "\"Got a reference to a value: {:?}\""
+
+#: src/flow_control/match/destructuring/destructure_pointers.md:51
+msgid "// Use `ref mut` similarly.\n"
+msgstr "// 同様に`ref mut`を使用。\n"
+
+#: src/flow_control/match/destructuring/destructure_pointers.md:54
+msgid ""
+"// Got a reference. Gotta dereference it before we can\n"
+"            // add anything to it.\n"
+msgstr "// 参照を取得、値を変更するためにはデリファレンスします。\n"
+
+#: src/flow_control/match/destructuring/destructure_pointers.md:57
+msgid "\"We added 10. `mut_value`: {:?}\""
+msgstr "\"We added 10. `mut_value`: {:?}\""
+
+#: src/flow_control/match/destructuring/destructure_pointers.md:65
+msgid "[The ref pattern](../../../scope/borrow/ref.md)"
+msgstr "[ref パターン](../../../scope/borrow/ref.md)"
+
+#: src/flow_control/match/destructuring/destructure_structures.md:3
+msgid "Similarly, a `struct` can be destructured as shown:"
+msgstr "以下のようにして、構造体も同様にデストラクトすることができます。"
+
+#: src/flow_control/match/destructuring/destructure_structures.md:12
+msgid "// Try changing the values in the struct to see what happens\n"
+msgstr "// 構造体の中の値を変えて、何が起きるか見てみましょう。\n"
+
+#: src/flow_control/match/destructuring/destructure_structures.md:16
+msgid "\"First of x is 1, b = {},  y = {} \""
+msgstr "\"First of x is 1, b = {},  y = {} \""
+
+#: src/flow_control/match/destructuring/destructure_structures.md:18
+msgid ""
+"// you can destructure structs and rename the variables,\n"
+"        // the order is not important\n"
+msgstr ""
+"// 構造体をデストラクトして変数をリネーム。\n"
+"        // 順番は重要ではありません。\n"
+
+#: src/flow_control/match/destructuring/destructure_structures.md:20
+msgid "\"y is 2, i = {:?}\""
+msgstr "\"y is 2, i = {:?}\""
+
+#: src/flow_control/match/destructuring/destructure_structures.md:22
+msgid "// and you can also ignore some variables:\n"
+msgstr "// 一部の変数を無視することもできます。\n"
+
+#: src/flow_control/match/destructuring/destructure_structures.md:23
+msgid "\"y = {}, we don't care about x\""
+msgstr "\"y = {}, we don't care about x\""
+
+#: src/flow_control/match/destructuring/destructure_structures.md:24
+msgid ""
+"// this will give an error: pattern does not mention field `x`\n"
+"        //Foo { y } => println!(\"y = {}\", y),\n"
+msgstr ""
+"// `x`に言及していないため、以下はエラーになります。\n"
+"        //Foo { y } => println!(\"y = {}\", y),\n"
+
+#: src/flow_control/match/destructuring/destructure_structures.md:30
+msgid "// You do not need a match block to destructure structs:\n"
+msgstr "// matchを使わずとも構造体はデストラクトできます。\n"
+
+#: src/flow_control/match/destructuring/destructure_structures.md:32
+msgid "\"Outside: x0 = {x0:?}, y0 = {y0}\""
+msgstr "\"Outside: x0 = {x0:?}, y0 = {y0}\""
+
+#: src/flow_control/match/destructuring/destructure_structures.md:34
+msgid "// Destructuring works with nested structs as well:\n"
+msgstr "// ネストした構造体もデストラクトできます。\n"
+
+#: src/flow_control/match/destructuring/destructure_structures.md:41
+msgid "\"Nested: nested_x = {nested_x:?}, nested_y = {nested_y:?}\""
+msgstr "\"Nested: nested_x = {nested_x:?}, nested_y = {nested_y:?}\""
+
+#: src/flow_control/match/destructuring/destructure_structures.md:47
+msgid "[Structs](../../../custom_types/structs.md)"
+msgstr "[構造体](../../../custom_types/structs.md)"
+
+#: src/flow_control/match/guard.md:3
+msgid "A `match` _guard_ can be added to filter the arm."
+msgstr "`match`内の条件文をフィルタリングするために、 *ガード* を使用することができます。"
+
+#: src/flow_control/match/guard.md:14
+msgid "// ^ TODO try different values for `temperature`\n"
+msgstr "// ^ TODO `temperature`の値を変更してみましょう。\n"
+
+#: src/flow_control/match/guard.md:17
+msgid "\"{}C is above 30 Celsius\""
+msgstr "\"{}C is above 30 Celsius\""
+
+#: src/flow_control/match/guard.md:18
+msgid "// The `if condition` part ^ is a guard\n"
+msgstr "//                         ^ `if`とそれに続く条件式がガードです。\n"
+
+#: src/flow_control/match/guard.md:19
+msgid "\"{}C is equal to or below 30 Celsius\""
+msgstr "\"{}C is equal to or below 30 Celsius\""
+
+#: src/flow_control/match/guard.md:21
+msgid "\"{}F is above 86 Fahrenheit\""
+msgstr "\"{}F is above 86 Fahrenheit\""
+
+#: src/flow_control/match/guard.md:22
+msgid "\"{}F is equal to or below 86 Fahrenheit\""
+msgstr "\"{}F is equal to or below 86 Fahrenheit\""
+
+#: src/flow_control/match/guard.md:27
+msgid ""
+"Note that the compiler won't take guard conditions into account when "
+"checking if all patterns are covered by the match expression."
+msgstr ""
+"パターンが全てカバーされているかどうかを判断する際に、ガード条件は考慮されないことに注意してください。"
+
+#: src/flow_control/match/guard.md:35
+msgid "\"Zero\""
+msgstr "\"Zero\""
+
+#: src/flow_control/match/guard.md:36
+msgid "\"Greater than zero\""
+msgstr "\"Greater than zero\""
+
+#: src/flow_control/match/guard.md:37
+msgid ""
+"// _ => unreachable!(\"Should never happen.\"),\n"
+"        // TODO ^ uncomment to fix compilation\n"
+msgstr ""
+"// _ => unreachable!(\"Should never happen.\"),\n"
+"        // TODO ^ アンコメントしてコンパイルエラーを直してみましょう。\n"
+
+#: src/flow_control/match/guard.md:45
+msgid ""
+"[Tuples](../../primitives/tuples.md) [Enums](../../custom_types/enum.md)"
+msgstr ""
+"[タプル](../../primitives/tuples.md) [列挙型](../../custom_types/enum.md)"
+
+#: src/flow_control/match/binding.md:3
+msgid ""
+"Indirectly accessing a variable makes it impossible to branch and use that "
+"variable without re-binding. `match` provides the `@` sigil for binding "
+"values to names:"
+msgstr ""
+"いくつかの変数をまとめてマッチ対象とした場合、そのうちの一つを分岐先で使用することはそのままでは不可能です。"
+"`match`内では`@`マークを使用して変数を束縛することができます。"
+
+#: src/flow_control/match/binding.md:8
+msgid "// A function `age` which returns a `u32`.\n"
+msgstr "// `age`関数は`u32`の値を返します。\n"
+
+#: src/flow_control/match/binding.md:14
+msgid "\"Tell me what type of person you are\""
+msgstr "\"Tell me what type of person you are\""
+
+#: src/flow_control/match/binding.md:17
+msgid "\"I haven't celebrated my first birthday yet\""
+msgstr "\"I haven't celebrated my first birthday yet\""
+
+#: src/flow_control/match/binding.md:18
+msgid ""
+"// Could `match` 1 ..= 12 directly but then what age\n"
+"        // would the child be? Instead, bind to `n` for the\n"
+"        // sequence of 1 ..= 12. Now the age can be reported.\n"
+msgstr ""
+"// `1 ..= 12`の値を一挙に`match`させることができます。\n"
+"        // しかしその場合、子供は何歳でしょうか？\n"
+"        // マッチした値を`n`に束縛することで値を使用できます。\n"
+
+#: src/flow_control/match/binding.md:21
+msgid "\"I'm a child of age {:?}\""
+msgstr "\"I'm a child of age {:?}\""
+
+#: src/flow_control/match/binding.md:22
+msgid "\"I'm a teen of age {:?}\""
+msgstr "\"I'm a teen of age {:?}\""
+
+#: src/flow_control/match/binding.md:23
+msgid "// Nothing bound. Return the result.\n"
+msgstr "// マッチしなかった場合の処理\n"
+
+#: src/flow_control/match/binding.md:24
+msgid "\"I'm an old person of age {:?}\""
+msgstr "\"I'm an old person of age {:?}\""
+
+#: src/flow_control/match/binding.md:29
+msgid ""
+"You can also use binding to \"destructure\" `enum` variants, such as "
+"`Option`:"
+msgstr "`Option`のような、列挙型の値をデストラクトするためにも、束縛を利用できます。"
+
+#: src/flow_control/match/binding.md:38
+msgid ""
+"// Got `Some` variant, match if its value, bound to `n`,\n"
+"        // is equal to 42.\n"
+msgstr "// `n`に束縛された`Some`の値が42に等しいときにマッチ。\n"
+
+#: src/flow_control/match/binding.md:40
+msgid "\"The Answer: {}!\""
+msgstr "\"The Answer: {}!\""
+
+#: src/flow_control/match/binding.md:41
+msgid "// Match any other number.\n"
+msgstr "// それ以外の数値にマッチ。\n"
+
+#: src/flow_control/match/binding.md:42
+msgid "\"Not interesting... {}\""
+msgstr "\"Not interesting... {}\""
+
+#: src/flow_control/match/binding.md:43
+msgid "// Match anything else (`None` variant).\n"
+msgstr "// それ以外にマッチ（`None`の値）。\n"
+
+#: src/flow_control/match/binding.md:50
+msgid ""
+"[`functions`](../../fn.md), [`enums`](../../custom_types/enum.md) and "
+"[`Option`](../../std/option.md)"
+msgstr ""
+"[関数](../../fn.md), [列挙型](../../custom_types/enum.md), "
+"[`Option`](../../std/option.md)"
+
+#: src/flow_control/if_let.md:3
+msgid ""
+"For some use cases, when matching enums, `match` is awkward. For example:"
+msgstr "列挙型をマッチさせるとき、場合によっては`match`を使用すると不自然な書き方になってしまう場合があります。例えば"
+
+#: src/flow_control/if_let.md:6 src/flow_control/while_let.md:7
+#: src/flow_control/while_let.md:34
+msgid "// Make `optional` of type `Option<i32>`\n"
+msgstr "// `optional`という変数の型を`Option<i32>`に指定。\n"
+
+#: src/flow_control/if_let.md:11
+msgid "\"This is a really long string and `{:?}`\""
+msgstr "\"This is a really long string and `{:?}`\""
+
+#: src/flow_control/if_let.md:12
+msgid ""
+"// ^ Needed 2 indentations just so we could destructure\n"
+"        // `i` from the option.\n"
+msgstr ""
+"// ^ `i`をOption型からデストラクトするためだけに\n"
+"        // インデントが一つ増えてしまっている。\n"
+
+#: src/flow_control/if_let.md:16
+msgid ""
+"// ^ Required because `match` is exhaustive. Doesn't it seem\n"
+"    // like wasted space?\n"
+msgstr ""
+"// ^ `match`は全てのパターンに対して網羅的でなくてはならないので必要。\n"
+"    // 冗長に見えませんか？\n"
+
+#: src/flow_control/if_let.md:22
+msgid ""
+"`if let` is cleaner for this use case and in addition allows various failure "
+"options to be specified:"
+msgstr "この場合は`if let`を用いたほうが美しく、失敗時の処理も柔軟に行うことができます。"
+
+#: src/flow_control/if_let.md:27
+msgid "// All have type `Option<i32>`\n"
+msgstr "// 全て`Option<i32>`型\n"
+
+#: src/flow_control/if_let.md:32
+msgid ""
+"// The `if let` construct reads: \"if `let` destructures `number` into\n"
+"    // `Some(i)`, evaluate the block (`{}`).\n"
+msgstr ""
+"// `if let`文は以下と同じ意味。\n"
+"    // もしletがnumberをデストラクトした結果が`Some(i)`になるならば\n"
+"    // ブロック内（`{}`）を実行します。\n"
+
+#: src/flow_control/if_let.md:35 src/flow_control/if_let.md:40
+#: src/flow_control/if_let.md:50
+msgid "\"Matched {:?}!\""
+msgstr "\"Matched {:?}!\""
+
+#: src/flow_control/if_let.md:38
+msgid "// If you need to specify a failure, use an else:\n"
+msgstr ""
+"// デストラクトした結果が`Some()`にならない場合の処理を明示したい場合、\n"
+"    // `else`を使用します。\n"
+
+#: src/flow_control/if_let.md:42
+msgid "// Destructure failed. Change to the failure case.\n"
+msgstr "// デストラクト失敗の場合。このブロック内を実行。\n"
+
+#: src/flow_control/if_let.md:43 src/flow_control/if_let.md:54
+msgid "\"Didn't match a number. Let's go with a letter!\""
+msgstr "\"Didn't match a number. Let's go with a letter!\""
+
+#: src/flow_control/if_let.md:46
+msgid "// Provide an altered failing condition.\n"
+msgstr "// デストラクト失敗時の処理を更に分岐させることもできます。\n"
+
+#: src/flow_control/if_let.md:51
+msgid ""
+"// Destructure failed. Evaluate an `else if` condition to see if the\n"
+"    // alternate failure branch should be taken:\n"
+msgstr "// デストラクト失敗。`else if`を評価し、処理をさらに分岐させます。\n"
+
+#: src/flow_control/if_let.md:56
+msgid "// The condition evaluated false. This branch is the default:\n"
+msgstr "// 今回は`else if`の評価がfalseなので、このブロック内がデフォルト。\n"
+
+#: src/flow_control/if_let.md:57
+msgid "\"I don't like letters. Let's go with an emoticon :)!\""
+msgstr "\"I don't like letters. Let's go with an emoticon :)!\""
+
+#: src/flow_control/if_let.md:62
+msgid "In the same way, `if let` can be used to match any enum value:"
+msgstr "同様に`if let`は任意の列挙型のマッチに使えます。"
+
+#: src/flow_control/if_let.md:65
+msgid "// Our example enum\n"
+msgstr "// 列挙型の例\n"
+
+#: src/flow_control/if_let.md:73
+msgid "// Create example variables\n"
+msgstr "// 変数の作成\n"
+
+#: src/flow_control/if_let.md:78 src/flow_control/if_let.md:114
+msgid "// Variable a matches Foo::Bar\n"
+msgstr "// Foo::Barにマッチする変数\n"
+
+#: src/flow_control/if_let.md:80 src/flow_control/if_let.md:117
+msgid "\"a is foobar\""
+msgstr "\"a is foobar\""
+
+#: src/flow_control/if_let.md:83
+msgid ""
+"// Variable b does not match Foo::Bar\n"
+"    // So this will print nothing\n"
+msgstr "// 変数bはFoo::Barにマッチしないので出力されません。\n"
+
+#: src/flow_control/if_let.md:86
+msgid "\"b is foobar\""
+msgstr "\"b is foobar\""
+
+#: src/flow_control/if_let.md:89
+msgid ""
+"// Variable c matches Foo::Qux which has a value\n"
+"    // Similar to Some() in the previous example\n"
+msgstr ""
+"// 変数cはFoo::Quxにマッチしつつ値を取り出せます。\n"
+"    // これはSome()と同様です。\n"
+
+#: src/flow_control/if_let.md:92
+msgid "\"c is {}\""
+msgstr "\"c is {}\""
+
+#: src/flow_control/if_let.md:95
+msgid "// Binding also works with `if let`\n"
+msgstr "// 束縛も可能です。\n"
+
+#: src/flow_control/if_let.md:97
+msgid "\"c is one hundred\""
+msgstr "\"c is one hundred\""
+
+#: src/flow_control/if_let.md:102
+msgid ""
+"Another benefit is that `if let` allows us to match non-parameterized enum "
+"variants. This is true even in cases where the enum doesn't implement or "
+"derive `PartialEq`. In such cases `if Foo::Bar == a` would fail to compile, "
+"because instances of the enum cannot be equated, however `if let` will "
+"continue to work."
+msgstr ""
+"もう一つのメリットは`if let`がパラメータを持たない列挙型にも使えることです。"
+"列挙型が`PartialEq`を実装または導出していなくても問題ありません。"
+"その場合、列挙型のインスタンスは比較できないので`if Foo::Bar == a`はコンパイルエラーとなりますが、"
+"`if let`は引き続き使えます。"
+
+#: src/flow_control/if_let.md:104
+msgid "Would you like a challenge? Fix the following example to use `if let`:"
+msgstr "試してみましょう。以下の例を`if let`を使って直してみてください。"
+
+#: src/flow_control/if_let.md:107
+msgid ""
+"// This enum purposely neither implements nor derives PartialEq.\n"
+"// That is why comparing Foo::Bar == a fails below.\n"
+msgstr ""
+"// この列挙型はPartialEqを実装も導出もしていません。\n"
+"// そのためFoo::Bar == aはエラーとなります。\n"
+
+#: src/flow_control/if_let.md:116
+msgid "// ^-- this causes a compile-time error. Use `if let` instead.\n"
+msgstr "// ^-- ここでコンパイルエラー。`if let`を使ってみましょう。\n"
+
+#: src/flow_control/if_let.md:124
+msgid ""
+"[`enum`](../custom_types/enum.md), [`Option`](../std/option.md), and the "
+"[RFC](https://github.com/rust-lang/rfcs/pull/160)"
+msgstr ""
+"[列挙型](../custom_types/enum.md), [`Option`](../std/option.md), "
+"[RFC](https://github.com/rust-lang/rfcs/pull/160)"
+
+#: src/flow_control/let_else.md:4
+msgid "🛈 stable since: rust 1.65"
+msgstr "🛈 Rust 1.65で安定化。"
+
+#: src/flow_control/let_else.md:6
+msgid ""
+"🛈 you can target specific edition by compiling like this `rustc --"
+"edition=2021 main.rs`"
+msgstr ""
+"🛈 エディションを指定するには`rustc --edition=2021 main.rs`のようにします。"
+
+#: src/flow_control/let_else.md:10
+msgid ""
+"With `let`\\-`else`, a refutable pattern can match and bind variables in the "
+"surrounding scope like a normal `let`, or else diverge (e.g. `break`, "
+"`return`, `panic!`) when the pattern doesn't match."
+msgstr ""
+"`let`\\-`else`を使うと反駁できるパターンにマッチさせつつ、通常の`let`のように変数束縛することができます。"
+"マッチしなかった場合は（`break`、`return`、`panic!`のように）処理を分岐させます。"
+
+#: src/flow_control/let_else.md:18 src/flow_control/let_else.md:41
+#: src/std/str.md:41
+msgid "' '"
+msgstr "' '"
+
+#: src/flow_control/let_else.md:20 src/flow_control/let_else.md:44
+msgid "\"Can't segment count item pair: '{s}'\""
+msgstr "\"Can't segment count item pair: '{s}'\""
+
+#: src/flow_control/let_else.md:23 src/flow_control/let_else.md:49
+msgid "\"Can't parse integer: '{count_str}'\""
+msgstr "\"Can't parse integer: '{count_str}'\""
+
+#: src/flow_control/let_else.md:29 src/flow_control/let_else.md:54
+msgid "\"3 chairs\""
+msgstr "\"3 chairs\""
+
+#: src/flow_control/let_else.md:29 src/flow_control/let_else.md:54
+msgid "\"chairs\""
+msgstr "\"chairs\""
+
+#: src/flow_control/let_else.md:33
+msgid ""
+"The scope of name bindings is the main thing that makes this different from "
+"`match` or `if let`\\-`else` expressions. You could previously approximate "
+"these patterns with an unfortunate bit of repetition and an outer `let`:"
+msgstr ""
+"束縛した変数名のスコープが`match`や`if let`\\-`else`式との主な違いです。"
+"`match`や`if let`\\-`else`でも似たようなことができますが、"
+"残念ながらコードの繰り返しや追加の`let`が必要になってしまいます。"
+
+#: src/flow_control/let_else.md:59
+msgid ""
+"[option](../std/option.md), [match](./match.md), [if let](./if_let.md) and "
+"the [let-else RFC](https://rust-lang.github.io/rfcs/3137-let-else.html)."
+msgstr ""
+"[Option](../std/option.md), [match](./match.md), [if let](./if_let.md), "
+"[let-else RFC](https://rust-lang.github.io/rfcs/3137-let-else.html)."
+
+#: src/flow_control/while_let.md:3
+msgid ""
+"Similar to `if let`, `while let` can make awkward `match` sequences more "
+"tolerable. Consider the following sequence that increments `i`:"
+msgstr ""
+"`if let`と同様に、`while let`も不格好な`match`処理を多少マシにしてくれます。"
+"例えば、以下の`i`をインクリメントする処理を見てください。"
+
+#: src/flow_control/while_let.md:9
+msgid "// Repeatedly try this test.\n"
+msgstr "// 変数の照合を繰り返し行います。\n"
+
+#: src/flow_control/while_let.md:13
+msgid "// If `optional` destructures, evaluate the block.\n"
+msgstr "// もし`optional`のデストラクトに成功した場合、値に応じて処理を分岐。\n"
+
+#: src/flow_control/while_let.md:16 src/flow_control/while_let.md:41
+msgid "\"Greater than 9, quit!\""
+msgstr "\"Greater than 9, quit!\""
+
+#: src/flow_control/while_let.md:19 src/flow_control/while_let.md:44
+msgid "\"`i` is `{:?}`. Try again.\""
+msgstr "\"`i` is `{:?}`. Try again.\""
+
+#: src/flow_control/while_let.md:22
+msgid "// ^ Requires 3 indentations!\n"
+msgstr "// ^ 3つものインデントが必要。\n"
+
+#: src/flow_control/while_let.md:24
+msgid "// Quit the loop when the destructure fails:\n"
+msgstr "// デストラクトに失敗した場合、ループを脱出。\n"
+
+#: src/flow_control/while_let.md:26
+msgid "// ^ Why should this be required? There must be a better way!\n"
+msgstr "// ^ どうしてこんな行を書く必要が？もっと良い方法があるはずです！\n"
+
+#: src/flow_control/while_let.md:31
+msgid "Using `while let` makes this sequence much nicer:"
+msgstr "`while let`を使ってすっきり書くことができます。"
+
+#: src/flow_control/while_let.md:36
+msgid ""
+"// This reads: \"while `let` destructures `optional` into\n"
+"// `Some(i)`, evaluate the block (`{}`). Else `break`.\n"
+msgstr ""
+"// これは次のように読めます。「`let`が`optional`を`Some(i)`にデストラクト\n"
+"// している間はブロック内（`{}`）を評価せよ。さもなくば`break`せよ。」\n"
+
+#: src/flow_control/while_let.md:47
+msgid ""
+"// ^ Less rightward drift and doesn't require\n"
+"    // explicitly handling the failing case.\n"
+msgstr "// ^ インデントが少なく、デストラクト失敗時の処理を追加する必要がありません。\n"
+
+#: src/flow_control/while_let.md:49
+msgid ""
+"// ^ `if let` had additional optional `else`/`else if`\n"
+"// clauses. `while let` does not have these.\n"
+msgstr ""
+"// ^ `if let`の場合は`else`/`else if`句が一つ余分にありましたが、\n"
+"// `while let`では必要ありません。\n"
+
+#: src/flow_control/while_let.md:56
+msgid ""
+"[`enum`](../custom_types/enum.md), [`Option`](../std/option.md), and the "
+"[RFC](https://github.com/rust-lang/rfcs/pull/214)"
+msgstr ""
+"[列挙型](../custom_types/enum.md), [`Option`](../std/option.md), "
+"[RFC](https://github.com/rust-lang/rfcs/pull/214)"
+
+#: src/fn.md:3
+msgid ""
+"Functions are declared using the `fn` keyword. Its arguments are type "
+"annotated, just like variables, and, if the function returns a value, the "
+"return type must be specified after an arrow `->`."
+msgstr ""
+"関数は`fn`キーワードを用いて定義することができます。"
+"引数は変数と同様に型を指定する必要があり、もし関数が値を返すならば`->`の後にその型も指定する必要があります。"
+
+#: src/fn.md:7
+msgid ""
+"The final expression in the function will be used as return value. "
+"Alternatively, the `return` statement can be used to return a value earlier "
+"from within the function, even from inside loops or `if` statements."
+msgstr ""
+"関数内の最後の式が返り値となります。"
+"関数の途中で値を返したい場合は`return`文を使用します。"
+"ループの最中や`if`文の中からも値を返すことができます。"
+
+#: src/fn.md:11
+msgid "Let's rewrite FizzBuzz using functions!"
+msgstr "では、今度は関数を使ってFizzBuzz問題を解いてみましょう！"
+
+#: src/fn.md:14
+msgid ""
+"// Unlike C/C++, there's no restriction on the order of function "
+"definitions\n"
+msgstr "// C/C++とは違い、関数の定義を行う順番に制限はありません。\n"
+
+#: src/fn.md:16
+msgid "// We can use this function here, and define it somewhere later\n"
+msgstr "// ここで関数を使用し、後ほど定義してもかまいません。\n"
+
+#: src/fn.md:19
+msgid "// Function that returns a boolean value\n"
+msgstr "// ブーリアン型を返す関数\n"
+
+#: src/fn.md:22
+msgid "// Corner case, early return\n"
+msgstr "// 例外的な引数を受けた場合、早めに返します。\n"
+
+#: src/fn.md:27
+msgid "// This is an expression, the `return` keyword is not necessary here\n"
+msgstr "// これは式であり、`return`キーワードは必要ありません。\n"
+
+#: src/fn.md:30
+msgid ""
+"// Functions that \"don't\" return a value, actually return the unit type "
+"`()`\n"
+msgstr "// 値を「返さない」関数、実際にはユニット型（`()`）を返しています。\n"
+
+#: src/fn.md:43
+msgid ""
+"// When a function returns `()`, the return type can be omitted from the\n"
+"// signature\n"
+msgstr "// 関数が`()`を返すとき、返り値の型は省略できます。\n"
+
+#: src/fn/methods.md:1
+msgid "Associated functions & Methods"
+msgstr "関連関数とメソッド"
+
+#: src/fn/methods.md:3
+msgid ""
+"Some functions are connected to a particular type. These come in two forms: "
+"associated functions, and methods. Associated functions are functions that "
+"are defined on a type generally, while methods are associated functions that "
+"are called on a particular instance of a type."
+msgstr ""
+"関数には特定の型に紐づいたものがあります。これには関連関数とメソッドの2つの形式があります。"
+"メソッドは特定のインスタンスに関連付けて呼ばれる関数であるのに対し、関連関数は型全体に対して定義される関数です。"
+
+#: src/fn/methods.md:13
+msgid ""
+"// Implementation block, all `Point` associated functions & methods go in "
+"here\n"
+msgstr "// 実装のためのブロック。`Point`の持つ関連関数とメソッドを全て定義します。\n"
+
+#: src/fn/methods.md:16
+msgid ""
+"// This is an \"associated function\" because this function is associated "
+"with\n"
+"    // a particular type, that is, Point.\n"
+"    //\n"
+"    // Associated functions don't need to be called with an instance.\n"
+"    // These functions are generally used like constructors.\n"
+msgstr ""
+"// これは特定の型（すなわち Point）に関連した関数なので関連関数\n"
+"    //\n"
+"    // 関連関数はインスタンスからでなく呼び出すことができます。\n"
+"    // 以下のようにコンストラクタとしてよく使用されます。\n"
+
+#: src/fn/methods.md:25
+msgid "// Another associated function, taking two arguments:\n"
+msgstr "// 引数を2つ取る関連関数\n"
+
+#: src/fn/methods.md:37
+msgid ""
+"// This is a method\n"
+"    // `&self` is sugar for `self: &Self`, where `Self` is the type of the\n"
+"    // caller object. In this case `Self` = `Rectangle`\n"
+msgstr ""
+"// こちらはメソッド。`&self`は`self: &Self`の糖衣構文。\n"
+"    // `Self`は呼び出し元オブジェクトの型。この場合は`Rectangle`。\n"
+
+#: src/fn/methods.md:41
+msgid "// `self` gives access to the struct fields via the dot operator\n"
+msgstr "// `self`はドット演算子によって構造体のフィールドを参照できます。\n"
+
+#: src/fn/methods.md:45
+msgid ""
+"// `abs` is a `f64` method that returns the absolute value of the\n"
+"        // caller\n"
+msgstr "// `abs`は`f64`のメソッドで、呼び出し元の値の絶対値を返します。\n"
+
+#: src/fn/methods.md:57
+msgid ""
+"// This method requires the caller object to be mutable\n"
+"    // `&mut self` desugars to `self: &mut Self`\n"
+msgstr ""
+"// このメソッドは呼び出し元オブジェクトがミュータブルであることを\n"
+"    // 必要とします。`&mut self`は`self: &mut Self`の糖衣構文です。\n"
+
+#: src/fn/methods.md:67
+msgid "// `Pair` owns resources: two heap allocated integers\n"
+msgstr "// `Pair`はヒープ上の整数を2つ保持します。\n"
+
+#: src/fn/methods.md:72
+msgid ""
+"// This method \"consumes\" the resources of the caller object\n"
+"    // `self` desugars to `self: Self`\n"
+msgstr ""
+"// このメソッドは呼び出し元オブジェクトを「消費」します。\n"
+"    // `self`は`self: Self`の糖衣構文です。\n"
+
+#: src/fn/methods.md:75
+msgid "// Destructure `self`\n"
+msgstr "// `self`をデストラクト。\n"
+
+#: src/fn/methods.md:78
+msgid "\"Destroying Pair({}, {})\""
+msgstr "\"Destroying Pair({}, {})\""
+
+#: src/fn/methods.md:80
+msgid "// `first` and `second` go out of scope and get freed\n"
+msgstr "// `first`、`second`はスコープから抜け出すと同時に、解放されます。\n"
+
+#: src/fn/methods.md:86
+msgid "// Associated functions are called using double colons\n"
+msgstr "// 関連関数はコロンを2つ挟んで呼び出すことができます。\n"
+
+#: src/fn/methods.md:91
+msgid ""
+"// Methods are called using the dot operator\n"
+"    // Note that the first argument `&self` is implicitly passed, i.e.\n"
+"    // `rectangle.perimeter()` === `Rectangle::perimeter(&rectangle)`\n"
+msgstr ""
+"// メソッドはドット演算子を用いて呼び出されます。\n"
+"    // 最初の引数`&self`は明示せずに受け渡されていることに注目。つまり\n"
+"    // `rectangle.perimeter()` === `Rectangle::perimeter(&rectangle)`\n"
+
+#: src/fn/methods.md:94
+msgid "\"Rectangle perimeter: {}\""
+msgstr "\"Rectangle perimeter: {}\""
+
+#: src/fn/methods.md:95
+msgid "\"Rectangle area: {}\""
+msgstr "\"Rectangle area: {}\""
+
+#: src/fn/methods.md:102
+msgid ""
+"// Error! `rectangle` is immutable, but this method requires a mutable\n"
+"    // object\n"
+"    //rectangle.translate(1.0, 0.0);\n"
+"    // TODO ^ Try uncommenting this line\n"
+msgstr ""
+"// エラー！`rectangle`はイミュータブルですがこのメソッドは\n"
+"    // ミュータブルなオブジェクトを必要とします。\n"
+"    //rectangle.translate(1.0, 0.0);\n"
+"    // TODO ^ この行をアンコメントしてみましょう。\n"
+
+#: src/fn/methods.md:107
+msgid "// Okay! Mutable objects can call mutable methods\n"
+msgstr "// OK！ミュータブルなオブジェクトはミュータブルなメソッドを呼び出せます。\n"
+
+#: src/fn/methods.md:114
+msgid ""
+"// Error! Previous `destroy` call \"consumed\" `pair`\n"
+"    //pair.destroy();\n"
+"    // TODO ^ Try uncommenting this line\n"
+msgstr ""
+"// エラー！先ほどの`destroy`で`pair`はすでに消費されてしまっています。\n"
+"    //pair.destroy();\n"
+"    // TODO ^ この行をアンコメントしてみましょう。\n"
+
+#: src/fn/closures.md:3
+msgid ""
+"Closures are functions that can capture the enclosing environment. For "
+"example, a closure that captures the `x` variable:"
+msgstr ""
+"Rustにおけるクロージャは、その外側の環境を捕捉した関数のことです。"
+"例えば、次のコードは変数`x`を捕捉したクロージャです。"
+
+#: src/fn/closures.md:10
+msgid ""
+"The syntax and capabilities of closures make them very convenient for on the "
+"fly usage. Calling a closure is exactly like calling a function. However, "
+"both input and return types _can_ be inferred and input variable names "
+"_must_ be specified."
+msgstr ""
+"クロージャの構文や機能は、その場限りの用途で何かを作るのに便利です。"
+"クロージャの呼び出しは関数の呼び出しと全く同じです。"
+"しかし、入力の型と戻り値の型は推論させることができますが、入力変数の名前は必ず指定しなくてはなりません。"
+
+#: src/fn/closures.md:15
+msgid "Other characteristics of closures include:"
+msgstr "クロージャの他の特徴を以下に示します。"
+
+#: src/fn/closures.md:16
+msgid "using `||` instead of `()` around input variables."
+msgstr "入力変数を囲むのに、`()`の代わりに`||`を用います。"
+
+#: src/fn/closures.md:17
+msgid ""
+"optional body delimitation (`{}`) for a single line expression (mandatory "
+"otherwise)."
+msgstr "本体が単一の式の場合は、本体の区切り文字（`{}`）を省略できます。（それ以外の場合は必須です）"
+
+#: src/fn/closures.md:18
+msgid "the ability to capture the outer environment variables."
+msgstr "外側の環境にある変数を捕捉することができます。"
+
+#: src/fn/closures.md:24
+msgid ""
+"// A regular function can't refer to variables in the enclosing environment\n"
+"    //fn function(i: i32) -> i32 { i + outer_var }\n"
+"    // TODO: uncomment the line above and see the compiler error. The "
+"compiler\n"
+"    // suggests that we define a closure instead.\n"
+msgstr ""
+"// 通常の関数は周辺の環境の変数を参照できません。\n"
+"    //fn function(i: i32) -> i32 { i + outer_var }\n"
+"    // TODO: 上の行をアンコメントしてコンパイルエラーを見てみましょう。\n"
+"    // 代わりにクロージャを定義することをコンパイラが提案してくれます。\n"
+
+#: src/fn/closures.md:29
+msgid ""
+"// Closures are anonymous, here we are binding them to references.\n"
+"    // Annotation is identical to function annotation but is optional\n"
+"    // as are the `{}` wrapping the body. These nameless functions\n"
+"    // are assigned to appropriately named variables.\n"
+msgstr ""
+"// クロージャは匿名なので、参照に束縛して使います。\n"
+"    // 型アノテーションは、通常の関数と同様の方法で行えますが、必須ではありません。\n"
+"    // `{}`も必須ではありません。\n"
+"    // このように定義した無名関数を適切な名前の変数に代入します。\n"
+
+#: src/fn/closures.md:36
+msgid "// Call the closures.\n"
+msgstr "// クロージャを呼び出す。\n"
+
+#: src/fn/closures.md:37
+msgid "\"closure_annotated: {}\""
+msgstr "\"closure_annotated: {}\""
+
+#: src/fn/closures.md:38
+msgid "\"closure_inferred: {}\""
+msgstr "\"closure_inferred: {}\""
+
+#: src/fn/closures.md:39
+msgid ""
+"// Once closure's type has been inferred, it cannot be inferred again with "
+"another type.\n"
+"    //println!(\"cannot reuse closure_inferred with another type: {}\", "
+"closure_inferred(42i64));\n"
+"    // TODO: uncomment the line above and see the compiler error.\n"
+msgstr ""
+"// クロージャの型が一度推論されると、別の型にあらためて推論することはできません。\n"
+"    //println!(\"cannot reuse closure_inferred with another type: {}\", closure_inferred(42i64));\n"
+"    // TODO: 上の行をアンコメントしてコンパイルエラーを見てみましょう。\n"
+
+#: src/fn/closures.md:43
+msgid ""
+"// A closure taking no arguments which returns an `i32`.\n"
+"    // The return type is inferred.\n"
+msgstr ""
+"// 引数なしで`i32`を返すクロージャ。\n"
+"    // 戻り値の型は推論されます。\n"
+
+#: src/fn/closures.md:46
+msgid "\"closure returning one: {}\""
+msgstr "\"closure returning one: {}\""
+
+#: src/fn/closures/capture.md:3
+msgid ""
+"Closures are inherently flexible and will do what the functionality requires "
+"to make the closure work without annotation. This allows capturing to "
+"flexibly adapt to the use case, sometimes moving and sometimes borrowing. "
+"Closures can capture variables:"
+msgstr ""
+"クロージャはとてもフレキシブルに動作するように出来ています。"
+"クロージャにおいて型アノテーションをする必要が無いのは前述の仕組みのためですが、"
+"この仕組みのおかげでユースケースに応じて参照を取得したり値そのものを取得したりといった動作が可能になります。"
+"クロージャは外側の環境にある要素を、以下の形で取得することができます。"
+
+#: src/fn/closures/capture.md:8
+msgid "by reference: `&T`"
+msgstr "参照：`&T`"
+
+#: src/fn/closures/capture.md:9
+msgid "by mutable reference: `&mut T`"
+msgstr "ミュータブルな参照：`&mut T`"
+
+#: src/fn/closures/capture.md:10
+msgid "by value: `T`"
+msgstr "値そのもの：`T`"
+
+#: src/fn/closures/capture.md:12
+msgid ""
+"They preferentially capture variables by reference and only go lower when "
+"required."
+msgstr "クロージャは出来る限り参照を取得しようとし、その他2つは必要なときのみ取得します。"
+
+#: src/fn/closures/capture.md:19
+msgid "\"green\""
+msgstr "\"green\""
+
+#: src/fn/closures/capture.md:21
+msgid ""
+"// A closure to print `color` which immediately borrows (`&`) `color` and\n"
+"    // stores the borrow and closure in the `print` variable. It will "
+"remain\n"
+"    // borrowed until `print` is used the last time. \n"
+"    //\n"
+"    // `println!` only requires arguments by immutable reference so it "
+"doesn't\n"
+"    // impose anything more restrictive.\n"
+msgstr ""
+"// `color`を出力するためのクロージャ。\n"
+"    // これは`color`を借用（`&`）し、その借用とクロージャを`print`\n"
+"    // という名の変数に保持します。\n"
+"    // 借用は`print`がスコープから出るまで続きます。\n"
+"    //\n"
+"    // `println!`は参照を与えれば機能するので、\n"
+"    // これ以上なにかする必要はありません。\n"
+
+#: src/fn/closures/capture.md:27
+msgid "\"`color`: {}\""
+msgstr "\"`color`: {}\""
+
+#: src/fn/closures/capture.md:29
+msgid "// Call the closure using the borrow.\n"
+msgstr "// 借用を行ったクロージャを呼び出します。\n"
+
+#: src/fn/closures/capture.md:32
+msgid ""
+"// `color` can be borrowed immutably again, because the closure only holds\n"
+"    // an immutable reference to `color`. \n"
+msgstr ""
+"// `color`を再びイミュータブルで借用することができます。\n"
+"    // これはクロージャが`color`に対するイミュータブルな\n"
+"    // 参照しか保持しないためです。\n"
+
+#: src/fn/closures/capture.md:37
+msgid "// A move or reborrow is allowed after the final use of `print`\n"
+msgstr "// 最後に`print`を使用した後は移動や再借用が許可されます。\n"
+
+#: src/fn/closures/capture.md:42
+msgid ""
+"// A closure to increment `count` could take either `&mut count` or `count`\n"
+"    // but `&mut count` is less restrictive so it takes that. Immediately\n"
+"    // borrows `count`.\n"
+"    //\n"
+"    // A `mut` is required on `inc` because a `&mut` is stored inside. "
+"Thus,\n"
+"    // calling the closure mutates `count` which requires a `mut`.\n"
+msgstr ""
+"// `count`をインクリメントするためのクロージャ。`count`と`&mut count`\n"
+"    // の両方を取ることができますが、後者のほうが制限が少ないため、\n"
+"    // （訳注: `count`だと`&mut count`と違い、一度しか呼ぶことができない。）\n"
+"    // そちらを取ります。直後に`count`を借用します。\n"
+"    //\n"
+"    // `inc`には`mut`をつける必要があります。なぜならミュータブルな型が\n"
+"    // 中で使用されているからです。ミュータブルなクロージャは呼ぶたびに\n"
+"    // 内部変数を変更します。\n"
+
+#: src/fn/closures/capture.md:50
+msgid "\"`count`: {}\""
+msgstr "\"`count`: {}\""
+
+#: src/fn/closures/capture.md:53
+msgid "// Call the closure using a mutable borrow.\n"
+msgstr "// ミュータブルな借用を使ってクロージャを実行。\n"
+
+#: src/fn/closures/capture.md:56
+msgid ""
+"// The closure still mutably borrows `count` because it is called later.\n"
+"    // An attempt to reborrow will lead to an error.\n"
+"    // let _reborrow = &count; \n"
+"    // ^ TODO: try uncommenting this line.\n"
+msgstr ""
+"// クロージャは後で呼ばれるため、まだ `count` をミュータブルで借用しています。\n"
+"    // 再借用しようとするとエラーになります。\n"
+"    // let _reborrow = &count; \n"
+"    // ^ TODO: この行のコメントアウトを解除しましょう。\n"
+
+#: src/fn/closures/capture.md:62
+msgid ""
+"// The closure no longer needs to borrow `&mut count`. Therefore, it is\n"
+"    // possible to reborrow without an error\n"
+msgstr ""
+"// クロージャはもう`&mut count`を借用する必要がありません。\n"
+"    // なので、エラーを起こさず再借用することができます。\n"
+
+#: src/fn/closures/capture.md:67
+msgid "// A non-copy type.\n"
+msgstr "// コピー不可能な型\n"
+
+#: src/fn/closures/capture.md:70
+msgid ""
+"// `mem::drop` requires `T` so this must take by value. A copy type\n"
+"    // would copy into the closure leaving the original untouched.\n"
+"    // A non-copy must move and so `movable` immediately moves into\n"
+"    // the closure.\n"
+msgstr ""
+"// `mem::drop`は`T`（ジェネリック型）を取る必要があるため、このクロージャは\n"
+"    // 参照ではなく値を取ります。その場合、もしもコピー可能な値ならば、\n"
+"    // 元の値はそのままでコピーのみを取ります。\n"
+"    // 不可能ならば値そのものを移動させます。\n"
+
+#: src/fn/closures/capture.md:75
+msgid "\"`movable`: {:?}\""
+msgstr "\"`movable`: {:?}\""
+
+#: src/fn/closures/capture.md:79
+msgid "// `consume` consumes the variable so this can only be called once.\n"
+msgstr "// `consume`は変数を消費（開放）するため、一度しか呼び出すことができません。\n"
+
+#: src/fn/closures/capture.md:81
+msgid ""
+"// consume();\n"
+"    // ^ TODO: Try uncommenting this line.\n"
+msgstr ""
+"// consume();\n"
+"    // ^ TODO: この行のコメントアウトを解除しましょう。\n"
+
+#: src/fn/closures/capture.md:86
+msgid ""
+"Using `move` before vertical pipes forces closure to take ownership of "
+"captured variables:"
+msgstr "バーティカルパイプ（訳注：縦線記号`||`）の前に`move`を使用することで、キャプチャする変数の所有権を取ることをクロージャに強制します。"
+
+#: src/fn/closures/capture.md:91
+msgid "// `Vec` has non-copy semantics.\n"
+msgstr "// `Vec`はコピーセマンティクスではない。\n"
+
+#: src/fn/closures/capture.md:99
+msgid ""
+"// println!(\"There're {} elements in vec\", haystack.len());\n"
+"    // ^ Uncommenting above line will result in compile-time error\n"
+"    // because borrow checker doesn't allow re-using variable after it\n"
+"    // has been moved.\n"
+msgstr ""
+"// println!(\"There're {} elements in vec\", haystack.len());\n"
+"    // ^ 上の行のコメントアウトを解除すると、コンパイル時エラーになります。\n"
+"    // これは変数の所有権が移った後の再利用を借用チェッカーが許可しないからです。\n"
+
+#: src/fn/closures/capture.md:104
+msgid ""
+"// Removing `move` from closure's signature will cause closure\n"
+"    // to borrow _haystack_ variable immutably, hence _haystack_ is still\n"
+"    // available and uncommenting above line will not cause an error.\n"
+msgstr ""
+"// クロージャのシグネチャから`move`を削除すると、クロージャは\n"
+"    // _haystack_ 変数をイミュータブルで借用するようになります。\n"
+"    // そのため _haystack_ はまだ利用可能となり、上の行のコメントアウトを\n"
+"    // 解除してもエラーが発生しなくなります。\n"
+
+#: src/fn/closures/capture.md:112
+msgid ""
+"[`Box`](../../std/box.md) and [`std::mem::drop`](https://doc.rust-lang.org/"
+"std/mem/fn.drop.html)"
+msgstr ""
+"[`Box`](../../std/box.md), [`std::mem::drop`](https://doc.rust-lang.org/"
+"std/mem/fn.drop.html)"
+
+#: src/fn/closures/input_parameters.md:3
+msgid ""
+"While Rust chooses how to capture variables on the fly mostly without type "
+"annotation, this ambiguity is not allowed when writing functions. When "
+"taking a closure as an input parameter, the closure's complete type must be "
+"annotated using one of a few `traits`, and they're determined by what the "
+"closure does with captured value. In order of decreasing restriction, they "
+"are:"
+msgstr ""
+"Rustはたいていの場合、型アノテーションなしでも変数を捕捉する方法を臨機応変に選択してくれますが、関数を書く場合にはこの曖昧さは許されません。"
+"引数のパラメータとしてクロージャを取る場合、そのクロージャの完全な型はいくつかの`traits`の中の1つを使って明示されなければなりません。"
+"どれが使われるかは、捕捉された値でクロージャが何をするかによって決まります。"
+"制限の少ない順に並べると、下記の通りです。"
+
+#: src/fn/closures/input_parameters.md:10
+msgid "`Fn`: the closure uses the captured value by reference (`&T`)"
+msgstr "`Fn`：参照（`&T`）によって捕捉するクロージャ"
+
+#: src/fn/closures/input_parameters.md:11
+msgid ""
+"`FnMut`: the closure uses the captured value by mutable reference (`&mut T`)"
+msgstr "`FnMut`：ミュータブルな参照（`&mut T`）によって捕捉するクロージャ"
+
+#: src/fn/closures/input_parameters.md:12
+msgid "`FnOnce`: the closure uses the captured value by value (`T`)"
+msgstr "`FnOnce`：値（`T`）によって捕捉するクロージャ"
+
+#: src/fn/closures/input_parameters.md:14
+msgid ""
+"On a variable-by-variable basis, the compiler will capture variables in the "
+"least restrictive manner possible."
+msgstr "変数ごとに、コンパイラは可能な限り制約の少ない方法でその変数を捕捉します。"
+
+#: src/fn/closures/input_parameters.md:17
+msgid ""
+"For instance, consider a parameter annotated as `FnOnce`. This specifies "
+"that the closure _may_ capture by `&T`, `&mut T`, or `T`, but the compiler "
+"will ultimately choose based on how the captured variables are used in the "
+"closure."
+msgstr ""
+"例えば、`FnOnce`というアノテーションの付けられたパラメータを考えてみましょう。"
+"これはそのクロージャが`&T`、`&mut T`もしくは`T`の *どれか* で捕捉することを指定するものですが、"
+"コンパイラは捕捉した変数がそのクロージャの中でどのように使用されるかに基づき、"
+"最終的に捕捉する方法を選択することになります。"
+
+#: src/fn/closures/input_parameters.md:22
+msgid ""
+"This is because if a move is possible, then any type of borrow should also "
+"be possible. Note that the reverse is not true. If the parameter is "
+"annotated as `Fn`, then capturing variables by `&mut T` or `T` are not "
+"allowed. However, `&T` is allowed."
+msgstr ""
+"これは、もし移動が可能であれば、いずれの種類の借用であっても同様に可能だからです。"
+"その逆は正しくないことに注意してください。パラメータが`Fn`としてアノテーションされている場合、"
+"変数を`&mut T`や`T`で捕捉することは許可されません。"
+"しかし`&T`は許可されます。"
+
+#: src/fn/closures/input_parameters.md:27
+msgid ""
+"In the following example, try swapping the usage of `Fn`, `FnMut`, and "
+"`FnOnce` to see what happens:"
+msgstr "以下の例で、`Fn`、`FnMut`、および`FnOnce`を入れ替えて、何が起こるのかを見てみましょう。"
+
+#: src/fn/closures/input_parameters.md:31
+msgid ""
+"// A function which takes a closure as an argument and calls it.\n"
+"// <F> denotes that F is a \"Generic type parameter\"\n"
+msgstr ""
+"// クロージャを引数として取り、クロージャを呼び出す関数。\n"
+"// <F>はFが「ジェネリックな型パラメータ」であることを示します。\n"
+
+#: src/fn/closures/input_parameters.md:34
+msgid "// The closure takes no input and returns nothing.\n"
+msgstr "// クロージャには引数も返り値もありません。\n"
+
+#: src/fn/closures/input_parameters.md:36
+msgid "// ^ TODO: Try changing this to `Fn` or `FnMut`.\n"
+msgstr "// ^ TODO: ここを`Fn`あるいは`FnMut`に変えてみましょう。\n"
+
+#: src/fn/closures/input_parameters.md:40
+msgid "// A function which takes a closure and returns an `i32`.\n"
+msgstr "// クロージャを引数に取り、`i32`を返す関数\n"
+
+#: src/fn/closures/input_parameters.md:43
+msgid "// The closure takes an `i32` and returns an `i32`.\n"
+msgstr "// このクロージャは引数、返り値ともに`i32`。\n"
+
+#: src/fn/closures/input_parameters.md:53
+msgid ""
+"// A non-copy type.\n"
+"    // `to_owned` creates owned data from borrowed one\n"
+msgstr "// コピーではなくmoveが起きる型\n"
+
+#: src/fn/closures/input_parameters.md:55
+msgid "\"goodbye\""
+msgstr "\"goodbye\""
+
+#: src/fn/closures/input_parameters.md:57
+msgid ""
+"// Capture 2 variables: `greeting` by reference and\n"
+"    // `farewell` by value.\n"
+msgstr ""
+"// 変数を2つ捕捉。`greeting`は参照を、\n"
+"    // `farewell`は値をそれぞれ捕捉します。\n"
+
+#: src/fn/closures/input_parameters.md:60
+msgid "// `greeting` is by reference: requires `Fn`.\n"
+msgstr "// `greeting`は参照なので、`Fn`が必要です。\n"
+
+#: src/fn/closures/input_parameters.md:61
+msgid "\"I said {}.\""
+msgstr "\"I said {}.\""
+
+#: src/fn/closures/input_parameters.md:63
+msgid ""
+"// Mutation forces `farewell` to be captured by\n"
+"        // mutable reference. Now requires `FnMut`.\n"
+msgstr ""
+"// `farewell`の値を変更するので、この時点で`FnMut`\n"
+"        // が必要になります。\n"
+
+#: src/fn/closures/input_parameters.md:65
+msgid "\"!!!\""
+msgstr "\"!!!\""
+
+#: src/fn/closures/input_parameters.md:66
+msgid "\"Then I screamed {}.\""
+msgstr "\"Then I screamed {}.\""
+
+#: src/fn/closures/input_parameters.md:67
+msgid "\"Now I can sleep. zzzzz\""
+msgstr "\"Now I can sleep. zzzzz\""
+
+#: src/fn/closures/input_parameters.md:69
+msgid ""
+"// Manually calling drop forces `farewell` to\n"
+"        // be captured by value. Now requires `FnOnce`.\n"
+msgstr ""
+"// `mem::drop`を明示的に呼ぶと`farewell`が値で\n"
+"        // 捕捉される必要性が発生します。よって`FnOnce`が必要になります。\n"
+
+#: src/fn/closures/input_parameters.md:74
+msgid "// Call the function which applies the closure.\n"
+msgstr "// クロージャを適用する関数を実行。\n"
+
+#: src/fn/closures/input_parameters.md:77
+msgid "// `double` satisfies `apply_to_3`'s trait bound\n"
+msgstr "// `double`は`apply_to_3`のトレイト境界を満たす。\n"
+
+#: src/fn/closures/input_parameters.md:80
+msgid "\"3 doubled: {}\""
+msgstr "\"3 doubled: {}\""
+
+#: src/fn/closures/input_parameters.md:86
+msgid ""
+"[`std::mem::drop`](https://doc.rust-lang.org/std/mem/fn.drop.html), [`Fn`]"
+"(https://doc.rust-lang.org/std/ops/trait.Fn.html), [`FnMut`](https://doc."
+"rust-lang.org/std/ops/trait.FnMut.html), [Generics](../../generics.md), "
+"[where](../../generics/where.md) and [`FnOnce`](https://doc.rust-lang.org/"
+"std/ops/trait.FnOnce.html)"
+msgstr ""
+"[`std::mem::drop`](https://doc.rust-lang.org/std/mem/fn.drop.html), [`Fn`]"
+"(https://doc.rust-lang.org/std/ops/trait.Fn.html), [`FnMut`](https://doc."
+"rust-lang.org/std/ops/trait.FnMut.html), [ジェネリクス](../../generics.md), "
+"[where](../../generics/where.md), [`FnOnce`](https://doc.rust-lang.org/"
+"std/ops/trait.FnOnce.html)"
+
+#: src/fn/closures/anonymity.md:3
+msgid ""
+"Closures succinctly capture variables from enclosing scopes. Does this have "
+"any consequences? It surely does. Observe how using a closure as a function "
+"parameter requires [generics](../../generics.md), which is necessary because "
+"of how they are defined:"
+msgstr ""
+"クロージャが周辺の環境から変数を取得するやり方は非常に明瞭です。何か注意すべき点はあるのでしょうか？"
+"もちろんです。関数内でクロージャを使う場合、[ジェネリクス](../../generics.md)を使用する必要があります。詳しく見ていきましょう。"
+
+#: src/fn/closures/anonymity.md:9
+msgid "// `F` must be generic.\n"
+msgstr "// `F` はジェネリック型でなくてはなりません。\n"
+
+#: src/fn/closures/anonymity.md:16
+msgid ""
+"When a closure is defined, the compiler implicitly creates a new anonymous "
+"structure to store the captured variables inside, meanwhile implementing the "
+"functionality via one of the `traits`: `Fn`, `FnMut`, or `FnOnce` for this "
+"unknown type. This type is assigned to the variable which is stored until "
+"calling."
+msgstr ""
+"クロージャが定義されると、コンパイラは裏側で、無名の構造体を作り、"
+"そこにクロージャによって使用される外側の変数を入れます。"
+"同時に`Fn`、`FnMut`、`FnOnce`という名のトレイトのいずれか一つを介して"
+"この構造体に関数としての機能を実装し、実際に呼び出されるまで待ちます。"
+
+#: src/fn/closures/anonymity.md:22
+msgid ""
+"Since this new type is of unknown type, any usage in a function will require "
+"generics. However, an unbounded type parameter `<T>` would still be "
+"ambiguous and not be allowed. Thus, bounding by one of the `traits`: `Fn`, "
+"`FnMut`, or `FnOnce` (which it implements) is sufficient to specify its type."
+msgstr ""
+"この無名構造体は型が未指定なため、関数を実行する際にはジェネリクスが必要とされます。"
+"とはいえ、`<T>`で指定するだけでは、まだ曖昧です。"
+"（訳注：`&self`、`&mut self`、`self`のいずれをとるのかがわからないため）"
+"そのため、`Fn`、`FnMut`、`FnOnce`のいずれか一つを実装することで対応しています。"
+
+#: src/fn/closures/anonymity.md:28
+msgid ""
+"// `F` must implement `Fn` for a closure which takes no\n"
+"// inputs and returns nothing - exactly what is required\n"
+"// for `print`.\n"
+msgstr ""
+"// `F`は引数と戻り値を持たないクロージャ`Fn`を実装していなくてはなりません。\n"
+"// これはまさに`print`に必要とされるものです。\n"
+
+#: src/fn/closures/anonymity.md:39
+msgid ""
+"// Capture `x` into an anonymous type and implement\n"
+"    // `Fn` for it. Store it in `print`.\n"
+msgstr ""
+"// `x`を無名の構造体に入れ、それに対し`Fn`を実装します。\n"
+"    // （訳注: ここでは`Fn`は`fn Fn(&self) -> {println!(\"{}\", &self)}`）\n"
+"    // その構造体を`print`に代入します。\n"
+
+#: src/fn/closures/anonymity.md:49
+msgid ""
+"[A thorough analysis](https://huonw.github.io/blog/2015/05/finding-closure-"
+"in-rust/), [`Fn`](https://doc.rust-lang.org/std/ops/trait.Fn.html), [`FnMut`]"
+"(https://doc.rust-lang.org/std/ops/trait.FnMut.html), and [`FnOnce`](https://"
+"doc.rust-lang.org/std/ops/trait.FnOnce.html)"
+msgstr ""
+"[徹底解説](https://huonw.github.io/blog/2015/05/finding-closure-"
+"in-rust/), [`Fn`](https://doc.rust-lang.org/std/ops/trait.Fn.html), [`FnMut`]"
+"(https://doc.rust-lang.org/std/ops/trait.FnMut.html), [`FnOnce`](https://"
+"doc.rust-lang.org/std/ops/trait.FnOnce.html)"
+
+#: src/fn/closures/input_functions.md:3
+msgid ""
+"Since closures may be used as arguments, you might wonder if the same can be "
+"said about functions. And indeed they can! If you declare a function that "
+"takes a closure as parameter, then any function that satisfies the trait "
+"bound of that closure can be passed as a parameter."
+msgstr ""
+"これまで、クロージャを引数として渡せることを見てきました。すると次の疑問が浮かんできます。"
+"「クロージャではない普通の関数を引数として渡すことは可能なのだろうか？」"
+"可能です！もしパラメータとしてクロージャを取る関数を定義すれば、"
+"そのクロージャのトレイト境界を満たす任意の関数をパラメータとして渡すことができます。"
+
+#: src/fn/closures/input_functions.md:9
+msgid ""
+"// Define a function which takes a generic `F` argument\n"
+"// bounded by `Fn`, and calls it\n"
+msgstr "// 関数を引数として取り、即座に実行する関数を定義。\n"
+
+#: src/fn/closures/input_functions.md:14
+msgid "// Define a wrapper function satisfying the `Fn` bound\n"
+msgstr "// `Fn`境界を満たすラッパ関数を定義。\n"
+
+#: src/fn/closures/input_functions.md:17
+msgid "\"I'm a function!\""
+msgstr "\"I'm a function!\""
+
+#: src/fn/closures/input_functions.md:21
+msgid "// Define a closure satisfying the `Fn` bound\n"
+msgstr "// `Fn`境界を満たすクロージャを定義。\n"
+
+#: src/fn/closures/input_functions.md:22
+msgid "\"I'm a closure!\""
+msgstr "\"I'm a closure!\""
+
+#: src/fn/closures/input_functions.md:29
+msgid ""
+"As an additional note, the `Fn`, `FnMut`, and `FnOnce` `traits` dictate how "
+"a closure captures variables from the enclosing scope."
+msgstr "クロージャによる変数の捕捉がどのように行われているかを詳しく見たいときは`Fn`、`FnMut`、`FnOnce`を参照してください。"
+
+#: src/fn/closures/input_functions.md:34
+msgid ""
+"[`Fn`](https://doc.rust-lang.org/std/ops/trait.Fn.html), [`FnMut`](https://"
+"doc.rust-lang.org/std/ops/trait.FnMut.html), and [`FnOnce`](https://doc.rust-"
+"lang.org/std/ops/trait.FnOnce.html)"
+msgstr ""
+"[`Fn`](https://doc.rust-lang.org/std/ops/trait.Fn.html), [`FnMut`](https://"
+"doc.rust-lang.org/std/ops/trait.FnMut.html), [`FnOnce`](https://doc.rust-"
+"lang.org/std/ops/trait.FnOnce.html)"
+
+#: src/fn/closures/output_parameters.md:3
+msgid ""
+"Closures as input parameters are possible, so returning closures as output "
+"parameters should also be possible. However, anonymous closure types are, by "
+"definition, unknown, so we have to use `impl Trait` to return them."
+msgstr ""
+"クロージャを引数のパラメータとして用いることができるのと同様に、"
+"クロージャを戻り値として返すことも可能です。"
+"しかし無名のクロージャの型はその定義上、不明であるため、"
+"クロージャを返すためには`impl Trait`を使用する必要があります。"
+
+#: src/fn/closures/output_parameters.md:8
+msgid "The valid traits for returning a closure are:"
+msgstr "クロージャを返すために有効なトレイトは下記の通りです。"
+
+#: src/fn/closures/output_parameters.md:10
+msgid "`Fn`"
+msgstr "`Fn`"
+
+#: src/fn/closures/output_parameters.md:11
+msgid "`FnMut`"
+msgstr "`FnMut`"
+
+#: src/fn/closures/output_parameters.md:12
+msgid "`FnOnce`"
+msgstr "`FnOnce`"
+
+#: src/fn/closures/output_parameters.md:14
+msgid ""
+"Beyond this, the `move` keyword must be used, which signals that all "
+"captures occur by value. This is required because any captures by reference "
+"would be dropped as soon as the function exited, leaving invalid references "
+"in the closure."
+msgstr ""
+"更に、`move`というキーワードを使用し、全ての捕捉が値でおこなわれることを明示しなければなりません。"
+"これは、関数を抜けると同時に参照による捕捉がドロップされ、無効な参照がクロージャに残ってしまうのを防ぐためです。"
+
+#: src/fn/closures/output_parameters.md:21
+msgid "\"Fn\""
+msgstr "\"Fn\""
+
+#: src/fn/closures/output_parameters.md:23
+#: src/fn/closures/output_parameters.md:29
+#: src/fn/closures/output_parameters.md:35
+msgid "\"This is a: {}\""
+msgstr "\"This is a: {}\""
+
+#: src/fn/closures/output_parameters.md:27
+msgid "\"FnMut\""
+msgstr "\"FnMut\""
+
+#: src/fn/closures/output_parameters.md:33
+msgid "\"FnOnce\""
+msgstr "\"FnOnce\""
+
+#: src/fn/closures/output_parameters.md:51
+msgid ""
+"[`Fn`](https://doc.rust-lang.org/std/ops/trait.Fn.html), [`FnMut`](https://"
+"doc.rust-lang.org/std/ops/trait.FnMut.html), [Generics](../../generics.md) "
+"and [impl Trait](../../trait/impl_trait.md)."
+msgstr ""
+"[`Fn`](https://doc.rust-lang.org/std/ops/trait.Fn.html), [`FnMut`](https://"
+"doc.rust-lang.org/std/ops/trait.FnMut.html), [ジェネリクス](../../generics.md), "
+"[impl Trait](../../trait/impl_trait.md)."
+
+#: src/fn/closures/closure_examples.md:3
+msgid ""
+"This section contains a few examples of using closures from the `std` "
+"library."
+msgstr "この節では`std`ライブラリを用いて、クロージャの利用例を幾つかお見せします。"
+
+#: src/fn/closures/closure_examples/iter_any.md:3
+msgid ""
+"`Iterator::any` is a function which when passed an iterator, will return "
+"`true` if any element satisfies the predicate. Otherwise `false`. Its "
+"signature:"
+msgstr ""
+"`iterator::any`は、イテレータ内に一つでも条件を満たす要素があれば、"
+"`true`を返し、さもなくば`false`を返すイテレータです。以下がそのシグネチャです"
+
+#: src/fn/closures/closure_examples/iter_any.md:9
+#: src/fn/closures/closure_examples/iter_find.md:9
+msgid "// The type being iterated over.\n"
+msgstr "// イテレートされる値の型\n"
+
+#: src/fn/closures/closure_examples/iter_any.md:12
+msgid ""
+"// `any` takes `&mut self` meaning the caller may be borrowed\n"
+"    // and modified, but not consumed.\n"
+msgstr ""
+"// `any`は`&mut self`を取るため、イテレータを呼び出した値を借用し\n"
+"    // 変更しますが、消費することはありません。\n"
+
+#: src/fn/closures/closure_examples/iter_any.md:15
+msgid ""
+"// `FnMut` meaning any captured variable may at most be\n"
+"        // modified, not consumed. `Self::Item` states it takes\n"
+"        // arguments to the closure by value.\n"
+msgstr ""
+"// `FnMut`はクロージャによって捕捉される変数が変更される\n"
+"        // 事はあっても消費されることはないということを示します。\n"
+"        // `Self::Item`はクロージャが変数を値として取ることを示します。\n"
+
+#: src/fn/closures/closure_examples/iter_any.md:27
+msgid "// `iter()` for vecs yields `&i32`. Destructure to `i32`.\n"
+msgstr "// ベクタ型に対する`iter()`は`&i32`を生成するので、`i32`へとデストラクト。\n"
+
+#: src/fn/closures/closure_examples/iter_any.md:28
+msgid "\"2 in vec1: {}\""
+msgstr "\"2 in vec1: {}\""
+
+#: src/fn/closures/closure_examples/iter_any.md:29
+msgid "// `into_iter()` for vecs yields `i32`. No destructuring required.\n"
+msgstr "// `into_iter()`の場合は`i32`を生成するので、デストラクトは必要ありません。\n"
+
+#: src/fn/closures/closure_examples/iter_any.md:30
+msgid "\"2 in vec2: {}\""
+msgstr "\"2 in vec2: {}\""
+
+#: src/fn/closures/closure_examples/iter_any.md:32
+msgid ""
+"// `iter()` only borrows `vec1` and its elements, so they can be used again\n"
+msgstr "// `iter()`は`vec1`とその要素を借用するだけなので、再び利用できます。\n"
+
+#: src/fn/closures/closure_examples/iter_any.md:33
+msgid "\"vec1 len: {}\""
+msgstr "\"vec1 len: {}\""
+
+#: src/fn/closures/closure_examples/iter_any.md:34
+msgid "\"First element of vec1 is: {}\""
+msgstr "\"First element of vec1 is: {}\""
+
+#: src/fn/closures/closure_examples/iter_any.md:35
+msgid ""
+"// `into_iter()` does move `vec2` and its elements, so they cannot be used "
+"again\n"
+"    // println!(\"First element of vec2 is: {}\", vec2[0]);\n"
+"    // println!(\"vec2 len: {}\", vec2.len());\n"
+"    // TODO: uncomment two lines above and see compiler errors.\n"
+msgstr ""
+"// `into_iter()`は`vec2`とその要素をムーブするので、再利用できません。\n"
+"    // println!(\"First element of vec2 is: {}\", vec2[0]);\n"
+"    // println!(\"vec2 len: {}\", vec2.len());\n"
+"    // TODO: 上の2行をアンコメントしてコンパイルエラーを確認しましょう。\n"
+
+#: src/fn/closures/closure_examples/iter_any.md:43
+msgid "// `iter()` for arrays yields `&i32`.\n"
+msgstr "// 配列に対する`iter()`は`&i32`を生成します。\n"
+
+#: src/fn/closures/closure_examples/iter_any.md:44
+msgid "\"2 in array1: {}\""
+msgstr "\"2 in array1: {}\""
+
+#: src/fn/closures/closure_examples/iter_any.md:45
+msgid "// `into_iter()` for arrays yields `i32`.\n"
+msgstr "// 配列に`into_iter()`を使うと`&i32`を生成します。\n"
+
+#: src/fn/closures/closure_examples/iter_any.md:46
+msgid "\"2 in array2: {}\""
+msgstr "\"2 in array2: {}\""
+
+#: src/fn/closures/closure_examples/iter_any.md:52
+msgid ""
+"[`std::iter::Iterator::any`](https://doc.rust-lang.org/std/iter/trait."
+"Iterator.html#method.any)"
+msgstr ""
+"[`std::iter::Iterator::any`](https://doc.rust-lang.org/std/iter/trait."
+"Iterator.html#method.any)"
+
+#: src/fn/closures/closure_examples/iter_find.md:3
+msgid ""
+"`Iterator::find` is a function which iterates over an iterator and searches "
+"for the  first value which satisfies some condition. If none of the values "
+"satisfy the  condition, it returns `None`. Its signature:"
+msgstr ""
+"`Iterator::find`はイテレータを辿る関数で、条件を満たす最初の値を探します。"
+"もし条件を満たす値がなければ`None`を返します。型シグネチャは以下のようになります。"
+
+#: src/fn/closures/closure_examples/iter_find.md:12
+msgid ""
+"// `find` takes `&mut self` meaning the caller may be borrowed\n"
+"    // and modified, but not consumed.\n"
+msgstr ""
+"// `find`は`&mut self`を取るため、イテレータを呼び出した値を借用し\n"
+"    // 変更しますが、消費することはありません。\n"
+
+#: src/fn/closures/closure_examples/iter_find.md:15
+msgid ""
+"// `FnMut` meaning any captured variable may at most be\n"
+"        // modified, not consumed. `&Self::Item` states it takes\n"
+"        // arguments to the closure by reference.\n"
+msgstr ""
+"// `FnMut`はクロージャによって捕捉される変数が変更される\n"
+"        // 事はあっても消費されることはないということを示します。\n"
+"        // `&Self::Item`はクロージャが変数を参照として取ることを示します。\n"
+
+#: src/fn/closures/closure_examples/iter_find.md:27
+msgid "// `iter()` for vecs yields `&i32`.\n"
+msgstr "// ベクタ型に対する`iter`は`&i32`を生成します。\n"
+
+#: src/fn/closures/closure_examples/iter_find.md:29
+msgid "// `into_iter()` for vecs yields `i32`.\n"
+msgstr "// `inter_iter()`の場合は`i32`を生成します。\n"
+
+#: src/fn/closures/closure_examples/iter_find.md:32
+msgid ""
+"// `iter()` for vecs yields `&i32`, and we want to reference one of its\n"
+"    // items, so we have to destructure `&&i32` to `i32`\n"
+msgstr ""
+"// `iter()`は`&i32`を生成し、ここではその参照が必要なので\n"
+"    // `&&i32`を`i32`へとデストラクトします。\n"
+
+#: src/fn/closures/closure_examples/iter_find.md:34
+msgid "\"Find 2 in vec1: {:?}\""
+msgstr "\"Find 2 in vec1: {:?}\""
+
+#: src/fn/closures/closure_examples/iter_find.md:35
+msgid ""
+"// `into_iter()` for vecs yields `i32`, and we want to reference one of\n"
+"    // its items, so we have to destructure `&i32` to `i32`\n"
+msgstr ""
+"// `into_iter()`は`i32`を生成し、ここではその参照が必要なので\n"
+"    // `&i32`を`i32`へとデストラクトします。\n"
+
+#: src/fn/closures/closure_examples/iter_find.md:37
+msgid "\"Find 2 in vec2: {:?}\""
+msgstr "\"Find 2 in vec2: {:?}\""
+
+#: src/fn/closures/closure_examples/iter_find.md:42
+msgid "// `iter()` for arrays yields `&&i32`\n"
+msgstr "// 配列に対する`iter()`も`&i32`を生成します。\n"
+
+#: src/fn/closures/closure_examples/iter_find.md:43
+msgid "\"Find 2 in array1: {:?}\""
+msgstr "\"Find 2 in array1: {:?}\""
+
+#: src/fn/closures/closure_examples/iter_find.md:44
+msgid "// `into_iter()` for arrays yields `&i32`\n"
+msgstr "// 配列に`into_iter()`を使うと`&i32`を生成します。\n"
+
+#: src/fn/closures/closure_examples/iter_find.md:45
+msgid "\"Find 2 in array2: {:?}\""
+msgstr "\"Find 2 in array2: {:?}\""
+
+#: src/fn/closures/closure_examples/iter_find.md:49
+msgid ""
+"`Iterator::find` gives you a reference to the item. But if you want the "
+"_index_ of the item, use `Iterator::position`."
+msgstr ""
+"`Iterator::find`は要素への参照を返します。"
+"要素の _インデックス_ を使用したい場合、`Iterator::position`を使用してください。"
+
+#: src/fn/closures/closure_examples/iter_find.md:56
+msgid ""
+"// `iter()` for vecs yields `&i32` and `position()` does not take a "
+"reference, so\n"
+"    // we have to destructure `&i32` to `i32`\n"
+msgstr ""
+"// `iter()`は`&i32`を生成しますが`position()`は参照を取らないので\n"
+"    // `&i32`を`i32`へとデストラクトします。\n"
+
+#: src/fn/closures/closure_examples/iter_find.md:61
+msgid ""
+"// `into_iter()` for vecs yields `i32` and `position()` does not take a "
+"reference, so\n"
+"    // we do not have to destructure    \n"
+msgstr ""
+"// `into_iter()`は`i32`を生成し、`position()`は参照を取らないので\n"
+"    // `デストラクトする必要はありません。\n"
+
+#: src/fn/closures/closure_examples/iter_find.md:70
+msgid ""
+"[`std::iter::Iterator::find`](https://doc.rust-lang.org/std/iter/trait."
+"Iterator.html#method.find)"
+msgstr ""
+"[`std::iter::Iterator::find`](https://doc.rust-lang.org/std/iter/trait."
+"Iterator.html#method.find)"
+
+#: src/fn/closures/closure_examples/iter_find.md:72
+msgid ""
+"[`std::iter::Iterator::find_map`](https://doc.rust-lang.org/std/iter/trait."
+"Iterator.html#method.find_map)"
+msgstr ""
+"[`std::iter::Iterator::find_map`](https://doc.rust-lang.org/std/iter/trait."
+"Iterator.html#method.find_map)"
+
+#: src/fn/closures/closure_examples/iter_find.md:74
+msgid ""
+"[`std::iter::Iterator::position`](https://doc.rust-lang.org/std/iter/trait."
+"Iterator.html#method.position)"
+msgstr ""
+"[`std::iter::Iterator::position`](https://doc.rust-lang.org/std/iter/trait."
+"Iterator.html#method.position)"
+
+#: src/fn/closures/closure_examples/iter_find.md:76
+msgid ""
+"[`std::iter::Iterator::rposition`](https://doc.rust-lang.org/std/iter/trait."
+"Iterator.html#method.rposition)"
+msgstr ""
+"[`std::iter::Iterator::rposition`](https://doc.rust-lang.org/std/iter/trait."
+"Iterator.html#method.rposition)"
+
+#: src/fn/hof.md:3
+msgid ""
+"Rust provides Higher Order Functions (HOF). These are functions that take "
+"one or more functions and/or produce a more useful function. HOFs and lazy "
+"iterators give Rust its functional flavor."
+msgstr "Rustには高階関数（`Higher Order Functions, HOF`）を扱う機能が備わっています。"
+
+#: src/fn/hof.md:13
+msgid "\"Find the sum of all the numbers with odd squares under 1000\""
+msgstr "\"Find the sum of all the numbers with odd squares under 1000\""
+
+#: src/fn/hof.md:16
+msgid ""
+"// Imperative approach\n"
+"    // Declare accumulator variable\n"
+msgstr ""
+"// 宣言型プログラミングによるアプローチ\n"
+"    // 値を蓄積する変数を宣言。\n"
+
+#: src/fn/hof.md:19
+msgid "// Iterate: 0, 1, 2, ... to infinity\n"
+msgstr "// 0から無限までイテレートします。\n"
+
+#: src/fn/hof.md:21
+msgid "// Square the number\n"
+msgstr "// 値を2乗。\n"
+
+#: src/fn/hof.md:25
+msgid "// Break loop if exceeded the upper limit\n"
+msgstr "// 上限に達した場合、ループを終了。\n"
+
+#: src/fn/hof.md:28
+msgid "// Accumulate value, if it's odd\n"
+msgstr "// 奇数ならば値を値を足しあわせていきます。\n"
+
+#: src/fn/hof.md:32
+msgid "\"imperative style: {}\""
+msgstr "\"imperative style: {}\""
+
+#: src/fn/hof.md:34
+msgid "// Functional approach\n"
+msgstr "// 関数型プログラミングによるアプローチ\n"
+
+#: src/fn/hof.md:36
+msgid "// All natural numbers squared\n"
+msgstr "// 全自然数を2乗し\n"
+
+#: src/fn/hof.md:37
+msgid "// Below upper limit\n"
+msgstr "// 上限より小さい値で\n"
+
+#: src/fn/hof.md:38
+msgid "// That are odd\n"
+msgstr "// かつ奇数のものを\n"
+
+#: src/fn/hof.md:39
+msgid "// Sum them\n"
+msgstr "// 合計します。\n"
+
+#: src/fn/hof.md:40
+msgid "\"functional style: {}\""
+msgstr "\"functional style: {}\""
+
+#: src/fn/hof.md:44
+msgid ""
+"[Option](https://doc.rust-lang.org/core/option/enum.Option.html) and "
+"[Iterator](https://doc.rust-lang.org/core/iter/trait.Iterator.html) "
+"implement their fair share of HOFs."
+msgstr ""
+"[Option](https://doc.rust-lang.org/core/option/enum.Option.html) と "
+"[イテレータ](https://doc.rust-lang.org/core/iter/trait.Iterator.html) "
+"には高階関数が使用されています。"
+
+#: src/fn/diverging.md:3
+msgid ""
+"Diverging functions never return. They are marked using `!`, which is an "
+"empty type."
+msgstr ""
+"発散する関数は決してリターンしない関数です。"
+"こうした関数は `!` を使って、空の型であることが示されます。"
+
+#: src/fn/diverging.md:7 src/fn/diverging.md:35
+msgid "\"This call never returns.\""
+msgstr "\"This call never returns.\""
+
+#: src/fn/diverging.md:11
+msgid ""
+"As opposed to all the other types, this one cannot be instantiated, because "
+"the set of all possible values this type can have is empty. Note that, it is "
+"different from the `()` type, which has exactly one possible value."
+msgstr ""
+"他の全ての型と異なり、この型はインスタンス化できません。"
+"この型が持ちうる全ての値の集合は空です。"
+"この型は`()`型とは異なることに注意してください。"
+"`()`型は値をただ1つだけ持つ型です。"
+
+#: src/fn/diverging.md:15
+msgid ""
+"For example, this function returns as usual, although there is no "
+"information in the return value."
+msgstr "例えば、この関数は通常どおりリターンしますが、戻り値には何の情報も含みません。"
+
+#: src/fn/diverging.md:25
+msgid "\"This function returns and you can see this line.\""
+msgstr "\"This function returns and you can see this line.\""
+
+#: src/fn/diverging.md:29
+msgid ""
+"As opposed to this function, which will never return the control back to the "
+"caller."
+msgstr "一方、この関数は呼び出し元に決してリターンしません。"
+
+#: src/fn/diverging.md:36
+msgid "\"You will never see this line!\""
+msgstr "\"You will never see this line!\""
+
+#: src/fn/diverging.md:40
+msgid ""
+"Although this might seem like an abstract concept, it is in fact very useful "
+"and often handy. The main advantage of this type is that it can be cast to "
+"any other one and therefore used at places where an exact type is required, "
+"for instance in `match` branches. This allows us to write code like this:"
+msgstr ""
+"これは抽象的な概念に見えるかもしれませんが、実際のところはとても実用的で、便利なことも多いのです。"
+"この型の主な利点は、他のどのような型にもキャストできることです。"
+"そのため、例えば`match`の分岐の中のような正確な型が要求される場所でも使用できます。"
+
+#: src/fn/diverging.md:50
+msgid ""
+"// Notice that the return type of this match expression must be u32\n"
+"            // because of the type of the \"addition\" variable.\n"
+msgstr ""
+"// 変数\"addition\"の型がu32であるため、\n"
+"            // このmatch式はu32をリターンしなければならないことに注意。\n"
+
+#: src/fn/diverging.md:53
+msgid "// The \"i\" variable is of type u32, which is perfectly fine.\n"
+msgstr "// 変数\"i\"はu32型であるため、全く問題ありません。\n"
+
+#: src/fn/diverging.md:55
+msgid ""
+"// On the other hand, the \"continue\" expression does not return\n"
+"                // u32, but it is still fine, because it never returns and "
+"therefore\n"
+"                // does not violate the type requirements of the match "
+"expression.\n"
+msgstr ""
+"// 一方、\"continue\"式はu32をリターンしませんが、これでも問題ありません。\n"
+"                // 決してリターンしないため、このmatch式が要求する型に違反しないからです。\n"
+
+#: src/fn/diverging.md:64
+msgid "\"Sum of odd numbers up to 9 (excluding): {}\""
+msgstr "\"Sum of odd numbers up to 9 (excluding): {}\""
+
+#: src/fn/diverging.md:68
+msgid ""
+"It is also the return type of functions that loop forever (e.g. `loop {}`) "
+"like network servers or functions that terminate the process (e.g. `exit()`)."
+msgstr ""
+"この型は、ネットワークサーバのような永遠にループする関数（例：`loop {}`）の戻り値の型や、"
+"プロセスを終了させる関数（例：`exit()`）の戻り値の型としても使用されます。"
+
+#: src/mod.md:3
+msgid ""
+"Rust provides a powerful module system that can be used to hierarchically "
+"split code in logical units (modules), and manage visibility (public/"
+"private) between them."
+msgstr "Rustにはコードを階層的に分割し、お互いの機能を隠蔽・公開するための強力なモジュールシステムがあります。"
+
+#: src/mod.md:7
+msgid ""
+"A module is a collection of items: functions, structs, traits, `impl` "
+"blocks, and even other modules."
+msgstr "モジュールは関数、構造体、トレイト、`impl`ブロック、さらには他のモジュールなどの要素の集合です。"
+
+#: src/mod/visibility.md:3
+msgid ""
+"By default, the items in a module have private visibility, but this can be "
+"overridden with the `pub` modifier. Only the public items of a module can be "
+"accessed from outside the module scope."
+msgstr ""
+"デフォルトでは、モジュール内の要素はプライベートですが、"
+"これは`pub`で修飾することでパブリックな属性にすることができます。"
+"パブリックな属性のみがモジュールの外のスコープからアクセスできます。"
+
+#: src/mod/visibility.md:8
+msgid "// A module named `my_mod`\n"
+msgstr "// `my_mod`という名前のモジュール\n"
+
+#: src/mod/visibility.md:10
+msgid "// Items in modules default to private visibility.\n"
+msgstr "// モジュール内の要素はデフォルトでプライベート。\n"
+
+#: src/mod/visibility.md:12
+msgid "\"called `my_mod::private_function()`\""
+msgstr "\"called `my_mod::private_function()`\""
+
+#: src/mod/visibility.md:15
+msgid "// Use the `pub` modifier to override default visibility.\n"
+msgstr "// `pub`を用いてパブリックに変更。\n"
+
+#: src/mod/visibility.md:17
+msgid "\"called `my_mod::function()`\""
+msgstr "\"called `my_mod::function()`\""
+
+#: src/mod/visibility.md:20
+msgid ""
+"// Items can access other items in the same module,\n"
+"    // even when private.\n"
+msgstr "// モジュール内からならば、プライベートな属性にアクセスできます。\n"
+
+#: src/mod/visibility.md:23
+msgid "\"called `my_mod::indirect_access()`, that\\n> \""
+msgstr "\"called `my_mod::indirect_access()`, that\\n> \""
+
+#: src/mod/visibility.md:27
+msgid "// Modules can also be nested\n"
+msgstr "// モジュールもネストできます。\n"
+
+#: src/mod/visibility.md:30
+msgid "\"called `my_mod::nested::function()`\""
+msgstr "\"called `my_mod::nested::function()`\""
+
+#: src/mod/visibility.md:35
+msgid "\"called `my_mod::nested::private_function()`\""
+msgstr "\"called `my_mod::nested::private_function()`\""
+
+#: src/mod/visibility.md:38
+msgid ""
+"// Functions declared using `pub(in path)` syntax are only visible\n"
+"        // within the given path. `path` must be a parent or ancestor "
+"module\n"
+msgstr ""
+"// `pub(in path)`形式で宣言された関数は該当のパス内でのみアクセスできます。\n"
+"        // `path`は親や先祖のモジュールでなくてはなりません。\n"
+
+#: src/mod/visibility.md:41
+msgid "\"called `my_mod::nested::public_function_in_my_mod()`, that\\n> \""
+msgstr "\"called `my_mod::nested::public_function_in_my_mod()`, that\\n> \""
+
+#: src/mod/visibility.md:45
+msgid ""
+"// Functions declared using `pub(self)` syntax are only visible within\n"
+"        // the current module, which is the same as leaving them private\n"
+msgstr ""
+"// `pub(self)`形式で宣言された関数は現在のモジュール内でのみアクセスできます。\n"
+"        // つまり、プライベートにするのと同じです。\n"
+
+#: src/mod/visibility.md:48
+msgid "\"called `my_mod::nested::public_function_in_nested()`\""
+msgstr "\"called `my_mod::nested::public_function_in_nested()`\""
+
+#: src/mod/visibility.md:51
+msgid ""
+"// Functions declared using `pub(super)` syntax are only visible within\n"
+"        // the parent module\n"
+msgstr "// `pub(super)`形式で宣言された関数は親モジュール内でのみアクセスできます。\n"
+
+#: src/mod/visibility.md:54
+msgid "\"called `my_mod::nested::public_function_in_super_mod()`\""
+msgstr "\"called `my_mod::nested::public_function_in_super_mod()`\""
+
+#: src/mod/visibility.md:59
+msgid "\"called `my_mod::call_public_function_in_my_mod()`, that\\n> \""
+msgstr "\"called `my_mod::call_public_function_in_my_mod()`, that\\n> \""
+
+#: src/mod/visibility.md:61
+msgid "\"> \""
+msgstr "\"> \""
+
+#: src/mod/visibility.md:65
+msgid "// pub(crate) makes functions visible only within the current crate\n"
+msgstr "// pub(crate)により関数は現在のクレート内でのみアクセスできます。\n"
+
+#: src/mod/visibility.md:67
+msgid "\"called `my_mod::public_function_in_crate()`\""
+msgstr "\"called `my_mod::public_function_in_crate()`\""
+
+#: src/mod/visibility.md:70
+msgid "// Nested modules follow the same rules for visibility\n"
+msgstr "// ネストしたモジュールも、同様の性質を示します。\n"
+
+#: src/mod/visibility.md:74
+msgid "\"called `my_mod::private_nested::function()`\""
+msgstr "\"called `my_mod::private_nested::function()`\""
+
+#: src/mod/visibility.md:77
+msgid ""
+"// Private parent items will still restrict the visibility of a child item,\n"
+"        // even if it is declared as visible within a bigger scope.\n"
+msgstr ""
+"// 親がプライベートな場合、子要素がより大きなスコープでアクセスできるように宣言されていても、\n"
+"        // 子要素にアクセス可能な範囲は制限されます。\n"
+
+#: src/mod/visibility.md:81
+msgid "\"called `my_mod::private_nested::restricted_function()`\""
+msgstr "\"called `my_mod::private_nested::restricted_function()`\""
+
+#: src/mod/visibility.md:87 src/mod/use.md:25 src/mod/super.md:8
+#: src/mod/split.md:24
+msgid "\"called `function()`\""
+msgstr "\"called `function()`\""
+
+#: src/mod/visibility.md:91
+msgid ""
+"// Modules allow disambiguation between items that have the same name.\n"
+msgstr "// モジュールによって、同名の関数を区別することができます。\n"
+
+#: src/mod/visibility.md:95
+msgid ""
+"// Public items, including those inside nested modules, can be\n"
+"    // accessed from outside the parent module.\n"
+msgstr ""
+"// パブリックな要素ならば、たとえネストしたものでも、\n"
+"    // モジュールの外からアクセスすることができます。\n"
+
+#: src/mod/visibility.md:101
+msgid "// pub(crate) items can be called from anywhere in the same crate\n"
+msgstr "// pub(crate)の要素は同じクレートのどこからでも呼び出すことができます。\n"
+
+#: src/mod/visibility.md:104
+msgid ""
+"// pub(in path) items can only be called from within the module specified\n"
+"    // Error! function `public_function_in_my_mod` is private\n"
+"    //my_mod::nested::public_function_in_my_mod();\n"
+"    // TODO ^ Try uncommenting this line\n"
+msgstr ""
+"// pub(in path)の要素は指定されたモジュールからのみ呼び出すことができます。\n"
+"    // エラー！`public_function_in_my_mod`関数はプライベート。\n"
+"    //my_mod::nested::public_function_in_my_mod();\n"
+"    // TODO ^ 試しにこの行をアンコメントしてみましょう。\n"
+
+#: src/mod/visibility.md:109
+msgid ""
+"// Private items of a module cannot be directly accessed, even if\n"
+"    // nested in a public module:\n"
+msgstr ""
+"// プライベートな要素は、たとえパブリックなモジュール内に存在していても\n"
+"    // 直接アクセスすることはできません。\n"
+
+#: src/mod/visibility.md:112
+msgid ""
+"// Error! `private_function` is private\n"
+"    //my_mod::private_function();\n"
+"    // TODO ^ Try uncommenting this line\n"
+msgstr ""
+"// エラー！`private_function`はプライベート。\n"
+"    //my_mod::private_function();\n"
+"    // TODO ^ 試しにこの行をアンコメントしてみましょう。\n"
+
+#: src/mod/visibility.md:116
+msgid ""
+"// Error! `private_function` is private\n"
+"    //my_mod::nested::private_function();\n"
+"    // TODO ^ Try uncommenting this line\n"
+msgstr ""
+"// エラー！`private_function`はプライベート。\n"
+"    //my_mod::nested::private_function();\n"
+"    // TODO ^ 試しにこの行をアンコメントしてみましょう。\n"
+
+#: src/mod/visibility.md:120
+msgid ""
+"// Error! `private_nested` is a private module\n"
+"    //my_mod::private_nested::function();\n"
+"    // TODO ^ Try uncommenting this line\n"
+msgstr ""
+"// エラー！`private_nested`はプライベートなモジュール。\n"
+"    //my_mod::private_nested::function();\n"
+"    // TODO ^ 試しにこの行をアンコメントしてみましょう。\n"
+
+#: src/mod/visibility.md:124
+msgid ""
+"// Error! `private_nested` is a private module\n"
+"    //my_mod::private_nested::restricted_function();\n"
+"    // TODO ^ Try uncommenting this line\n"
+msgstr ""
+"// エラー！`private_nested`はプライベートなモジュール。\n"
+"    //my_mod::private_nested::restricted_function();\n"
+"    // TODO ^ 試しにこの行をアンコメントしてみましょう。\n"
+
+#: src/mod/struct_visibility.md:3
+msgid ""
+"Structs have an extra level of visibility with their fields. The visibility  "
+"defaults to private, and can be overridden with the `pub` modifier. This  "
+"visibility only matters when a struct is accessed from outside the module  "
+"where it is defined, and has the goal of hiding information (encapsulation)."
+msgstr ""
+"構造体はそれ自身に加え、フィールドごとにもパブリック・プライベートを設定することができます。"
+"デフォルトではプライベートですが、`pub`宣言をすることで、"
+"フィールドをパブリックにすることができます。"
+"これは、構造体がモジュールの外から参照される時に限り意味のあるもので、"
+"情報の隠蔽（カプセル化）を達成するための機能です。"
+
+#: src/mod/struct_visibility.md:10
+msgid "// A public struct with a public field of generic type `T`\n"
+msgstr "// パブリックなフィールド`T`（ジェネリック型）を持つパブリックな構造体\n"
+
+#: src/mod/struct_visibility.md:15
+msgid "// A public struct with a private field of generic type `T`\n"
+msgstr "// プライベートなフィールド`T`（ジェネリック型）を持つパブリックな構造体\n"
+
+#: src/mod/struct_visibility.md:21
+msgid "// A public constructor method\n"
+msgstr "// パブリックなコンストラクタメソッドを持つ構造体\n"
+
+#: src/mod/struct_visibility.md:31
+msgid "// Public structs with public fields can be constructed as usual\n"
+msgstr ""
+"// パブリックなフィールドを持つパブリックな構造体は、通常通り\n"
+"    // インスタンス化できます。\n"
+
+#: src/mod/struct_visibility.md:32
+msgid "\"public information\""
+msgstr "\"public information\""
+
+#: src/mod/struct_visibility.md:34
+msgid "// and their fields can be normally accessed.\n"
+msgstr "// フィールドにも普通にアクセスできます。\n"
+
+#: src/mod/struct_visibility.md:35
+msgid "\"The open box contains: {}\""
+msgstr "\"The open box contains: {}\""
+
+#: src/mod/struct_visibility.md:37
+msgid ""
+"// Public structs with private fields cannot be constructed using field "
+"names.\n"
+"    // Error! `ClosedBox` has private fields\n"
+"    //let closed_box = my::ClosedBox { contents: \"classified information"
+"\" };\n"
+"    // TODO ^ Try uncommenting this line\n"
+msgstr ""
+"// プライベートなフィールドを持つ構造体は、インスタンス化する際に\n"
+"    // フィールド名を指定することができません。\n"
+"    // エラー！`ClosedBox`にはプライベートなフィールドがあります。\n"
+"    //let closed_box = my::ClosedBox { contents: \"classified information"
+"\" };\n"
+"    // TODO ^ 試しにここをアンコメントしてみましょう。\n"
+
+#: src/mod/struct_visibility.md:42
+msgid ""
+"// However, structs with private fields can be created using\n"
+"    // public constructors\n"
+msgstr ""
+"// そのような場合でも、パブリックなコンストラクタを介して作成\n"
+"    // することはできます。\n"
+
+#: src/mod/struct_visibility.md:44
+msgid "\"classified information\""
+msgstr "\"classified information\""
+
+#: src/mod/struct_visibility.md:46
+msgid ""
+"// and the private fields of a public struct cannot be accessed.\n"
+"    // Error! The `contents` field is private\n"
+"    //println!(\"The closed box contains: {}\", _closed_box.contents);\n"
+"    // TODO ^ Try uncommenting this line\n"
+msgstr ""
+"// パブリックな構造体でも、プライベートなフィールドにはアクセスできません。\n"
+"    // エラー！`contents`フィールドはプライベートです。\n"
+"    //println!(\"The closed box contains: {}\", _closed_box.contents);\n"
+"    // TODO ^ ここをアンコメントしてみましょう。\n"
+
+#: src/mod/struct_visibility.md:55
+msgid "[generics](../generics.md) and [methods](../fn/methods.md)"
+msgstr "[ジェネリクス](../generics.md), [メソッド](../fn/methods.md)"
+
+#: src/mod/use.md:3
+msgid ""
+"The `use` declaration can be used to bind a full path to a new name, for "
+"easier access. It is often used like this:"
+msgstr ""
+"`use`宣言をすることで、要素の絶対パスを新しい名前に束縛することができ、"
+"より簡潔な記述が可能になります。例えば以下のように使えます。"
+
+#: src/mod/use.md:18
+msgid "You can use the `as` keyword to bind imports to a different name:"
+msgstr "`as`キーワードを使用することで、インポートを別名に束縛することができます。"
+
+#: src/mod/use.md:21
+msgid "// Bind the `deeply::nested::function` path to `other_function`.\n"
+msgstr "// `deeply::nested::function`を`other_function`に束縛\n"
+
+#: src/mod/use.md:31
+msgid "\"called `deeply::nested::function()`\""
+msgstr "\"called `deeply::nested::function()`\""
+
+#: src/mod/use.md:37
+msgid "// Easier access to `deeply::nested::function`\n"
+msgstr "// `deeply::nested::function`へ、より簡潔にアクセス。\n"
+
+#: src/mod/use.md:40
+msgid "\"Entering block\""
+msgstr "\"Entering block\""
+
+#: src/mod/use.md:42
+msgid ""
+"// This is equivalent to `use deeply::nested::function as function`.\n"
+"        // This `function()` will shadow the outer one.\n"
+msgstr ""
+"// これは`use deeply::nested::function as function`と同等\n"
+"        // この`function()`は外の`function()`をシャドウイングします。\n"
+
+#: src/mod/use.md:46
+msgid ""
+"// `use` bindings have a local scope. In this case, the\n"
+"        // shadowing of `function()` is only in this block.\n"
+msgstr ""
+"// `use`束縛は局所的なスコープを持ちます。\n"
+"        // この場合には`function()`のシャドーイングはこのブロック内のみとなります。\n"
+
+#: src/mod/use.md:50
+msgid "\"Leaving block\""
+msgstr "\"Leaving block\""
+
+#: src/mod/super.md:3
+msgid ""
+"The `super` and `self` keywords can be used in the path to remove ambiguity "
+"when accessing items and to prevent unnecessary hardcoding of paths."
+msgstr ""
+"`super`及び`self`キーワードは、要素にアクセスする際に、"
+"曖昧さをなくし、不必要なハードコーディングを避けるために使用できます。"
+
+#: src/mod/super.md:13
+msgid "\"called `cool::function()`\""
+msgstr "\"called `cool::function()`\""
+
+#: src/mod/super.md:19 src/mod/split.md:49
+msgid "\"called `my::function()`\""
+msgstr "\"called `my::function()`\""
+
+#: src/mod/super.md:24
+msgid "\"called `my::cool::function()`\""
+msgstr "\"called `my::cool::function()`\""
+
+#: src/mod/super.md:29
+msgid "// Let's access all the functions named `function` from this scope!\n"
+msgstr "// `function`という名の様々な関数をこのスコープ内から参照してみましょう。\n"
+
+#: src/mod/super.md:30
+msgid "\"called `my::indirect_call()`, that\\n> \""
+msgstr "\"called `my::indirect_call()`, that\\n> \""
+
+#: src/mod/super.md:32
+msgid ""
+"// The `self` keyword refers to the current module scope - in this case "
+"`my`.\n"
+"        // Calling `self::function()` and calling `function()` directly both "
+"give\n"
+"        // the same result, because they refer to the same function.\n"
+msgstr ""
+"// `self`キーワードは現在のモジュールスコープを示します。\n"
+"        // この場合は`my`です。`self::function()`と`funcition()`は\n"
+"        // 同じ関数であるため、同じ結果になります。\n"
+
+#: src/mod/super.md:38
+msgid "// We can also use `self` to access another module inside `my`:\n"
+msgstr ""
+"// `my`以下の別のモジュールを呼び出す際に\n"
+"        // `self`を用いて明示的に参照できます。\n"
+
+#: src/mod/super.md:41
+msgid ""
+"// The `super` keyword refers to the parent scope (outside the `my` "
+"module).\n"
+msgstr "// `super`は親スコープ（`my`の外側）を参照します。\n"
+
+#: src/mod/super.md:44
+msgid ""
+"// This will bind to the `cool::function` in the *crate* scope.\n"
+"        // In this case the crate scope is the outermost scope.\n"
+msgstr ""
+"// 以下は *クレート* スコープ内の`cool::function`を束縛します。\n"
+"        // この場合、クレートスコープは一番外側のスコープです。\n"
+
+#: src/mod/split.md:3
+msgid ""
+"Modules can be mapped to a file/directory hierarchy. Let's break down the "
+"[visibility example](visibility.md) in files:"
+msgstr ""
+"モジュールはファイル・ディレクトリの階層構造と対応関係にあります。"
+"以下の様なファイルで[可視性の例](visibility.md)を詳しく見ていきましょう。"
+
+#: src/mod/split.md:16
+msgid "In `split.rs`:"
+msgstr "`split.rs`は以下のようになります。"
+
+#: src/mod/split.md:19
+msgid ""
+"// This declaration will look for a file named `my.rs` and will\n"
+"// insert its contents inside a module named `my` under this scope\n"
+msgstr ""
+"// このように宣言すると、`my.rs`という名のファイルを探し、\n"
+"// その内容をこのファイル中で`my`という名から使用することができるようにします。\n"
+
+#: src/mod/split.md:39
+msgid "In `my.rs`:"
+msgstr "`my.rs`は以下のようになります。"
+
+#: src/mod/split.md:42
+msgid ""
+"// Similarly `mod inaccessible` and `mod nested` will locate the `nested."
+"rs`\n"
+"// and `inaccessible.rs` files and insert them here under their respective\n"
+"// modules\n"
+msgstr ""
+"// 同様に`mod inaccessible`、`mod nested`によって、`nested.rs`、`inaccessible.rs`\n"
+"// の内容をこの中で使用することができるようになります。\n"
+"// 訳注：`pub`をつけないかぎり、この中でしか使用できません。\n"
+
+#: src/mod/split.md:53
+msgid "\"called `my::private_function()`\""
+msgstr "\"called `my::private_function()`\""
+
+#: src/mod/split.md:57
+msgid "\"called `my::indirect_access()`, that\\n> \""
+msgstr "\"called `my::indirect_access()`, that\\n> \""
+
+#: src/mod/split.md:63
+msgid "In `my/nested.rs`:"
+msgstr "`my/nested.rs`は以下のようになります。"
+
+#: src/mod/split.md:67
+msgid "\"called `my::nested::function()`\""
+msgstr "\"called `my::nested::function()`\""
+
+#: src/mod/split.md:72
+msgid "\"called `my::nested::private_function()`\""
+msgstr "\"called `my::nested::private_function()`\""
+
+#: src/mod/split.md:76
+msgid "In `my/inaccessible.rs`:"
+msgstr "`my/inaccessible.rs`は以下のようになります。"
+
+#: src/mod/split.md:81
+msgid "\"called `my::inaccessible::public_function()`\""
+msgstr "\"called `my::inaccessible::public_function()`\""
+
+#: src/mod/split.md:85
+msgid "Let's check that things still work as before:"
+msgstr "では、以前と同じように実行できるか確認しましょう。"
+
+#: src/crates.md:3
+msgid ""
+"A crate is a compilation unit in Rust. Whenever `rustc some_file.rs` is "
+"called, `some_file.rs` is treated as the _crate file_. If `some_file.rs` has "
+"`mod` declarations in it, then the contents of the module files would be "
+"inserted in places where `mod` declarations in the crate file are found, "
+"_before_ running the compiler over it. In other words, modules do _not_ get "
+"compiled individually, only crates get compiled."
+msgstr ""
+"クレートはRustにおけるコンパイルの単位です。"
+"`rustc some_file.rs`が呼ばれると、`some_file.rs`は必ず *クレートファイル* として扱われます。"
+"もし`some_file.rs`が`mod`宣言を含んでいるのならば、コンパイルの *前に* 、"
+"そのモジュールファイルの中身が`mod`の位置に挿入されます。"
+"言い換えると、それぞれのモジュールが独立にコンパイルされるということはありませんが、"
+"それぞれのクレートは互いに独立にコンパイルされるということです。"
+
+#: src/crates.md:10
+msgid ""
+"A crate can be compiled into a binary or into a library. By default, `rustc` "
+"will produce a binary from a crate. This behavior can be overridden by "
+"passing the `--crate-type` flag to `lib`."
+msgstr ""
+"クレートはバイナリあるいはライブラリ形式でコンパイルされることが可能です。"
+"デフォルトでは`rustc`はクレートからバイナリを作り出しますが、"
+"この振る舞いは`--crate-type`フラグに`lib`を渡すことでオーバーライドできます。"
+
+#: src/crates/lib.md:3
+msgid "Let's create a library, and then see how to link it to another crate."
+msgstr "ではライブラリを作成し、それを別のクレートにリンクする方法を見ていきましょう。"
+
+#: src/crates/lib.md:5
+msgid "In `rary.rs`:"
+msgstr "`rary.rs`は以下のようになります。"
+
+#: src/crates/lib.md:9 src/attribute/crate.md:19
+msgid "\"called rary's `public_function()`\""
+msgstr "\"called rary's `public_function()`\""
+
+#: src/crates/lib.md:13 src/attribute/crate.md:23
+msgid "\"called rary's `private_function()`\""
+msgstr "\"called rary's `private_function()`\""
+
+#: src/crates/lib.md:17 src/attribute/crate.md:27
+msgid "\"called rary's `indirect_access()`, that\\n> \""
+msgstr "\"called rary's `indirect_access()`, that\\n> \""
+
+#: src/crates/lib.md:29
+msgid ""
+"Libraries get prefixed with \"lib\", and by default they get named after "
+"their crate file, but this default name can be overridden by passing the `--"
+"crate-name` option to `rustc` or by using the [`crate_name` attribute](../"
+"attribute/crate.md)."
+msgstr ""
+"ライブラリは「lib」が頭につき、デフォルトでは、その後ろに元となったクレートファイル名をつけます。"
+"（訳注: ここでは`lib` + `rary`）この振る舞いは[`crate_name`アトリビュート](../attribute/crate.md)を用いてオーバーライドできます。"
+
+#: src/crates/using_lib.md:3
+msgid ""
+"To link a crate to this new library you may use `rustc`'s `--extern` flag. "
+"All  of its items will then be imported under a module named the same as the "
+"library. This module generally behaves the same way as any other module."
+msgstr ""
+"クレートをこの新しいライブラリにリンクするには、`rustc`の`--extern`フラグを利用します。"
+"クレートの要素を全てライブラリと同じ名前のモジュールにインポートします。"
+"一般に、このモジュールは他のモジュールと同じように振る舞います。"
+
+#: src/crates/using_lib.md:8
+msgid ""
+"// extern crate rary; // May be required for Rust 2015 edition or earlier\n"
+msgstr ""
+"// extern crate rary; // Rust 2015以前で必要。\n"
+
+#: src/crates/using_lib.md:13
+msgid ""
+"// Error! `private_function` is private\n"
+"    //rary::private_function();\n"
+msgstr ""
+"// エラー！`private_function`はプライベート。\n"
+"    //rary::private_function();\n"
+
+#: src/cargo.md:3
+msgid ""
+"`cargo` is the official Rust package management tool. It has lots of really "
+"useful features to improve code quality and developer velocity! These include"
+msgstr ""
+"`cargo`はRustの公式パッケージ管理ツールです。"
+"とても便利な機能が多くあり、コードの品質や開発速度の向上に役立ちます。以下はその例です。"
+
+#: src/cargo.md:6
+msgid ""
+"Dependency management and integration with [crates.io](https://crates.io) "
+"(the official Rust package registry)"
+msgstr "依存関係の管理と[crates.io](https://crates.io)（Rustの公式パッケージレジストリ）との統合"
+
+#: src/cargo.md:8
+msgid "Awareness of unit tests"
+msgstr "ユニットテスト"
+
+#: src/cargo.md:9
+msgid "Awareness of benchmarks"
+msgstr "ベンチマーク"
+
+#: src/cargo.md:11
+msgid ""
+"This chapter will go through some quick basics, but you can find the "
+"comprehensive docs in [The Cargo Book](https://doc.rust-lang.org/cargo/)."
+msgstr ""
+"この章では、簡単な基本機能を説明します。"
+"包括的なドキュメントは[The Cargo Book](https://doc.rust-lang.org/cargo/)を参照してください。"
+
+#: src/cargo/deps.md:3
+msgid ""
+"Most programs have dependencies on some libraries. If you have ever managed "
+"dependencies by hand, you know how much of a pain this can be. Luckily, the "
+"Rust ecosystem comes standard with `cargo`! `cargo` can manage dependencies "
+"for a project."
+msgstr ""
+"ほとんどのプログラムはライブラリに依存関係を持ちます。"
+"もし依存関係を手動で管理したことがあれば、それがどれだけ苦痛であるか分かるでしょう。"
+"幸運なことに、Rustのエコシステムには`cargo`が標準装備されています！"
+"`cargo`によってプロジェクトの依存関係を管理することができます。"
+
+#: src/cargo/deps.md:8
+msgid "To create a new Rust project,"
+msgstr "Rustのプロジェクトを新しく作るには下記のようにします。"
+
+#: src/cargo/deps.md:11
+msgid "# A binary\n"
+msgstr "# バイナリ\n"
+
+#: src/cargo/deps.md:13
+msgid "# A library\n"
+msgstr "# ライブラリ\n"
+
+#: src/cargo/deps.md:18
+msgid ""
+"For the rest of this chapter, let's assume we are making a binary, rather "
+"than a library, but all of the concepts are the same."
+msgstr "この章の残りでは、ライブラリではなくバイナリを作ることを想定しますが、コンセプトはすべて同じです。"
+
+#: src/cargo/deps.md:21
+msgid "After the above commands, you should see a file hierarchy like this:"
+msgstr "上のコマンドを実行すると、次のようなファイル階層ができます。"
+
+#: src/cargo/deps.md:35
+msgid ""
+"The `main.rs` is the root source file for your new `foo` project -- nothing "
+"new there. The `Cargo.toml` is the config file for `cargo` for this project. "
+"If you look inside it, you should see something like this:"
+msgstr ""
+"`main.rs`がこの新規プロジェクト `foo` のルートのソースファイルです。"
+"なにも新しいことはありませんね。`Cargo.toml`はこのプロジェクトの`cargo`の設定ファイルです。"
+"中を見てみるとこのようになっています。"
+
+#: src/cargo/deps.md:48
+msgid ""
+"The `name` field under `[package]` determines the name of the project. This "
+"is used by `crates.io` if you publish the crate (more later). It is also the "
+"name of the output binary when you compile."
+msgstr ""
+"`[package]`の下の`name`フィールドがプロジェクトの名前を決定します。"
+"これはクレートを公開するときに`crates.io`によって使われます（詳細は後述）。"
+"またコンパイルしたときの出力ファイルの名前でもあります。"
+
+#: src/cargo/deps.md:52
+msgid ""
+"The `version` field is a crate version number using [Semantic Versioning]"
+"(http://semver.org/)."
+msgstr ""
+"`version`フィールドはクレートのバージョン番号で、"
+"[セマンティックバージョニング](http://semver.org/)を使っています。"
+
+#: src/cargo/deps.md:55
+msgid ""
+"The `authors` field is a list of authors used when publishing the crate."
+msgstr "`authors`フィールドは作者のリストで、クレートを公開するときに使われます。"
+
+#: src/cargo/deps.md:57
+msgid ""
+"The `[dependencies]` section lets you add dependencies for your project."
+msgstr "`[dependencies]`セクションにはプロジェクトの依存関係を追加できます。"
+
+#: src/cargo/deps.md:59
+msgid ""
+"For example, suppose that we want our program to have a great CLI. You can "
+"find lots of great packages on [crates.io](https://crates.io) (the official "
+"Rust package registry). One popular choice is [clap](https://crates.io/"
+"crates/clap). As of this writing, the most recent published version of "
+"`clap` is `2.27.1`. To add a dependency to our program, we can simply add "
+"the following to our `Cargo.toml` under `[dependencies]`: `clap = "
+"\"2.27.1\"`. And that's it! You can start using `clap` in your program."
+msgstr ""
+"例えば、プログラムに素晴らしいCLIが欲しいとします。"
+"[crates.io](https://crates.io)（Rustの公式パッケージレジストリ）には素晴らしいパッケージがたくさんあります。"
+"よくある選択肢の1つは[clap](https://crates.io/crates/clap)です。"
+"この記事を書いている時点での`clap`の最新の公開バージョンは`2.27.1`です。"
+"依存関係をプログラムに追加するには、`Cargo.toml`の`[dependencies]`の下に`clap = \"2.27.1\"`と単に書き加えます。"
+"これだけです！`clap`をプログラム内で使用できます。"
+
+#: src/cargo/deps.md:67
+msgid ""
+"`cargo` also supports [other types of dependencies](https://doc.rust-lang."
+"org/cargo/reference/specifying-dependencies.html). Here is just a small "
+"sampling:"
+msgstr ""
+"`cargo`は[他の形式の依存関係](https://doc.rust-lang.org/cargo/reference/specifying-dependencies.html)"
+"もサポートしています。その一部を示します。"
+
+#: src/cargo/deps.md:82
+msgid ""
+"`cargo` is more than a dependency manager. All of the available "
+"configuration options are listed in the [format specification](https://doc."
+"rust-lang.org/cargo/reference/manifest.html) of `Cargo.toml`."
+msgstr ""
+"`cargo`は依存管理ツール以上のこともできます。"
+"`Cargo.toml`の[format specification](https://doc.rust-lang.org/cargo/reference/manifest.html)"
+"に全ての設定オプションがリストアップされています。"
+
+#: src/cargo/deps.md:86
+msgid ""
+"To build our project we can execute `cargo build` anywhere in the project "
+"directory (including subdirectories!). We can also do `cargo run` to build "
+"and run. Notice that these commands will resolve all dependencies, download "
+"crates if needed, and build everything, including your crate. (Note that it "
+"only rebuilds what it has not already built, similar to `make`)."
+msgstr ""
+"プロジェクトをビルドするには、プロジェクトディレクトリのどこか（サブディレクトでも！）で`cargo build`を実行します。"
+"また`cargo run`でビルドと実行をできます。"
+"これらのコマンドは、全ての依存関係の解決、必要なクレートのダウンロード、"
+"自分のクレートを含む全てのビルドを行うことに注意してください。"
+"（`make`と同様、まだビルドしていないものだけをビルドします。）"
+
+#: src/cargo/deps.md:92
+msgid "Voila! That's all there is to it!"
+msgstr "Voila！これで完成です！"
+
+#: src/cargo/conventions.md:3
+msgid "In the previous chapter, we saw the following directory hierarchy:"
+msgstr "前の章ではこのようなディレクトリ階層がありました。"
+
+#: src/cargo/conventions.md:12
+msgid ""
+"Suppose that we wanted to have two binaries in the same project, though. "
+"What then?"
+msgstr "しかし同じプロジェクトで2つのバイナリが欲しいとします。その場合は？"
+
+#: src/cargo/conventions.md:15
+msgid ""
+"It turns out that `cargo` supports this. The default binary name is `main`, "
+"as we saw before, but you can add additional binaries by placing them in a "
+"`bin/` directory:"
+msgstr ""
+"`cargo`はこれもサポートしています。"
+"以前見た通りデフォルトのバイナリ名は`main`ですが、"
+"`bin/`ディレクトリに置くことで他のバイナリを追加できます。"
+
+#: src/cargo/conventions.md:28
+msgid ""
+"To tell `cargo` to only compile or run this binary, we just pass `cargo` the "
+"`--bin my_other_bin` flag, where `my_other_bin` is the name of the binary we "
+"want to work with."
+msgstr ""
+"このバイナリだけをコンパイルや実行するように`cargo`に伝えるには、"
+"`cargo`に`--bin my_other_bin`フラグを渡します。"
+"ここでは`my_other_bin`が対象のバイナリの名前です。"
+
+#: src/cargo/conventions.md:32
+msgid ""
+"In addition to extra binaries, `cargo` supports [more features](https://doc."
+"rust-lang.org/cargo/guide/project-layout.html) such as benchmarks, tests, "
+"and examples."
+msgstr ""
+"バイナリの追加に加えて、`cargo`はベンチマークやテスト、サンプルなどの"
+"[その他の機能](https://doc.rust-lang.org/cargo/guide/project-layout.html)もサポートしています。"
+
+#: src/cargo/conventions.md:35
+msgid "In the next chapter, we will look more closely at tests."
+msgstr "次の章ではテストについてより詳しく見ていきます。"
+
+#: src/cargo/test.md:3
+msgid ""
+"As we know testing is integral to any piece of software! Rust has first-"
+"class support for unit and integration testing ([see this chapter](https://"
+"doc.rust-lang.org/book/ch11-00-testing.html) in TRPL)."
+msgstr ""
+"知っての通り、テストはどんなソフトウェアにも不可欠です！"
+"Rustはユニットテストと統合テストを第一級にサポートしています"
+"（TRPLの[この章を参照してください](https://doc.rust-lang.org/book/ch11-00-testing.html)）。"
+
+#: src/cargo/test.md:8
+msgid ""
+"From the testing chapters linked above, we see how to write unit tests and "
+"integration tests. Organizationally, we can place unit tests in the modules "
+"they test and integration tests in their own `tests/` directory:"
+msgstr ""
+"上のリンク先のテストの章では、ユニットテストと統合テストの書き方を紹介しています。"
+"ユニットテストはテスト対象のモジュール内に、統合テストは`tests/`ディレクトリ内に置きます。"
+
+#: src/cargo/test.md:23
+msgid ""
+"Each file in `tests` is a separate  [integration test](https://doc.rust-lang."
+"org/book/ch11-03-test-organization.html#integration-tests), i.e. a test that "
+"is meant to test your library as if it were being called from a dependent "
+"crate."
+msgstr ""
+"`tests`内の各ファイルは個別の[統合テスト](https://doc.rust-lang.org/book/ch11-03-test-organization.html#integration-tests)です。"
+"これはライブラリを依存クレートから呼ばれたかのようにテストできます。"
+
+#: src/cargo/test.md:28
+msgid ""
+"The [Testing](../testing.md) chapter elaborates on the three different "
+"testing styles:  [Unit](../testing/unit_testing.md), [Doc](../testing/"
+"doc_testing.md), and [Integration](../testing/integration_testing.md). "
+msgstr ""
+"[テスト](../testing.md)の章は3つの異なるテストスタイルについて解説しています。"
+"[単体テスト](../testing/unit_testing.md)、[ドキュメンテーションテスト](../testing/doc_testing.md)、"
+"そして[結合テスト](../testing/integration_testing.md)です。"
+
+#: src/cargo/test.md:31
+msgid "`cargo` naturally provides an easy way to run all of your tests!"
+msgstr "`cargo`は、全てのテストを簡単に実行する方法を提供します。"
+
+#: src/cargo/test.md:37
+msgid "You should see output like this:"
+msgstr "出力はこのようになります。"
+
+#: src/cargo/test.md:54
+msgid "You can also run tests whose name matches a pattern:"
+msgstr "パターンにマッチする名前のテストを実行することもできます。"
+
+#: src/cargo/test.md:39
+msgid ""
+"```shell\n"
+"$ cargo test\n"
+"   Compiling blah v0.1.0 (file:///nobackup/blah)\n"
+"    Finished dev [unoptimized + debuginfo] target(s) in 0.89 secs\n"
+"     Running target/debug/deps/blah-d3b32b97275ec472\n"
+"\n"
+"running 4 tests\n"
+"test test_bar ... ok\n"
+"test test_baz ... ok\n"
+"test test_foo_bar ... ok\n"
+"test test_foo ... ok\n"
+"\n"
+"test result: ok. 4 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out\n"
+"```"
+msgstr ""
+"```shell\n"
+"$ cargo test\n"
+"   Compiling blah v0.1.0 (file:///nobackup/blah)\n"
+"    Finished dev [unoptimized + debuginfo] target(s) in 0.89 secs\n"
+"     Running target/debug/deps/blah-d3b32b97275ec472\n"
+"\n"
+"running 4 tests\n"
+"test test_bar ... ok\n"
+"test test_baz ... ok\n"
+"test test_foo_bar ... ok\n"
+"test test_foo ... ok\n"
+"\n"
+"test result: ok. 4 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out\n"
+"```"
+
+#: src/cargo/test.md:60
+msgid ""
+"```shell\n"
+"$ cargo test test_foo\n"
+"   Compiling blah v0.1.0 (file:///nobackup/blah)\n"
+"    Finished dev [unoptimized + debuginfo] target(s) in 0.35 secs\n"
+"     Running target/debug/deps/blah-d3b32b97275ec472\n"
+"\n"
+"running 2 tests\n"
+"test test_foo ... ok\n"
+"test test_foo_bar ... ok\n"
+"\n"
+"test result: ok. 2 passed; 0 failed; 0 ignored; 0 measured; 2 filtered out\n"
+"```"
+msgstr ""
+"```shell\n"
+"$ cargo test test_foo\n"
+"   Compiling blah v0.1.0 (file:///nobackup/blah)\n"
+"    Finished dev [unoptimized + debuginfo] target(s) in 0.35 secs\n"
+"     Running target/debug/deps/blah-d3b32b97275ec472\n"
+"\n"
+"running 2 tests\n"
+"test test_foo ... ok\n"
+"test test_foo_bar ... ok\n"
+"\n"
+"test result: ok. 2 passed; 0 failed; 0 ignored; 0 measured; 2 filtered out\n"
+"```"
+
+#: src/cargo/test.md:73
+msgid ""
+"One word of caution: Cargo may run multiple tests concurrently, so make sure "
+"that they don't race with each other. "
+msgstr ""
+"注意：Cargoは複数のテストを並列で実行することがありますので、"
+"それらが互いに競合しないようにしてください。"
+
+#: src/cargo/test.md:76
+msgid ""
+"One example of this concurrency causing issues is if two tests output to a "
+"file, such as below:"
+msgstr ""
+"並行性が問題を引き起こす一例として、以下のように、"
+"2つのテストが1つのファイルに出力するケースがあります。"
+
+#: src/cargo/test.md:82
+msgid "// Import the necessary modules\n"
+msgstr "// 必要なモジュールをインポートします。\n"
+
+#: src/cargo/test.md:86
+msgid "// This test writes to a file\n"
+msgstr "// ファイルに書き込むテスト\n"
+
+#: src/cargo/test.md:89 src/cargo/test.md:106
+msgid "// Opens the file ferris.txt or creates one if it doesn't exist.\n"
+msgstr "// ferris.txtというファイルを開くか、存在しない場合は作成します。\n"
+
+#: src/cargo/test.md:93 src/cargo/test.md:110
+msgid "\"ferris.txt\""
+msgstr "\"ferris.txt\""
+
+#: src/cargo/test.md:94 src/cargo/test.md:111
+msgid "\"Failed to open ferris.txt\""
+msgstr "\"Failed to open ferris.txt\""
+
+#: src/cargo/test.md:96
+msgid "// Print \"Ferris\" 5 times.\n"
+msgstr "// \"Ferris\"と5回書き込みます。\n"
+
+#: src/cargo/test.md:98
+msgid "\"Ferris\\n\""
+msgstr "\"Ferris\\n\""
+
+#: src/cargo/test.md:99 src/cargo/test.md:116
+msgid "\"Could not write to ferris.txt\""
+msgstr "\"Could not write to ferris.txt\""
+
+#: src/cargo/test.md:103
+msgid "// This test tries to write to the same file\n"
+msgstr "// 同じファイルに書き込むテスト\n"
+
+#: src/cargo/test.md:113
+msgid "// Print \"Corro\" 5 times.\n"
+msgstr "// \"Corro\"と5回書き込みます。\n"
+
+#: src/cargo/test.md:115
+msgid "\"Corro\\n\""
+msgstr "\"Corro\\n\""
+
+#: src/cargo/test.md:122
+msgid "Although the intent is to get the following:"
+msgstr "以下のような結果を得ようと意図しています。"
+
+#: src/cargo/test.md:136
+msgid "What actually gets put into `ferris.txt` is this:"
+msgstr "しかし、実際に`ferris.txt`に出力されるのは、以下の通りです。"
+
+#: src/cargo/build_scripts.md:3
+msgid ""
+"Sometimes a normal build from `cargo` is not enough. Perhaps your crate "
+"needs some pre-requisites before `cargo` will successfully compile, things "
+"like code generation, or some native code that needs to be compiled. To "
+"solve this problem we have build scripts that Cargo can run."
+msgstr ""
+"`cargo`による通常のビルドでは十分でないことが時々あります。"
+"コード生成や、コンパイルが必要なネイティブコードなど、"
+"`cargo`がクレートをうまくコンパイルするにはなんらかの前提条件が必要かもしれません。"
+"この問題を解決するため、Cargoが実行できるビルドスクリプトがあります。"
+
+#: src/cargo/build_scripts.md:8
+msgid ""
+"To add a build script to your package it can either be specified in the "
+"`Cargo.toml` as follows:"
+msgstr "ビルドスクリプトをパッケージに追加するには、以下のように`Cargo.toml`の中で指定できます。"
+
+#: src/cargo/build_scripts.md:11
+msgid ""
+"```toml\n"
+"[package]\n"
+"...\n"
+"build = \"build.rs\"\n"
+"```"
+msgstr ""
+"```toml\n"
+"[package]\n"
+"...\n"
+"build = \"build.rs\"\n"
+"```"
+
+#: src/cargo/build_scripts.md:17
+msgid ""
+"Otherwise Cargo will look for a `build.rs` file in the project directory by "
+"default."
+msgstr "それ以外の場合、Cargoはデフォルトでプロジェクトディレクトリから`build.rs`を探します。"
+
+#: src/cargo/build_scripts.md:20
+msgid "How to use a build script"
+msgstr "ビルドスクリプトの使い方"
+
+#: src/cargo/build_scripts.md:22
+msgid ""
+"The build script is simply another Rust file that will be compiled and "
+"invoked prior to compiling anything else in the package. Hence it can be "
+"used to fulfill pre-requisites of your crate."
+msgstr ""
+"ビルドスクリプトは単にRustのファイルの1つで、"
+"パッケージ内の他のファイルをコンパイルする前にコンパイルされて起動されます。"
+"そのため、クレートの前提条件を満たすために使用できます。"
+
+#: src/cargo/build_scripts.md:26
+msgid ""
+"Cargo provides the script with inputs via environment variables [specified "
+"here](https://doc.rust-lang.org/cargo/reference/environment-variables."
+"html#environment-variables-cargo-sets-for-build-scripts) that can be used."
+msgstr ""
+"Cargoは、[ここで指定された](https://doc.rust-lang.org/cargo/reference/environment-variables.html#environment-variables-cargo-sets-for-build-scripts)"
+"環境変数を介してスクリプトに入力を与えます。"
+
+#: src/cargo/build_scripts.md:29
+msgid ""
+"The script provides output via stdout. All lines printed are written to "
+"`target/debug/build/<pkg>/output`. Further, lines prefixed with `cargo:` "
+"will be interpreted by Cargo directly and hence can be used to define "
+"parameters for the package's compilation."
+msgstr ""
+"スクリプトは標準出力に出力します。"
+"出力される行は全て、`target/debug/build/<pkg>/output`に書き込まれます。"
+"さらに、行頭に`cargo:`がついた行はCargoに直接解釈されるため、"
+"パッケージのコンパイル時のパラメーターを定義するのに使用できます。"
+
+#: src/cargo/build_scripts.md:34
+msgid ""
+"For further specification and examples have a read of the [Cargo "
+"specification](https://doc.rust-lang.org/cargo/reference/build-scripts.html)."
+msgstr ""
+"より詳細な仕様や例については、"
+"[Cargo specification](https://doc.rust-lang.org/cargo/reference/build-scripts.html)を参照してください。"
+
+#: src/attribute.md:3
+msgid ""
+"An attribute is metadata applied to some module, crate or item. This "
+"metadata can be used to/for:"
+msgstr "アトリビュートはモジュール、クレート、要素に対するメタデータです。以下がその使用目的です。"
+
+#: src/attribute.md:8
+msgid "[conditional compilation of code](attribute/cfg.md)"
+msgstr "[コンパイル時の条件分岐](attribute/cfg.md)"
+
+#: src/attribute.md:9
+msgid ""
+"[set crate name, version and type (binary or library)](attribute/crate.md)"
+msgstr ""
+"[クレート名、バージョン、種類（バイナリか、ライブラリか）の設定](attribute/crate.md)"
+
+#: src/attribute.md:10
+msgid ""
+"disable [lints](https://en.wikipedia.org/wiki/Lint_%28software%29) (warnings)"
+msgstr "[リント](https://en.wikipedia.org/wiki/Lint_%28software%29)の無効化"
+
+#: src/attribute.md:11
+msgid "enable compiler features (macros, glob imports, etc.)"
+msgstr "コンパイラ付属の機能（マクロ、グロブ、インポートなど）の使用"
+
+#: src/attribute.md:12
+msgid "link to a foreign library"
+msgstr "外部ライブラリへのリンク"
+
+#: src/attribute.md:13
+msgid "mark functions as unit tests"
+msgstr "ユニットテスト用の関数を明示"
+
+#: src/attribute.md:14
+msgid "mark functions that will be part of a benchmark"
+msgstr "ベンチマーク用の関数を明示"
+
+#: src/attribute.md:15
+msgid ""
+"[attribute like macros](https://doc.rust-lang.org/book/ch19-06-macros."
+"html#attribute-like-macros)"
+msgstr ""
+"[アトリビュートマクロ](https://doc.rust-lang.org/book/ch19-06-macros."
+"html#attribute-like-macros)"
+
+#: src/attribute.md:17
+msgid ""
+"Attributes look like `#[outer_attribute]` or `#![inner_attribute]`, with the "
+"difference between them being where they apply."
+msgstr ""
+
+#: src/attribute.md:20
+msgid ""
+"`#[outer_attribute]` applies to the [item](https://doc.rust-lang.org/stable/"
+"reference/items.html) immediately following it. Some examples of items are: "
+"a function, a module declaration, a constant, a structure, an enum. Here is "
+"an example where attribute `#[derive(Debug)]` applies to the struct "
+"`Rectangle`:"
+msgstr ""
+
+#: src/attribute.md:33
+msgid ""
+"`#![inner_attribute]` applies to the enclosing [item](https://doc.rust-lang."
+"org/stable/reference/items.html) (typically a module or a crate). In other "
+"words, this attribute is interpreted as applying to the entire scope in "
+"which it's place. Here is an example where `#![allow(unusude_variables)]` "
+"applies to the whole crate (if placed in `main.rs`):"
+msgstr ""
+
+#: src/attribute.md:42
+msgid "// This would normally warn about an unused variable.\n"
+msgstr ""
+
+#: src/attribute.md:46
+msgid "Attributes can take arguments with different syntaxes:"
+msgstr "アトリビュートは以下の様な書き方で引数を取ることができます。"
+
+#: src/attribute.md:48
+msgid "`#[attribute = \"value\"]`"
+msgstr "`#[attribute = \"value\"]`"
+
+#: src/attribute.md:49
+msgid "`#[attribute(key = \"value\")]`"
+msgstr "`#[attribute(key = \"value\")]`"
+
+#: src/attribute.md:50
+msgid "`#[attribute(value)]`"
+msgstr "`#[attribute(value)]`"
+
+#: src/attribute.md:52
+msgid ""
+"Attributes can have multiple values and can be separated over multiple "
+"lines, too:"
+msgstr "アトリビュートは複数の値を取ることができ、複数の行に分割することもできます。"
+
+#: src/attribute/unused.md:3
+msgid ""
+"The compiler provides a `dead_code` [_lint_](https://en.wikipedia.org/wiki/"
+"Lint_%28software%29) that will warn about unused functions. An _attribute_ "
+"can be used to disable the lint."
+msgstr ""
+"コンパイラは`dead_code`と呼ばれる[リント](https://en.wikipedia.org/wiki/Lint_%28software%29)機能を持つため、"
+"使用されていない関数が存在するときに警告を出します。"
+"*アトリビュート* によってこの機能を無効化することができます。"
+
+#: src/attribute/unused.md:9
+msgid ""
+"// `#[allow(dead_code)]` is an attribute that disables the `dead_code` lint\n"
+msgstr "/ `#[allow(dead_code)]`は`dead_code`リントを抑制するアトリビュートです。\n"
+
+#: src/attribute/unused.md:14
+msgid "// FIXME ^ Add an attribute to suppress the warning\n"
+msgstr "// FIXME ^ 警告を抑制するアトリビュートを追加しましょう。\n"
+
+#: src/attribute/unused.md:22
+msgid ""
+"Note that in real programs, you should eliminate dead code. In these "
+"examples we'll allow dead code in some places because of the interactive "
+"nature of the examples."
+msgstr ""
+"実際のコード中では、使用されていないコードが有る場合はそれを除外するべきです。"
+"この文書中では随所でアトリビュートによって警告を抑制していますが、"
+"それはあくまでインタラクティブな例を皆さんに提供するためです。"
+
+#: src/attribute/crate.md:3
+msgid ""
+"The `crate_type` attribute can be used to tell the compiler whether a crate "
+"is a binary or a library (and even which type of library), and the "
+"`crate_name` attribute can be used to set the name of the crate."
+msgstr ""
+"`crate_type`アトリビュートは、そのクレートがライブラリ、バイナリのいずれに"
+"コンパイルされるべきかをコンパイラに伝えるために使用します。"
+"ライブラリの場合は、どのタイプのライブラリであるかも伝えることができます。"
+"`crate_name`はクレートの名前を決定するのに使用します。"
+
+#: src/attribute/crate.md:7
+msgid ""
+"However, it is important to note that both the `crate_type` and `crate_name` "
+"attributes have **no** effect whatsoever when using Cargo, the Rust package "
+"manager. Since Cargo is used for the majority of Rust projects, this means "
+"real-world uses of `crate_type` and `crate_name` are relatively limited."
+msgstr ""
+"しかし、`crate_type`アトリビュートも`crate_name`アトリビュートも、"
+"RustのパッケージマネージャCargoを利用している場合は**何の**影響もないと知っておくことは重要です。"
+"Cargoは大半のRustプロジェクトで利用されており、実世界での`crate_type`と`crate_name`の利用は比較的限られています。"
+
+#: src/attribute/crate.md:13
+msgid "// This crate is a library\n"
+msgstr "// このクレートはライブラリです。\n"
+
+#: src/attribute/crate.md:14
+msgid "\"lib\""
+msgstr "\"lib\""
+
+#: src/attribute/crate.md:14
+msgid "// The library is named \"rary\"\n"
+msgstr "// このライブラリの名前は「rary」です。\n"
+
+#: src/attribute/crate.md:16
+msgid "\"rary\""
+msgstr "\"rary\""
+
+#: src/attribute/crate.md:33
+msgid ""
+"When the `crate_type` attribute is used, we no longer need to pass the `--"
+"crate-type` flag to `rustc`."
+msgstr ""
+"`crate_type`アトリビュートが使用されているときは、"
+"`rustc`に`--crate-type`フラグを伝える必要はありません。"
+
+#: src/attribute/cfg.md:3
+msgid ""
+"Configuration conditional checks are possible through two different "
+"operators:"
+msgstr "環境に応じたコンパイルをするには2種類の方法があります。"
+
+#: src/attribute/cfg.md:5
+msgid "the `cfg` attribute: `#[cfg(...)]` in attribute position"
+msgstr "`cfg`アトリビュート：`#[cfg(...)]`をアトリビュートとして使用する。"
+
+#: src/attribute/cfg.md:6
+msgid "the `cfg!` macro: `cfg!(...)` in boolean expressions"
+msgstr "`cfg!`マクロ：`cfg!(...)`をブーリアンとして評価する。"
+
+#: src/attribute/cfg.md:8
+msgid ""
+"While the former enables conditional compilation, the latter conditionally "
+"evaluates to `true` or `false` literals allowing for checks at run-time. "
+"Both utilize identical argument syntax."
+msgstr ""
+"前者は条件付きコンパイルを行いますが、後者は`true`または`false`リテラルに評価され実行時にチェックすることが可能です。"
+"いずれの場合も適切なシンタックスで記述する必要があります。"
+
+#: src/attribute/cfg.md:12
+msgid ""
+"`cfg!`, unlike `#[cfg]`, does not remove any code and only evaluates to true "
+"or false. For example, all blocks in an if/else expression need to be valid "
+"when `cfg!` is used for the condition, regardless of what `cfg!` is "
+"evaluating."
+msgstr ""
+"`#[cfg]`と異なり、`cfg!`はコードを削除せず、trueまたはfalseに評価されるだけです。"
+"例えば、`cfg!`が何を評価しているかに関係なく、`cfg!`が条件に利用されるとき、"
+"if/else式の中のすべてのブロックが有効でなくてはなりません。"
+
+#: src/attribute/cfg.md:15
+msgid "// This function only gets compiled if the target OS is linux\n"
+msgstr "// この関数はターゲットOSがLinuxの時のみコンパイルされます。\n"
+
+#: src/attribute/cfg.md:16 src/attribute/cfg.md:22 src/attribute/cfg.md:31
+msgid "\"linux\""
+msgstr "\"linux\""
+
+#: src/attribute/cfg.md:18
+msgid "\"You are running linux!\""
+msgstr "\"You are running linux!\""
+
+#: src/attribute/cfg.md:20
+msgid ""
+"// And this function only gets compiled if the target OS is *not* linux\n"
+msgstr "// そしてこの関数はターゲットOSがLinux *ではない* ときのみコンパイルされます。\n"
+
+#: src/attribute/cfg.md:24
+msgid "\"You are *not* running linux!\""
+msgstr "\"You are *not* running linux!\""
+
+#: src/attribute/cfg.md:30
+msgid "\"Are you sure?\""
+msgstr "\"Are you sure?\""
+
+#: src/attribute/cfg.md:32
+msgid "\"Yes. It's definitely linux!\""
+msgstr "\"Yes. It's definitely linux!\""
+
+#: src/attribute/cfg.md:34
+msgid "\"Yes. It's definitely *not* linux!\""
+msgstr "\"Yes. It's definitely *not* linux!\""
+
+#: src/attribute/cfg.md:41
+msgid ""
+"[the reference](https://doc.rust-lang.org/reference/attributes."
+"html#conditional-compilation), [`cfg!`](https://doc.rust-lang.org/std/macro."
+"cfg!.html), and [macros](../macros.md)."
+msgstr ""
+"[リファレンス](https://doc.rust-lang.org/reference/attributes."
+"html#conditional-compilation), [`cfg!`](https://doc.rust-lang.org/std/macro."
+"cfg!.html), [マクロ](../macros.md)."
+
+#: src/attribute/cfg/custom.md:3
+msgid ""
+"Some conditionals like `target_os` are implicitly provided by `rustc`, but "
+"custom conditionals must be passed to `rustc` using the `--cfg` flag."
+msgstr ""
+"`target_os`のように、いくつかの条件分岐は`rustc`が暗黙のうちに提供しています。"
+"条件を独自に追加する場合には`--cfg`フラグを用いて`rustc`に伝える必要があります。"
+
+#: src/attribute/cfg/custom.md:9
+msgid "\"condition met!\""
+msgstr "\"condition met!\""
+
+#: src/attribute/cfg/custom.md:17
+msgid "Try to run this to see what happens without the custom `cfg` flag."
+msgstr "独自の`cfg`フラグを用いない場合、何が起きるかやってみてください。"
+
+#: src/attribute/cfg/custom.md:19
+msgid "With the custom `cfg` flag:"
+msgstr "`cfg`フラグがある場合："
+
+#: src/generics.md:3
+msgid ""
+"_Generics_ is the topic of generalizing types and functionalities to broader "
+"cases. This is extremely useful for reducing code duplication in many ways, "
+"but can call for rather involved syntax. Namely, being generic requires  "
+"taking great care to specify over which types a generic type  is actually "
+"considered valid. The simplest and most common use of generics  is for type "
+"parameters."
+msgstr ""
+"ジェネリクスとは、型と関数の機能をより汎用的に使えるようにするための機能です。"
+"これはあらゆる局面でコードの重複を避けるために非常に役立ちますが、多少構文が複雑になります。"
+"すなわち、ジェネリック型を使いこなすには、どのようなジェネリック型がきちんと機能するかに細心の注意を払う必要があります。"
+"最もシンプルで一般的なジェネリクスの利用法は型パラメータです。"
+
+#: src/generics.md:10
+msgid ""
+"A type parameter is specified as generic by the use of angle brackets and "
+"upper [camel case](https://en.wikipedia.org/wiki/CamelCase): `<Aaa, Bbb, ..."
+">`. \"Generic type parameters\" are typically represented as `<T>`. In Rust, "
+"\"generic\" also describes anything that accepts one or more generic type "
+"parameters `<T>`. Any type specified as a  generic type parameter is "
+"generic, and everything else is concrete (non-generic)."
+msgstr ""
+"ジェネリック型の型パラメータにはかぎ括弧と"
+"アッパー[キャメルケース](https://en.wikipedia.org/wiki/CamelCase)（`<Aaa, Bbb, ...>`）が使われます。"
+"ジェネリックな型パラメータはたいていの場合`<T>`で示されます。"
+"Rustの場合、「ジェネリクス」には「１つ以上のジェネリックな型パラメータ`<T>`を受け付けるもの」という意味もあります。"
+"ジェネリックな型パラメータを指定された場合、それは必ずジェネリック型になり、"
+"そうでなければ必ず非ジェネリック型、すなわち具象型になります。"
+
+#: src/generics.md:16
+msgid ""
+"For example, defining a _generic function_ named `foo` that takes an "
+"argument `T` of any type:"
+msgstr "例として、あらゆる型の引数`T`をとる *ジェネリック関数* `foo`を定義すると"
+
+#: src/generics.md:23
+msgid ""
+"Because `T` has been specified as a generic type parameter using `<T>`, it  "
+"is considered generic when used here as `(arg: T)`. This is the case even if "
+"`T`  has previously been defined as a `struct`."
+msgstr ""
+"となります。`T`はジェネリックな型パラメータに指定されているので、"
+"この場所で`(arg: T)`のように使用するとジェネリック型として扱われます。"
+"これは`T`という構造体がそれ以前に定義されていても同様です。"
+
+#: src/generics.md:27
+msgid "This example shows some of the syntax in action:"
+msgstr "では、手を動かしながらジェネリック型の構文を体験していきましょう。"
+
+#: src/generics.md:30
+msgid "// A concrete type `A`.\n"
+msgstr "// `A`という具象型\n"
+
+#: src/generics.md:32
+msgid ""
+"// In defining the type `Single`, the first use of `A` is not preceded by "
+"`<A>`.\n"
+"// Therefore, `Single` is a concrete type, and `A` is defined as above.\n"
+msgstr ""
+"// `Single`という型を定義する際に`A`を使用していますが、その最初の使用よりも先に\n"
+"// `<A>`がないため、また、`A`自身も具象型であるため、`Single`は具象型となります。\n"
+
+#: src/generics.md:35
+msgid "//            ^ Here is `Single`s first use of the type `A`.\n"
+msgstr "//            ^ `Single`による`A`の一番最初の使用はここ。\n"
+
+#: src/generics.md:37
+msgid ""
+"// Here, `<T>` precedes the first use of `T`, so `SingleGen` is a generic "
+"type.\n"
+"// Because the type parameter `T` is generic, it could be anything, "
+"including\n"
+"// the concrete type `A` defined at the top.\n"
+msgstr ""
+"// ここでは`<T>`が一番初めの`T`の使用よりも先に来ています。\n"
+"// よって`SingleGen`はジェネリック型となります。\n"
+"// なぜならば型パラメータ`T`がジェネリックだからです。\n"
+"// `T`はどんな型にもなりえるため、上で定義した`A`を受け取ることもできます。\n"
+
+#: src/generics.md:44
+msgid "// `Single` is concrete and explicitly takes `A`.\n"
+msgstr "// `Single`は具象型で、`A`のみを受け取ります。\n"
+
+#: src/generics.md:47
+msgid ""
+"// Create a variable `_char` of type `SingleGen<char>`\n"
+"    // and give it the value `SingleGen('a')`.\n"
+"    // Here, `SingleGen` has a type parameter explicitly specified.\n"
+msgstr ""
+"// `_char`という名の変数を生成します。これは`SingleGen<char>`\n"
+"    // という型で、値は`SingleGen('a')`となります。\n"
+"    // ここでは、`SingleGen`には明示的な型パラメータが与えられています。\n"
+
+#: src/generics.md:52
+msgid "// `SingleGen` can also have a type parameter implicitly specified:\n"
+msgstr "// `SingleGen`型の変数には明示的に型パラメータを与えなくても構いません。\n"
+
+#: src/generics.md:53
+msgid "// Uses `A` defined at the top.\n"
+msgstr "// 上で定義した`A`を使用。\n"
+
+#: src/generics.md:54
+msgid "// Uses `i32`.\n"
+msgstr "// `i32`を使用。\n"
+
+#: src/generics.md:55
+msgid "// Uses `char`.\n"
+msgstr "// `char`を使用。\n"
+
+#: src/generics.md:61
+msgid "[`structs`](custom_types/structs.md)"
+msgstr "[構造体](custom_types/structs.md)"
+
+#: src/generics/gen_fn.md:3
+msgid ""
+"The same set of rules can be applied to functions: a type `T` becomes "
+"generic when preceded by `<T>`."
+msgstr "「型`T`はその前に`<T>`があるとジェネリック型になる」というルールは関数に対しても当てはまります。"
+
+#: src/generics/gen_fn.md:6
+msgid ""
+"Using generic functions sometimes requires explicitly specifying type  "
+"parameters. This may be the case if the function is called where the return "
+"type  is generic, or if the compiler doesn't have enough information to "
+"infer  the necessary type parameters."
+msgstr ""
+"ジェネリック関数を使用する際、型パラメータを明示する必要がある場合があります。"
+"返り値がジェネリック型である場合や、コンパイラが型パラメータを推論するのに十分な情報がない場合です。"
+
+#: src/generics/gen_fn.md:11
+msgid ""
+"A function call with explicitly specified type parameters looks like: `fun::"
+"<A, B, ...>()`."
+msgstr "型パラメータを明示したうえでの関数呼び出しの構文は`fun::<A, B, ...>()`のようになります。"
+
+#: src/generics/gen_fn.md:15
+msgid "// Concrete type `A`.\n"
+msgstr "// 具象型`A`\n"
+
+#: src/generics/gen_fn.md:16
+msgid "// Concrete type `S`.\n"
+msgstr "// 具象型`S`\n"
+
+#: src/generics/gen_fn.md:17
+msgid "// Generic type `SGen`.\n"
+msgstr "// ジェネリック型`SGen`\n"
+
+#: src/generics/gen_fn.md:18
+msgid ""
+"// The following functions all take ownership of the variable passed into\n"
+"// them and immediately go out of scope, freeing the variable.\n"
+msgstr ""
+"// 以下の関数は全て変数の所有権をとった後すぐにスコープを抜けて\n"
+"// 変数をメモリ上から開放します。\n"
+
+#: src/generics/gen_fn.md:21
+msgid ""
+"// Define a function `reg_fn` that takes an argument `_s` of type `S`.\n"
+"// This has no `<T>` so this is not a generic function.\n"
+msgstr ""
+"// `S`という型の引数`_s`をとる`reg_fn`という関数を定義。\n"
+"// `<T>`がないのでジェネリック関数ではありません。\n"
+
+#: src/generics/gen_fn.md:25
+msgid ""
+"// Define a function `gen_spec_t` that takes an argument `_s` of type "
+"`SGen<T>`.\n"
+"// It has been explicitly given the type parameter `A`, but because `A` has "
+"not \n"
+"// been specified as a generic type parameter for `gen_spec_t`, it is not "
+"generic.\n"
+msgstr ""
+"// `gen_spec_t`という関数を定義。これは`A`という型を与えられた`SGen<T>`\n"
+"// という型の引数`_s`を取ります。関数名の直後に`<A>`という型パラメータでAが\n"
+"// ジェネリックであることを明示していないので、この関数はAをジェネリック型\n"
+"// としては取りません\n"
+
+#: src/generics/gen_fn.md:30
+msgid ""
+"// Define a function `gen_spec_i32` that takes an argument `_s` of type "
+"`SGen<i32>`.\n"
+"// It has been explicitly given the type parameter `i32`, which is a "
+"specific type.\n"
+"// Because `i32` is not a generic type, this function is also not generic.\n"
+msgstr ""
+"// `gen_spec_i32`という関数を定義。\n"
+"// これは明示的な型パラメータとして`i32`を与えられた\n"
+"// `SGen<i32>`型の引数`_s`を取ります。\n"
+"// この関数もジェネリックではありません。\n"
+
+#: src/generics/gen_fn.md:35
+msgid ""
+"// Define a function `generic` that takes an argument `_s` of type "
+"`SGen<T>`.\n"
+"// Because `SGen<T>` is preceded by `<T>`, this function is generic over "
+"`T`.\n"
+msgstr ""
+"// `generic`という関数を定義。`SGen<T>`という型の引数`_s`を取ります。\n"
+"// `<T>`が`SGen<T>`に先行しているため、これはTに対してジェネリックな関数です。\n"
+
+#: src/generics/gen_fn.md:41
+msgid "// Using the non-generic functions\n"
+msgstr "// ジェネリックでない関数を使用します。\n"
+
+#: src/generics/gen_fn.md:42
+msgid "// Concrete type.\n"
+msgstr "// 具象型\n"
+
+#: src/generics/gen_fn.md:43
+msgid "// Implicitly specified type parameter `A`.\n"
+msgstr "// 型パラメータ`A`を暗黙のうちに受け取ります。\n"
+
+#: src/generics/gen_fn.md:44
+msgid "// Implicitly specified type parameter `i32`.\n"
+msgstr "// 型パラメータ`i32`を暗黙のうちに受け取ります。\n"
+
+#: src/generics/gen_fn.md:46
+msgid "// Explicitly specified type parameter `char` to `generic()`.\n"
+msgstr "// 型パラメータ`char`を明示的に`generic()`に渡します。\n"
+
+#: src/generics/gen_fn.md:49
+msgid "// Implicitly specified type parameter `char` to `generic()`.\n"
+msgstr "// 型パラメータ`char`を暗黙的に`generic()`に渡します。\n"
+
+#: src/generics/gen_fn.md:50
+msgid "'c'"
+msgstr "'c'"
+
+#: src/generics/gen_fn.md:56
+msgid "[functions](../fn.md) and [`struct`s](../custom_types/structs.md)"
+msgstr "[関数](../fn.md), [構造体](../custom_types/structs.md)"
+
+#: src/generics/impl.md:3
+msgid "Similar to functions, implementations require care to remain generic."
+msgstr "関数と同様、`impl`でメソッドを実装する際にもジェネリック型特有の記法が必要です。"
+
+#: src/generics/impl.md:6
+msgid "// Concrete type `S`\n"
+msgstr "// 具象型`S`\n"
+
+#: src/generics/impl.md:7
+msgid "// Generic type `GenericVal`\n"
+msgstr "// ジェネリック型`GenericVal`\n"
+
+#: src/generics/impl.md:8
+msgid "// impl of GenericVal where we explicitly specify type parameters:\n"
+msgstr "// 型パラメータを指定したうえで、GenericValにメソッドを実装。\n"
+
+#: src/generics/impl.md:10
+msgid "// Specify `f32`\n"
+msgstr "// `f32`の場合のメソッド\n"
+
+#: src/generics/impl.md:11
+msgid "// Specify `S` as defined above\n"
+msgstr "// 上で定義した`S`への実装\n"
+
+#: src/generics/impl.md:12
+msgid "// `<T>` Must precede the type to remain generic\n"
+msgstr "// ジェネリック型のまま扱うには`<T>`が先に来る必要があります。\n"
+
+#: src/generics/impl.md:25
+msgid "// impl of Val\n"
+msgstr "// Valに対して実装。\n"
+
+#: src/generics/impl.md:32
+msgid "// impl of GenVal for a generic type `T`\n"
+msgstr "// ジェネリック型`T`の場合のメソッドをGenValに対して実装。\n"
+
+#: src/generics/impl.md:50
+msgid ""
+"[functions returning references](../scope/lifetime/fn.md), [`impl`](../fn/"
+"methods.md), and [`struct`](../custom_types/structs.md)"
+msgstr ""
+"[参照を返す関数](../scope/lifetime/fn.md), [`impl`](../fn/"
+"methods.md), [構造体](../custom_types/structs.md)"
+
+#: src/generics/gen_trait.md:3
+msgid ""
+"Of course `trait`s can also be generic. Here we define one which "
+"reimplements the `Drop` `trait` as a generic method to `drop` itself and an "
+"input."
+msgstr ""
+"もちろんトレイトもジェネリクスを活用することができます。"
+"ここでは`Drop`トレイトをジェネリックメソッドとして再実装し、"
+"自身と引数として受け取った値の両方を`drop`するようなメソッドにします。"
+
+#: src/generics/gen_trait.md:7
+msgid "// Non-copyable types.\n"
+msgstr ""
+"// コピー不可な型\n"
+"// 訳注: `clone()`メソッドを用いないかぎり、値のコピーではなくムーブが起きる型\n"
+
+#: src/generics/gen_trait.md:10
+msgid "// A trait generic over `T`.\n"
+msgstr "// ジェネリック型 `T`に対するトレイト\n"
+
+#: src/generics/gen_trait.md:13
+msgid ""
+"// Define a method on the caller type which takes an\n"
+"    // additional single parameter `T` and does nothing with it.\n"
+msgstr ""
+"// `self`に加えてもう一つジェネリック型を受け取り、\n"
+"    // 何もしないメソッドのシグネチャを定義。\n"
+
+#: src/generics/gen_trait.md:17
+msgid ""
+"// Implement `DoubleDrop<T>` for any generic parameter `T` and\n"
+"// caller `U`.\n"
+msgstr ""
+"// `U`を`self`として、`T`をもう一つの引数として受け取る`DoubleDrop<T>`\n"
+"// を実装する。`U`,`T`はいずれもジェネリック型。\n"
+
+#: src/generics/gen_trait.md:21
+msgid ""
+"// This method takes ownership of both passed arguments,\n"
+"    // deallocating both.\n"
+msgstr "// このメソッドは2つの引数の所有権を取り、メモリ上から開放します。\n"
+
+#: src/generics/gen_trait.md:30
+msgid "// Deallocate `empty` and `null`.\n"
+msgstr "// `empty`と`null`を開放。\n"
+
+#: src/generics/gen_trait.md:33
+msgid ""
+"//empty;\n"
+"    //null;\n"
+"    // ^ TODO: Try uncommenting these lines.\n"
+msgstr ""
+"//empty;\n"
+"    //null;\n"
+"    // ^ TODO: これらの行をアンコメントしてみましょう。\n"
+
+#: src/generics/gen_trait.md:41
+msgid ""
+"[`Drop`](https://doc.rust-lang.org/std/ops/trait.Drop.html), [`struct`](../"
+"custom_types/structs.md), and [`trait`](../trait.md)"
+msgstr ""
+"[`Drop`](https://doc.rust-lang.org/std/ops/trait.Drop.html), [構造体](../"
+"custom_types/structs.md), [トレイト](../trait.md)"
+
+#: src/generics/bounds.md:3
+msgid ""
+"When working with generics, the type parameters often must use traits as "
+"_bounds_ to stipulate what functionality a type implements. For example, the "
+"following example uses the trait `Display` to print and so it requires `T` "
+"to be bound by `Display`; that is, `T` _must_ implement `Display`."
+msgstr ""
+"ジェネリックプログラミングをしていると、型パラメータが特定の機能を持っていることを規定するため、"
+"トレイトに境界を設ける必要があることがよくあります。"
+"例えば、以下の例では、引数の`Display`トレイトを用いて出力を行うため、"
+"`T`が`Display`を持っていることを規定しています。"
+"つまり、「`T`は`Display`を実装 *していなくてはならない* 」という意味です。"
+
+#: src/generics/bounds.md:9
+msgid ""
+"// Define a function `printer` that takes a generic type `T` which\n"
+"// must implement trait `Display`.\n"
+msgstr ""
+"// `Display`トレイトを実装している`T`を引数として取ります。\n"
+"// `printer`という関数を定義。\n"
+
+#: src/generics/bounds.md:16
+msgid ""
+"Bounding restricts the generic to types that conform to the bounds. That is:"
+msgstr "境界は、ジェネリクスを全ての型ではなく、一定条件を満たす型に対してのみ適用するためにあります。つまり"
+
+#: src/generics/bounds.md:20
+msgid ""
+"// Error! `Vec<T>` does not implement `Display`. This\n"
+"// specialization will fail.\n"
+msgstr ""
+"// エラー！`Vec<T>`は`Display`を実装していないため、この特殊化\n"
+"// は失敗します。\n"
+
+#: src/generics/bounds.md:26
+msgid ""
+"Another effect of bounding is that generic instances are allowed to access "
+"the  [methods](../fn/methods.md) of traits specified in the bounds. For "
+"example:"
+msgstr ""
+"境界のもう一つの効果は、ジェネリック型のインスタンスが、"
+"境界条件となるトレイトの[メソッド](../fn/methods.md)"
+"にアクセスすることができるようになる点です。以下がその例です。"
+
+#: src/generics/bounds.md:30
+msgid "// A trait which implements the print marker: `{:?}`.\n"
+msgstr "// 出力時のマーカー`{:?}`を実装するトレイト\n"
+
+#: src/generics/bounds.md:45
+msgid ""
+"// The generic `T` must implement `Debug`. Regardless\n"
+"// of the type, this will work properly.\n"
+msgstr ""
+"// ジェネリック型`T`は`Debug`トレイトを実装していなくてはなりません。\n"
+"// その限りにおいて、`T`がどのような具象型であろうとも次の関数は動作します。\n"
+
+#: src/generics/bounds.md:51
+msgid ""
+"// `T` must implement `HasArea`. Any type which meets\n"
+"// the bound can access `HasArea`'s function `area`.\n"
+msgstr ""
+"// 「`T`は`HasArea`を実装していなくてはならない」という境界条件を\n"
+"// 満たしていれば、`HasArea`の関数`area`にアクセスできます。\n"
+
+#: src/generics/bounds.md:61
+msgid "\"Area: {}\""
+msgstr "\"Area: {}\""
+
+#: src/generics/bounds.md:63
+msgid ""
+"//print_debug(&_triangle);\n"
+"    //println!(\"Area: {}\", area(&_triangle));\n"
+"    // ^ TODO: Try uncommenting these.\n"
+"    // | Error: Does not implement either `Debug` or `HasArea`. \n"
+msgstr ""
+"//print_debug(&_triangle);\n"
+"    //println!(\"Area: {}\", area(&_triangle));\n"
+"    // ^ TODO: これらの行をアンコメントしてみましょう。\n"
+"    // | Error: `Debug` も `HasArea`もどちらも実装されていません！\n"
+
+#: src/generics/bounds.md:70
+msgid ""
+"As an additional note, [`where`](../generics/where.md) clauses can also be "
+"used to apply bounds in some cases to be more expressive."
+msgstr ""
+"付け加えておくと、[`where`](../generics/where.md)句を用いて境界を適用することもできます。"
+"場合によってはこちらの記法を使用したほうが読みやすくなる場合もあります。"
+
+#: src/generics/bounds.md:75
+msgid ""
+"[`std::fmt`](../hello/print.md), [`struct`s](../custom_types/structs.md), "
+"and [`trait`s](../trait.md)"
+msgstr ""
+"[`std::fmt`](../hello/print.md), [構造体](../custom_types/structs.md), "
+"[トレイト](../trait.md)"
+
+#: src/generics/bounds/testcase_empty.md:3
+msgid ""
+"A consequence of how bounds work is that even if a `trait` doesn't include "
+"any functionality, you can still use it as a bound. `Eq` and `Copy` are "
+"examples of such `trait`s from the `std` library."
+msgstr ""
+"トレイト境界の仕組みから、「トレイトがなにも機能を持っていなくとも境界条件として使用できることには変わりはない」"
+"という帰結がもたらされます。`Eq`と`Copy`は`std`ライブラリにおけるそのような例です。"
+
+#: src/generics/bounds/testcase_empty.md:17
+msgid ""
+"// These functions are only valid for types which implement these\n"
+"// traits. The fact that the traits are empty is irrelevant.\n"
+msgstr ""
+"// 以下の関数はトレイト境界を設けていますが、そのトレイトが空である\n"
+"// か否かとは関係ありません。\n"
+
+#: src/generics/bounds/testcase_empty.md:20
+msgid "\"red\""
+msgstr "\"red\""
+
+#: src/generics/bounds/testcase_empty.md:21
+msgid "\"blue\""
+msgstr "\"blue\""
+
+#: src/generics/bounds/testcase_empty.md:28
+msgid ""
+"// `red()` won't work on a blue jay nor vice versa\n"
+"    // because of the bounds.\n"
+msgstr ""
+"// トレイト境界のため、`red`は`blue_jay`に対しては使用できません。\n"
+"    // `blue`と`Cardinal`も同様です。\n"
+
+#: src/generics/bounds/testcase_empty.md:30
+msgid "\"A cardinal is {}\""
+msgstr "\"A cardinal is {}\""
+
+#: src/generics/bounds/testcase_empty.md:31
+msgid "\"A blue jay is {}\""
+msgstr "\"A blue jay is {}\""
+
+#: src/generics/bounds/testcase_empty.md:32
+msgid ""
+"//println!(\"A turkey is {}\", red(&_turkey));\n"
+"    // ^ TODO: Try uncommenting this line.\n"
+msgstr ""
+"//println!(\"A turkey is {}\", red(&_turkey));\n"
+"    // ^ TODO: この行をアンコメントしてみましょう。\n"
+
+#: src/generics/bounds/testcase_empty.md:39
+msgid ""
+"[`std::cmp::Eq`](https://doc.rust-lang.org/std/cmp/trait.Eq.html), [`std::"
+"marker::Copy`](https://doc.rust-lang.org/std/marker/trait.Copy.html), and "
+"[`trait`s](../../trait.md)"
+msgstr ""
+"[`std::cmp::Eq`](https://doc.rust-lang.org/std/cmp/trait.Eq.html), [`std::"
+"marker::Copy`](https://doc.rust-lang.org/std/marker/trait.Copy.html), "
+"[トレイト](../../trait.md)"
+
+#: src/generics/multi_bounds.md:3
+msgid ""
+"Multiple bounds for a single type can be applied with a `+`. Like normal, "
+"different types are separated with `,`."
+msgstr "`+`を用いて1つの型に複数のトレイト境界を設けることができます。複数の引数を受け取るときは、通常時と同様、`,`で区切ります。"
+
+#: src/generics/multi_bounds.md:10
+msgid "\"Debug: `{:?}`\""
+msgstr "\"Debug: `{:?}`\""
+
+#: src/generics/multi_bounds.md:11
+msgid "\"Display: `{}`\""
+msgstr "\"Display: `{}`\""
+
+#: src/generics/multi_bounds.md:15
+msgid "\"t: `{:?}`\""
+msgstr "\"t: `{:?}`\""
+
+#: src/generics/multi_bounds.md:16
+msgid "\"u: `{:?}`\""
+msgstr "\"u: `{:?}`\""
+
+#: src/generics/multi_bounds.md:20
+msgid "\"words\""
+msgstr "\"words\""
+
+#: src/generics/multi_bounds.md:25
+msgid ""
+"//compare_prints(&array);\n"
+"    // TODO ^ Try uncommenting this.\n"
+msgstr ""
+"//compare_prints(&array);\n"
+"    // TODO ^ ここをアンコメントしてみましょう。\n"
+
+#: src/generics/multi_bounds.md:34
+msgid "[`std::fmt`](../hello/print.md) and [`trait`s](../trait.md)"
+msgstr "[`std::fmt`](../hello/print.md), [トレイト](../trait.md)"
+
+#: src/generics/where.md:3
+msgid ""
+"A bound can also be expressed using a `where` clause immediately before the "
+"opening `{`, rather than at the type's first mention.  Additionally, `where` "
+"clauses can apply bounds to arbitrary types,  rather than just to type "
+"parameters."
+msgstr ""
+"トレイト境界は、`{`の直前に`where`句を導入することでも設けることができます。"
+"`where`はさらに、型パラメータだけでなく任意の型に対して適用できます。"
+
+#: src/generics/where.md:8
+msgid "Some cases that a `where` clause is useful:"
+msgstr "`where`句のほうが有効なケースには例えば以下のようなものがあります。"
+
+#: src/generics/where.md:10
+msgid "When specifying generic types and bounds separately is clearer:"
+msgstr "ジェネリック型とジェネリック境界に別々に制限を加えたほうが明瞭になる場合"
+
+#: src/generics/where.md:14
+msgid "// Expressing bounds with a `where` clause\n"
+msgstr "// `where`を用いてジェネリック境界を設けます。\n"
+
+#: src/generics/where.md:21
+msgid ""
+"When using a `where` clause is more expressive than using normal syntax.  "
+"The `impl` in this example cannot be directly expressed without a `where` "
+"clause:"
+msgstr "`where`句の方が通常の構文より表現力が高い場合。この例では`where`句を使わずに書くことはできません。"
+
+#: src/generics/where.md:30
+msgid ""
+"// Because we would otherwise have to express this as `T: Debug` or \n"
+"// use another method of indirect approach, this requires a `where` clause:\n"
+msgstr ""
+"// `where`句を用いない場合、以下と等価な機能を実装するには、\n"
+"// `T: Debug`という形で表現するか、別の直接的でない方法\n"
+"// を使用するかしなくてはなりません。\n"
+
+#: src/generics/where.md:35
+msgid ""
+"// We want `Option<T>: Debug` as our bound because that is what's\n"
+"    // being printed. Doing otherwise would be using the wrong bound.\n"
+msgstr ""
+"// 出力されるのが`Some(self)`であるため、この関数の\n"
+"    // ジェネリック境界として`Option<T>: Debug`を使用したい。\n"
+
+#: src/generics/where.md:51
+msgid ""
+"[RFC](https://github.com/rust-lang/rfcs/blob/master/text/0135-where.md), "
+"[`struct`](../custom_types/structs.md), and [`trait`](../trait.md)"
+msgstr ""
+"[RFC](https://github.com/rust-lang/rfcs/blob/master/text/0135-where.md), "
+"[構造体](../custom_types/structs.md), [トレイト](../trait.md)"
+
+#: src/generics/new_types.md:3
+msgid ""
+"The `newtype` idiom gives compile time guarantees that the right type of "
+"value is supplied to a program."
+msgstr ""
+"ニュータイプイディオムは正しい型の値が与えられていることをコンパイル時に保証することができます。"
+
+#: src/generics/new_types.md:6
+msgid ""
+"For example, an age verification function that checks age in years, _must_ "
+"be given a value of type `Years`."
+msgstr "例えば、年齢を年単位で確認する`old_enough`には「Years」という型の値を *与えなければならない* ようにすることが可能です。"
+
+#: src/generics/new_types.md:22
+msgid "/// truncates partial years\n"
+msgstr "/// 1年に満たない日付は切り捨て。\n"
+
+#: src/generics/new_types.md:35 src/generics/new_types.md:36
+msgid "\"Old enough {}\""
+msgstr "\"Old enough {}\""
+
+#: src/generics/new_types.md:37
+msgid "// println!(\"Old enough {}\", old_enough(&age_days));\n"
+msgstr "// println!(\"Old enough {}\", old_enough(&age_days));\n"
+
+#: src/generics/new_types.md:41
+msgid ""
+"Uncomment the last print statement to observe that the type supplied must be "
+"`Years`."
+msgstr "最後の print文 のコメントを外して、与えられた型が `Years` でなければならないことを確認してください。"
+
+#: src/generics/new_types.md:43
+msgid ""
+"To obtain the `newtype`'s value as the base type, you may use the tuple or "
+"destructuring syntax like so:"
+msgstr "`newtype`の元に使われている型のデータを取得するには、以下のようにタプルやデストラクト構文を用いることで取得できます。"
+
+#: src/generics/new_types.md:49
+msgid "// Tuple\n"
+msgstr "// タプル\n"
+
+#: src/generics/new_types.md:50
+msgid "// Destructuring\n"
+msgstr "// デストラクト\n"
+
+#: src/generics/new_types.md:56
+msgid "[`structs`](../custom_types/structs.md)"
+msgstr "[構造体](../custom_types/structs.md)"
+
+#: src/generics/assoc_items.md:3
+msgid ""
+"\"Associated Items\" refers to a set of rules pertaining to [`item`](https://"
+"doc.rust-lang.org/reference/items.html)s of various types. It is an "
+"extension to `trait` generics, and allows  `trait`s to internally define new "
+"items."
+msgstr ""
+"関連要素とは複数の型の[要素](https://doc.rust-lang.org/reference/items.html)に関係のある規則の総称です。"
+"トレイトの拡張機能であり、トレイトの中で新しい要素を定義することを可能にします。"
+
+#: src/generics/assoc_items.md:7
+msgid ""
+"One such item is called an _associated type_, providing simpler usage  "
+"patterns when the `trait` is generic over its container type."
+msgstr ""
+"そのように定義する要素の一つに **関連型** があります。"
+"これにより、ジェネリックなコンテナ型に対するトレイトを使用する際に、よりシンプルな書き方ができるようになります。"
+
+#: src/generics/assoc_items.md:12
+msgid ""
+"[RFC](https://github.com/rust-lang/rfcs/blob/master/text/0195-associated-"
+"items.md)"
+msgstr ""
+"[RFC](https://github.com/rust-lang/rfcs/blob/master/text/0195-associated-"
+"items.md)"
+
+#: src/generics/assoc_items/the_problem.md:3
+msgid ""
+"A `trait` that is generic over its container type has type specification "
+"requirements - users of the `trait` _must_ specify all of its generic types."
+msgstr ""
+"コンテナ型に、その要素に対してジェネリックなトレイトを実装した場合、"
+"そのトレイトを使用する者は全てのジェネリック型を明記 *しなくてはなりません* 。"
+
+#: src/generics/assoc_items/the_problem.md:6
+msgid ""
+"In the example below, the `Contains` `trait` allows the use of the generic  "
+"types `A` and `B`. The trait is then implemented for the `Container` type,  "
+"specifying `i32` for `A` and `B` so that it can be used with `fn "
+"difference()`."
+msgstr ""
+"以下の例では`Contains`トレイトはジェネリック型`A`と`B`の使用を許しています。"
+"その後、`Container`型に対して`Contains`を実装していますが、"
+"その際後に`fn difference()`が使用できるように、`A`、`B`はそれぞれ`i32`と明記されています。"
+
+#: src/generics/assoc_items/the_problem.md:10
+msgid ""
+"Because `Contains` is generic, we are forced to explicitly state _all_ of "
+"the  generic types for `fn difference()`. In practice, we want a way to "
+"express that  `A` and `B` are determined by the _input_ `C`. As you will see "
+"in the next  section, associated types provide exactly that capability."
+msgstr ""
+"`Contains`はジェネリックトレイトなので、`fn difference()`では **全ての** ジェネリック型を宣言しなくてはなりません。"
+"実際のところ、`A`と`B`は **引数** である`C`によって決定されていて欲しいにも関わらず、です。"
+"これは次のページで紹介する関連型と呼ばれる機能によって可能です。"
+
+#: src/generics/assoc_items/the_problem.md:17
+#: src/generics/assoc_items/types.md:36
+msgid ""
+"// A trait which checks if 2 items are stored inside of container.\n"
+"// Also retrieves first or last value.\n"
+msgstr ""
+"// ２つの要素がコンテナ型の中にあることをチェックするトレイト\n"
+"// また、最初と最後の値を取得することもできます。\n"
+
+#: src/generics/assoc_items/the_problem.md:21
+msgid "// Explicitly requires `A` and `B`.\n"
+msgstr "// `A`と`B`両方を明示的に要求します。\n"
+
+#: src/generics/assoc_items/the_problem.md:22
+#: src/generics/assoc_items/the_problem.md:23
+msgid "// Doesn't explicitly require `A` or `B`.\n"
+msgstr "// `A`、`B`いずれも要求しません。\n"
+
+#: src/generics/assoc_items/the_problem.md:27
+msgid "// True if the numbers stored are equal.\n"
+msgstr "// コンテナ内の２つの要素が等しければTrueを返します。\n"
+
+#: src/generics/assoc_items/the_problem.md:32
+#: src/generics/assoc_items/types.md:60
+msgid "// Grab the first number.\n"
+msgstr "// ひとつ目の値を取得。\n"
+
+#: src/generics/assoc_items/the_problem.md:35
+#: src/generics/assoc_items/types.md:63
+msgid "// Grab the last number.\n"
+msgstr "// 最後（2つめ）の値を取得。\n"
+
+#: src/generics/assoc_items/the_problem.md:38
+msgid ""
+"// `C` contains `A` and `B`. In light of that, having to express `A` and\n"
+"// `B` again is a nuisance.\n"
+msgstr ""
+"// `A`と`B`は`C`に保持されていることを考慮すると、`A`と`B`を\n"
+"// ２度も書くのは面倒。\n"
+
+#: src/generics/assoc_items/the_problem.md:52
+#: src/generics/assoc_items/types.md:77
+msgid "\"Does container contain {} and {}: {}\""
+msgstr "\"Does container contain {} and {}: {}\""
+
+#: src/generics/assoc_items/the_problem.md:55
+#: src/generics/assoc_items/types.md:80
+msgid "\"First number: {}\""
+msgstr "\"First number: {}\""
+
+#: src/generics/assoc_items/the_problem.md:56
+#: src/generics/assoc_items/types.md:81
+msgid "\"Last number: {}\""
+msgstr "\"Last number: {}\""
+
+#: src/generics/assoc_items/the_problem.md:58
+#: src/generics/assoc_items/types.md:83
+msgid "\"The difference is: {}\""
+msgstr "\"The difference is: {}\""
+
+#: src/generics/assoc_items/the_problem.md:64
+msgid ""
+"[`struct`s](../../custom_types/structs.md), and [`trait`s](../../trait.md)"
+msgstr ""
+"[構造体](../../custom_types/structs.md), [トレイト](../../trait.md)"
+
+#: src/generics/assoc_items/types.md:3
+msgid ""
+"The use of \"Associated types\" improves the overall readability of code  by "
+"moving inner types locally into a trait as _output_ types. Syntax for the "
+"`trait` definition is as follows:"
+msgstr ""
+"関連型を使用すると、コンテナ型の中の要素をトレイトの中に *出力型* として書くことで、"
+"全体の可読性を上げることができます。トレイトを定義する際の構文は以下のようになります。"
+
+#: src/generics/assoc_items/types.md:8
+msgid ""
+"// `A` and `B` are defined in the trait via the `type` keyword.\n"
+"// (Note: `type` in this context is different from `type` when used for\n"
+"// aliases).\n"
+msgstr ""
+"// `A`と`B`は`type`キーワードを用いてトレイト内で宣言されています。\n"
+"// （注意：この文脈で使用する`type`は型エイリアスを宣言する際の`type`とは\n"
+"// 異なることに注意しましょう。）\n"
+
+#: src/generics/assoc_items/types.md:15
+msgid "// Updated syntax to refer to these new types generically.\n"
+msgstr ""
+"// これらの新しい型をジェネリックに使用するために、構文が\n"
+"    // アップデートされています。\n"
+
+#: src/generics/assoc_items/types.md:20
+msgid ""
+"Note that functions that use the `trait` `Contains` are no longer required "
+"to express `A` or `B` at all:"
+msgstr "`Contains`トレイトを使用する関数において、`A`と`B`を明示する必要がなくなっていることに注目しましょう。"
+
+#: src/generics/assoc_items/types.md:24
+msgid "// Without using associated types\n"
+msgstr "// 関連型を使用しない場合\n"
+
+#: src/generics/assoc_items/types.md:27
+msgid "// Using associated types\n"
+msgstr "// 使用する場合\n"
+
+#: src/generics/assoc_items/types.md:32
+msgid ""
+"Let's rewrite the example from the previous section using associated types:"
+msgstr "前セクションの例を関連型を使用して書きなおしてみましょう。"
+
+#: src/generics/assoc_items/types.md:40
+msgid "// Define generic types here which methods will be able to utilize.\n"
+msgstr "// メソッドが使用できるジェネリック型を定義。\n"
+
+#: src/generics/assoc_items/types.md:50
+msgid ""
+"// Specify what types `A` and `B` are. If the `input` type\n"
+"    // is `Container(i32, i32)`, the `output` types are determined\n"
+"    // as `i32` and `i32`.\n"
+msgstr ""
+"// `A`と`B`がどの型であるかを明示。入力型（訳注：つまり`Self`の型）\n"
+"    // が`Container(i32, i32)`である場合、出力型は`i32`と`i32`となります。\n"
+
+#: src/generics/assoc_items/types.md:56
+msgid "// `&Self::A` and `&Self::B` are also valid here.\n"
+msgstr "// `&i32`の代わりに`&Self::A`または`&self::B`と書いても構いません\n"
+
+#: src/generics/phantom.md:3
+msgid ""
+"A phantom type parameter is one that doesn't show up at runtime, but is "
+"checked statically (and only) at compile time."
+msgstr ""
+"幽霊型とは実行時には存在しないけれども、"
+"コンパイル時に静的に型チェックされるような型のことです。"
+
+#: src/generics/phantom.md:6
+msgid ""
+"Data types can use extra generic type parameters to act as markers or to "
+"perform type checking at compile time. These extra parameters hold no "
+"storage values, and have no runtime behavior."
+msgstr ""
+"構造体などのデータ型は、ジェネリック型パラメータを一つ余分に持ち、"
+"それをマーカーとして使ったりコンパイル時の型検査に使ったりすることができます。"
+"このマーカーは実際の値を何も持たず、したがって実行時の挙動そのものにはいかなる影響ももたらしません。"
+
+#: src/generics/phantom.md:10
+msgid ""
+"In the following example, we combine [std::marker::PhantomData](https://doc."
+"rust-lang.org/std/marker/struct.PhantomData.html) with the phantom type "
+"parameter concept to create tuples containing different data types."
+msgstr ""
+"以下の例では、そのようなマーカーとして幽霊型（[std::marker::PhantomData](https://doc.rust-lang.org/std/marker/struct.PhantomData.html)）"
+"を用い、それぞれ異なった型の値を持つタプルを作成します。"
+
+#: src/generics/phantom.md:16
+msgid ""
+"// A phantom tuple struct which is generic over `A` with hidden parameter "
+"`B`.\n"
+msgstr "// ジェネリックなタプル構造体。2つ目のパラメータは幽霊型。\n"
+
+#: src/generics/phantom.md:18 src/generics/phantom.md:22
+msgid "// Allow equality test for this type.\n"
+msgstr "// 比較演算子（`==`）での比較を可能にします。\n"
+
+#: src/generics/phantom.md:20
+msgid ""
+"// A phantom type struct which is generic over `A` with hidden parameter "
+"`B`.\n"
+msgstr "// 同様に構造体を定義。\n"
+
+#: src/generics/phantom.md:24
+msgid ""
+"// Note: Storage is allocated for generic type `A`, but not for `B`.\n"
+"//       Therefore, `B` cannot be used in computations.\n"
+msgstr ""
+"// 注意点:  ジェネリック型Aに対してはメモリが割り当てられていますが、\n"
+"//          Bには割り当てられていないため、計算に使うことはできません。\n"
+
+#: src/generics/phantom.md:29
+msgid ""
+"// Here, `f32` and `f64` are the hidden parameters.\n"
+"    // PhantomTuple type specified as `<char, f32>`.\n"
+msgstr ""
+"// ここで `f32` と `f64` は隠しパラメータです。\n"
+"    // <char, f32>と型宣言されたPhantomTupleを作成。\n"
+
+#: src/generics/phantom.md:31 src/generics/phantom.md:33
+#: src/generics/phantom.md:37 src/generics/phantom.md:42
+#: src/scope/borrow/ref.md:12
+msgid "'Q'"
+msgstr "'Q'"
+
+#: src/generics/phantom.md:32
+msgid "// PhantomTuple type specified as `<char, f64>`.\n"
+msgstr "// <char, f64>と型宣言されたPhantomTupleを作成。\n"
+
+#: src/generics/phantom.md:35
+msgid "// Type specified as `<char, f32>`.\n"
+msgstr "// <char, f32>の型が与えられた構造体を作成。\n"
+
+#: src/generics/phantom.md:40
+msgid "// Type specified as `<char, f64>`.\n"
+msgstr "// 同様に<char, f64>の構造体\n"
+
+#: src/generics/phantom.md:46
+msgid ""
+"// Compile-time Error! Type mismatch so these cannot be compared:\n"
+"    // println!(\"_tuple1 == _tuple2 yields: {}\",\n"
+"    //           _tuple1 == _tuple2);\n"
+msgstr ""
+"// コンパイルエラー！型が違うので比較することができません！\n"
+"    // println!(\"_tuple1 == _tuple2 yields: {}\",\n"
+"    //           _tuple1 == _tuple2);\n"
+
+#: src/generics/phantom.md:50
+msgid ""
+"// Compile-time Error! Type mismatch so these cannot be compared:\n"
+"    // println!(\"_struct1 == _struct2 yields: {}\",\n"
+"    //           _struct1 == _struct2);\n"
+msgstr ""
+"// コンパイルエラー! 型が違うので比較することができません!\n"
+"    // println!(\"_struct1 == _struct2 yields: {}\",\n"
+"    //           _struct1 == _struct2);\n"
+
+#: src/generics/phantom.md:58
+msgid ""
+"[Derive](../trait/derive.md), [struct](../custom_types/structs.md), and "
+"[TupleStructs](../custom_types/structs.md)"
+msgstr ""
+"[導出](../trait/derive.md), [構造体](../custom_types/structs.md), "
+"[タプル構造体](../custom_types/structs.md)"
+
+#: src/generics/phantom/testcase_units.md:3
+msgid ""
+"A useful method of unit conversions can be examined by implementing `Add` "
+"with a phantom type parameter. The `Add` `trait` is examined below:"
+msgstr ""
+"共通の単位同士を扱う際のチェックのために、`Add`を幽霊型を用いた実装にすると便利な場合があります。"
+"その場合`Add`トレイトは以下のようになります。"
+
+#: src/generics/phantom/testcase_units.md:7
+msgid ""
+"// This construction would impose: `Self + RHS = Output`\n"
+"// where RHS defaults to Self if not specified in the implementation.\n"
+msgstr ""
+"// このように定義しておくと、`Self + RHS = Output`であることが保証され、\n"
+"// かつ、impl時にRHSの型が明示されていない場合、デフォルトでSelfと同じに\n"
+"// なります。\n"
+
+#: src/generics/phantom/testcase_units.md:14
+msgid "// `Output` must be `T<U>` so that `T<U> + T<U> = T<U>`.\n"
+msgstr "// `Output`は`T<U>`でなくてはならないので`T<U> + T<U> = T<U>`となります。\n"
+
+#: src/generics/phantom/testcase_units.md:22
+msgid "The whole implementation:"
+msgstr "以下は全体を示した例です。"
+
+#: src/generics/phantom/testcase_units.md:27
+msgid "/// Create void enumerations to define unit types.\n"
+msgstr "/// 単位を定義するため、空の列挙型を作成。\n"
+
+#: src/generics/phantom/testcase_units.md:33
+msgid ""
+"/// `Length` is a type with phantom type parameter `Unit`,\n"
+"/// and is not generic over the length type (that is `f64`).\n"
+"///\n"
+"/// `f64` already implements the `Clone` and `Copy` traits.\n"
+msgstr ""
+"/// `Length`は`Unit`という幽霊型パラメータを持つ型ですが\n"
+"/// 長さを表す型はジェネリック型ではなく`f64`です。\n"
+"///\n"
+"/// `f64`ははじめから`Clone`、`Copy`トレイトを持っています。\n"
+
+#: src/generics/phantom/testcase_units.md:40
+msgid "/// The `Add` trait defines the behavior of the `+` operator.\n"
+msgstr "/// `Add`トレイトは加算演算子(`+`)の挙動を定義します。\n"
+
+#: src/generics/phantom/testcase_units.md:45
+msgid "// add() returns a new `Length` struct containing the sum.\n"
+msgstr ""
+"// add()は`Length`の新しいインスタンスを返します。\n"
+"    // Lengthの中の値は合計値になっています。\n"
+
+#: src/generics/phantom/testcase_units.md:47
+msgid "// `+` calls the `Add` implementation for `f64`.\n"
+msgstr "// ここでの`+`は`f64`の`Add`実装を呼び出します。\n"
+
+#: src/generics/phantom/testcase_units.md:53
+msgid "// Specifies `one_foot` to have phantom type parameter `Inch`.\n"
+msgstr "// `one_foot`が幽霊型`Inch`を持つように明示します。\n"
+
+#: src/generics/phantom/testcase_units.md:55
+msgid "// `one_meter` has phantom type parameter `Mm`.\n"
+msgstr "// `one_meter`が幽霊型`Mm`を持つように明示します。\n"
+
+#: src/generics/phantom/testcase_units.md:58
+msgid ""
+"// `+` calls the `add()` method we implemented for `Length<Unit>`.\n"
+"    //\n"
+"    // Since `Length` implements `Copy`, `add()` does not consume\n"
+"    // `one_foot` and `one_meter` but copies them into `self` and `rhs`.\n"
+msgstr ""
+"// 以下の`+`は上で定義した`Length<Unit>`用の`add()`メソッドを呼び出します。\n"
+"    //\n"
+"    // `Length`は`Copy`トレイトを持っているため、`add()`は`one_foot`と`one_meter`\n"
+"    // を消費する代わりにそのコピーを作り、`self`、`rhs`として扱います。\n"
+
+#: src/generics/phantom/testcase_units.md:65
+msgid "// Addition works.\n"
+msgstr "// 加算が問題なく実行されていることを確認。\n"
+
+#: src/generics/phantom/testcase_units.md:66
+msgid "\"one foot + one_foot = {:?} in\""
+msgstr "\"one foot + one_foot = {:?} in\""
+
+#: src/generics/phantom/testcase_units.md:67
+msgid "\"one meter + one_meter = {:?} mm\""
+msgstr "\"one meter + one_meter = {:?} mm\""
+
+#: src/generics/phantom/testcase_units.md:69
+msgid ""
+"// Nonsensical operations fail as they should:\n"
+"    // Compile-time Error: type mismatch.\n"
+"    //let one_feter = one_foot + one_meter;\n"
+msgstr ""
+"// 異なる単位間の加算は意味を成さないので、\n"
+"    // 以下はきちんとコンパイルエラーになります。\n"
+"    // コンパイルエラー：タイプミスマッチ\n"
+"    //let one_feter = one_foot + one_meter;\n"
+
+#: src/generics/phantom/testcase_units.md:77
+msgid ""
+"[Borrowing (`&`)](../../scope/borrow.md), [Bounds (`X: Y`)](../../generics/"
+"bounds.md), [enum](../../custom_types/enum.md), [impl & self](../../fn/"
+"methods.md), [Overloading](../../trait/ops.md), [ref](../../scope/borrow/ref."
+"md), [Traits (`X for Y`)](../../trait.md), and [TupleStructs](../../"
+"custom_types/structs.md)."
+msgstr ""
+"[借用 (`&`)](../../scope/borrow.md), [境界 (`X: Y`)](../../generics/"
+"bounds.md), [列挙型](../../custom_types/enum.md), [impl & self](../../fn/"
+"methods.md), [演算子のオーバーロード](../../trait/ops.md), [ref](../../scope/borrow/ref."
+"md), [トレイト (`X for Y`)](../../trait.md), [タプル構造体](../../"
+"custom_types/structs.md)."
+
+#: src/scope.md:3
+msgid ""
+"Scopes play an important part in ownership, borrowing, and lifetimes. That "
+"is, they indicate to the compiler when borrows are valid, when  resources "
+"can be freed, and when variables are created or destroyed."
+msgstr ""
+"所有権、借用、ライフタイムといったRustに特有の概念において、"
+"変数のスコープは重要な役割を果たします。"
+"すなわち、スコープの存在によってコンパイラは借用は可能か否か、"
+"メモリ上の資源は解放可能か、変数はいつ作成され、いつ破棄されるか。といったことを知るのです。"
+
+#: src/scope/raii.md:3
+msgid ""
+"Variables in Rust do more than just hold data in the stack: they also _own_ "
+"resources, e.g. `Box<T>` owns memory in the heap. Rust enforces [RAII]"
+"(https://en.wikipedia.org/wiki/Resource_Acquisition_Is_Initialization) "
+"(Resource Acquisition Is Initialization), so whenever an object goes out of "
+"scope, its destructor is called and its owned resources are freed."
+msgstr ""
+"Rustの変数は単にデータをスタック上に保持するだけのものではありません。"
+"例えばヒープメモリを確保する`Box<T>`のように、変数はメモリ上の資源を *保有* する場合もあるのです。"
+"Rustは[RAII](https://en.wikipedia.org/wiki/Resource_Acquisition_Is_Initialization)"
+"(Resource Acquisition Is Initialization)を強制するので、"
+"オブジェクトがスコープを抜けると、必ずデストラクタが呼び出されてそのオブジェクトが保持していた資源が解放されます。"
+
+#: src/scope/raii.md:8
+msgid ""
+"This behavior shields against _resource leak_ bugs, so you'll never have to "
+"manually free memory or worry about memory leaks again! Here's a quick "
+"showcase:"
+msgstr ""
+"この振る舞いは *リソースリーク* バグを防ぐのに役立ちます。"
+"手動でメモリを解放したり、メモリリークバグにわずらわされたりすることはなくなるのです！"
+"簡単な例で説明しましょう。"
+
+#: src/scope/raii.md:12
+msgid "// raii.rs\n"
+msgstr "// raii.rs\n"
+
+#: src/scope/raii.md:14 src/scope/raii.md:21 src/scope/raii.md:26
+msgid "// Allocate an integer on the heap\n"
+msgstr "// 整数をヒープ上に確保。\n"
+
+#: src/scope/raii.md:17
+msgid "// `_box1` is destroyed here, and memory gets freed\n"
+msgstr "// `_box1`はここで破棄され、メモリは解放されます。\n"
+
+#: src/scope/raii.md:24
+msgid "// A nested scope:\n"
+msgstr "// ネストしたスコープ\n"
+
+#: src/scope/raii.md:29
+msgid "// `_box3` is destroyed here, and memory gets freed\n"
+msgstr "// `_box3`はここで破棄され、メモリは解放されます。\n"
+
+#: src/scope/raii.md:32
+msgid ""
+"// Creating lots of boxes just for fun\n"
+"    // There's no need to manually free memory!\n"
+msgstr ""
+"// お遊びで大量のボックスを作ります。\n"
+"    // もちろん手動で開放する必要はないよ！\n"
+
+#: src/scope/raii.md:38
+msgid "// `_box2` is destroyed here, and memory gets freed\n"
+msgstr "// `_box2`はここで破棄され、メモリは解放されます。\n"
+
+#: src/scope/raii.md:42
+msgid ""
+"Of course, we can double check for memory errors using [`valgrind`](http://"
+"valgrind.org/info/):"
+msgstr "[`valgrind`](http://valgrind.org/info/)を用いて、メモリエラーが起きていないか2重チェックすることももちろん可能です。"
+
+#: src/scope/raii.md:65
+msgid "No leaks here!"
+msgstr "リークはないみたいですね！"
+
+#: src/scope/raii.md:67
+msgid "Destructor"
+msgstr "デストラクタ"
+
+#: src/scope/raii.md:69
+msgid ""
+"The notion of a destructor in Rust is provided through the [`Drop`](https://"
+"doc.rust-lang.org/std/ops/trait.Drop.html) trait. The destructor is called "
+"when the resource goes out of scope. This trait is not required to be "
+"implemented for every type, only implement it for your type if you require "
+"its own destructor logic."
+msgstr ""
+"Rustにおけるデストラクタの概念は[`Drop`]https://doc.rust-lang.org/std/ops/trait.Drop.html)"
+"トレイトによって提供されています。"
+"デストラクタは資源がスコープを抜けるときに呼び出されます。"
+"`Drop`トレイトは型定義のたびに必ず実装する必要があるわけではなく、"
+"デストラクタに独自のロジックが必要な場合にのみ実装します。"
+
+#: src/scope/raii.md:74
+msgid ""
+"Run the below example to see how the [`Drop`](https://doc.rust-lang.org/std/"
+"ops/trait.Drop.html) trait works. When the variable in the `main` function "
+"goes out of scope the custom destructor will be invoked."
+msgstr ""
+"下のコードを実行して、[`Drop`](https://doc.rust-lang.org/std/ops/trait.Drop.html)"
+"トレイトの動作を確認してみましょう。"
+"`main`関数内の変数がスコープを抜けるときにカスタムデストラクタが呼び出されるはずです。"
+
+#: src/scope/raii.md:82
+msgid "\"ToDrop is being dropped\""
+msgstr "\"ToDrop is being dropped\""
+
+#: src/scope/raii.md:88
+msgid "\"Made a ToDrop!\""
+msgstr "\"Made a ToDrop!\""
+
+#: src/scope/raii.md:94
+msgid "[Box](../std/box.md)"
+msgstr "[Box](../std/box.md)"
+
+#: src/scope/move.md:3
+msgid ""
+"Because variables are in charge of freeing their own resources,  **resources "
+"can only have one owner**. This prevents resources  from being freed more "
+"than once. Note that not all variables own  resources (e.g. [references](../"
+"flow_control/match/destructuring/destructure_pointers.md))."
+msgstr ""
+"変数には自身の保持する資源を開放する責任があるため、"
+"**資源は一度に一つの所有者** しか持つことができません。"
+"これはまた、資源を2度以上開放することができないということでもあります。"
+"ここで、全ての変数が資源を所有するわけではないということに注意しましょう。"
+"（e.g. [参照](../flow_control/match/destructuring/destructure_pointers.md)）"
+
+#: src/scope/move.md:8
+msgid ""
+"When doing assignments (`let x = y`) or passing function arguments by value "
+"(`foo(x)`), the _ownership_ of the resources is transferred. In Rust-speak,  "
+"this is known as a _move_."
+msgstr ""
+"変数を代入する（`let x = y`）際や、関数に引数を値渡しする（`foo(x)`）際は、"
+"資源の *所有権* が移動します。Rustっぽく言うと、「 *ムーブ* 」です。"
+
+#: src/scope/move.md:12
+msgid ""
+"After moving resources, the previous owner can no longer be used. This "
+"avoids creating dangling pointers."
+msgstr ""
+"資源を移動すると、それまでの所有者（訳注：変数などのこと）を使用することはできなくなります。"
+"これによりダングリングポインタの発生を防げます。"
+
+#: src/scope/move.md:16
+msgid "// This function takes ownership of the heap allocated memory\n"
+msgstr "// この関数はヒープメモリ上の資源の所有権を取ります。\n"
+
+#: src/scope/move.md:18
+msgid "\"Destroying a box that contains {}\""
+msgstr "\"Destroying a box that contains {}\""
+
+#: src/scope/move.md:20
+msgid "// `c` is destroyed and the memory freed\n"
+msgstr "// `c`は破棄されメモリは開放されます。\n"
+
+#: src/scope/move.md:24
+msgid "// _Stack_ allocated integer\n"
+msgstr "// _スタック_上に置かれた整数\n"
+
+#: src/scope/move.md:27
+msgid "// *Copy* `x` into `y` - no resources are moved\n"
+msgstr "// `x`を`y`に *コピー* します。元の値が移動するわけではありません。\n"
+
+#: src/scope/move.md:30
+msgid "// Both values can be independently used\n"
+msgstr "// 両方の値はそれぞれ独立に使うことができます。\n"
+
+#: src/scope/move.md:31
+msgid "\"x is {}, and y is {}\""
+msgstr "\"x is {}, and y is {}\""
+
+#: src/scope/move.md:33
+msgid "// `a` is a pointer to a _heap_ allocated integer\n"
+msgstr "// `a`は_ヒープ_上の整数へのポインタ。\n"
+
+#: src/scope/move.md:36
+msgid "\"a contains: {}\""
+msgstr "\"a contains: {}\""
+
+#: src/scope/move.md:38
+msgid "// *Move* `a` into `b`\n"
+msgstr "// `a`を`b`に *ムーブ* します。\n"
+
+#: src/scope/move.md:40
+msgid ""
+"// The pointer address of `a` is copied (not the data) into `b`.\n"
+"    // Both are now pointers to the same heap allocated data, but\n"
+"    // `b` now owns it.\n"
+msgstr ""
+"// すなわち、`a`の指すメモリ上の番地が`b`にコピーされるため\n"
+"    // いずれもヒープ上の同じ値を指すポインタとなります。\n"
+"    // しかし所有権は`b`にあります。\n"
+
+#: src/scope/move.md:44
+msgid ""
+"// Error! `a` can no longer access the data, because it no longer owns the\n"
+"    // heap memory\n"
+"    //println!(\"a contains: {}\", a);\n"
+"    // TODO ^ Try uncommenting this line\n"
+msgstr ""
+"// エラー！`a`は所有権を持たないため、ヒープ上のデータにアクセスできません。\n"
+"    //println!(\"a contains: {}\", a);\n"
+"    // TODO ^ 試しにここをアンコメントしてみましょう。\n"
+
+#: src/scope/move.md:49
+msgid ""
+"// This function takes ownership of the heap allocated memory from `b`\n"
+msgstr "// この関数はヒープメモリ上の所有権を`b`から取ります。\n"
+
+#: src/scope/move.md:52
+msgid ""
+"// Since the heap memory has been freed at this point, this action would\n"
+"    // result in dereferencing freed memory, but it's forbidden by the "
+"compiler\n"
+"    // Error! Same reason as the previous Error\n"
+"    //println!(\"b contains: {}\", b);\n"
+"    // TODO ^ Try uncommenting this line\n"
+msgstr ""
+"// この時点でヒープメモリ上の資源は開放されているので、次の操作は\n"
+"    // 解放済みメモリをデリファレンスすることになります。\n"
+"    // しかしそれはコンパイラが許しません。\n"
+"    // エラー！上述の理由より\n"
+"    //println!(\"b contains: {}\", b);\n"
+"    // TODO ^ 試しにここをアンコメントしてみましょう。\n"
+
+#: src/scope/move/mut.md:3
+msgid "Mutability of data can be changed when ownership is transferred."
+msgstr "データのミュータビリティは所有権を移譲した際に変更できます。"
+
+#: src/scope/move/mut.md:9
+msgid "\"immutable_box contains {}\""
+msgstr "\"immutable_box contains {}\""
+
+#: src/scope/move/mut.md:11
+msgid ""
+"// Mutability error\n"
+"    //*immutable_box = 4;\n"
+msgstr ""
+"// ミュータビリティエラー\n"
+"    //*immutable_box = 4;\n"
+
+#: src/scope/move/mut.md:14
+msgid "// *Move* the box, changing the ownership (and mutability)\n"
+msgstr "// boxを *ムーブ* する、同時に所有権とミュータビリティを変更します。\n"
+
+#: src/scope/move/mut.md:17
+msgid "\"mutable_box contains {}\""
+msgstr "\"mutable_box contains {}\""
+
+#: src/scope/move/mut.md:19
+msgid "// Modify the contents of the box\n"
+msgstr "// boxの内容を変更。\n"
+
+#: src/scope/move/mut.md:22
+msgid "\"mutable_box now contains {}\""
+msgstr "\"mutable_box now contains {}\""
+
+#: src/scope/move/partial_move.md:3
+msgid ""
+"Within the [destructuring](../../flow_control/match/destructuring.md) of a "
+"single variable, both `by-move` and  `by-reference` pattern bindings can be "
+"used at the same time. Doing  this will result in a _partial move_ of the "
+"variable, which means  that parts of the variable will be moved while other "
+"parts stay. In  such a case, the parent variable cannot be used afterwards "
+"as a  whole, however the parts that are only referenced (and not moved)  can "
+"still be used."
+msgstr ""
+"1つの変数の [デストラクト](../../flow_control/match/destructuring.md) の中で、"
+"`ムーブ` と `参照` の両方のパターン束縛を同時に使用することができます。"
+"両方を使用すると、変数の一部がムーブされ、他の部分が参照として残るという変数の部分的ムーブが発生した状態になります。"
+"変数の部分的ムーブが発生すると親変数はその後使用できませんが、"
+"参照されているだけの部分（ムーブされていない部分）は使用することができます。"
+
+#: src/scope/move/partial_move.md:24
+msgid "// `name` is moved out of person, but `age` is referenced\n"
+msgstr "// `name` は person からムーブしたが、 `age` は参照されています。\n"
+
+#: src/scope/move/partial_move.md:27
+msgid "\"The person's age is {}\""
+msgstr "\"The person's age is {}\""
+
+#: src/scope/move/partial_move.md:29
+msgid "\"The person's name is {}\""
+msgstr "\"The person's name is {}\""
+
+#: src/scope/move/partial_move.md:31
+msgid ""
+"// Error! borrow of partially moved value: `person` partial move occurs\n"
+"    //println!(\"The person struct is {:?}\", person);\n"
+msgstr ""
+"// エラー！部分的ムーブした値の借用：`person` では部分的ムーブが発生しています。\n"
+"    //println!(\"The person struct is {:?}\", person);\n"
+
+#: src/scope/move/partial_move.md:34
+msgid ""
+"// `person` cannot be used but `person.age` can be used as it is not moved\n"
+msgstr ""
+"// `person` は使用できませんが、\n"
+"    // `person.age` はムーブしていないので使用できます。\n"
+
+#: src/scope/move/partial_move.md:35
+msgid "\"The person's age from person struct is {}\""
+msgstr "\"The person's age from person struct is {}\""
+
+#: src/scope/move/partial_move.md:38
+msgid ""
+"(In this example, we store the `age` variable on the heap to  illustrate the "
+"partial move: deleting `ref` in the above code would  give an error as the "
+"ownership of `person.age` would be moved to the  variable `age`. If `Person."
+"age` were stored on the stack, `ref` would  not be required as the "
+"definition of `age` would copy the data from  `person.age` without moving "
+"it.)"
+msgstr ""
+"この例では、`age`変数をヒープ上に保持し、部分的ムーブを説明しています。"
+"上記コードで`ref`を削除すると、`person.age`の所有権が`age`変数にムーブされるため、エラーになります。"
+"もしも`Person.age`がスタック上に保持されていたら、"
+"`age`の定義が`person.age`をムーブすることなくデータをコピーするので、"
+"`ref`は必須ではないのですが、実際にはヒープ上に保持されているため`ref`は必須です。"
+
+#: src/scope/move/partial_move.md:46
+msgid "[destructuring](../../flow_control/match/destructuring.md)"
+msgstr "[デストラクト](../../flow_control/match/destructuring.md)"
+
+#: src/scope/borrow.md:3
+msgid ""
+"Most of the time, we'd like to access data without taking ownership over it. "
+"To accomplish this, Rust uses a _borrowing_ mechanism. Instead of passing "
+"objects by value (`T`), objects can be passed by reference (`&T`)."
+msgstr ""
+"実際には、データの所有権を完全に受け渡すことなく一時的にアクセスしたいという場合がほとんどです。"
+"そのために、Rustでは *借用* という仕組みを用います。"
+"値そのもの（`T`）を受け渡すのではなく、その参照（`&T`）を渡すのです。"
+
+#: src/scope/borrow.md:7
+msgid ""
+"The compiler statically guarantees (via its borrow checker) that references  "
+"_always_ point to valid objects. That is, while references to an object "
+"exist, the object cannot be destroyed."
+msgstr ""
+"コンパイラは借用チェッカを用いて参照が *常に* 有効なオブジェクトへの参照であることを、"
+"コンパイル時に保証します。つまり、あるオブジェクトへの参照が存在しているならば、"
+"そのオブジェクトを破壊することはできないということです。"
+
+#: src/scope/borrow.md:12
+msgid "// This function takes ownership of a box and destroys it\n"
+msgstr "// この関数はボックスの所有権を奪い、破棄します。\n"
+
+#: src/scope/borrow.md:14
+msgid "\"Destroying box that contains {}\""
+msgstr "\"Destroying box that contains {}\""
+
+#: src/scope/borrow.md:16
+msgid "// This function borrows an i32\n"
+msgstr "// この関数はi32を借用します。\n"
+
+#: src/scope/borrow.md:19
+msgid "\"This int is: {}\""
+msgstr "\"This int is: {}\""
+
+#: src/scope/borrow.md:23
+msgid ""
+"// Create a boxed i32 in the heap, and a i32 on the stack\n"
+"    // Remember: numbers can have arbitrary underscores added for "
+"readability\n"
+"    // 5_i32 is the same as 5i32\n"
+msgstr ""
+
+#: src/scope/borrow.md:29
+msgid ""
+"// Borrow the contents of the box. Ownership is not taken,\n"
+"    // so the contents can be borrowed again.\n"
+msgstr ""
+"// Boxの中身を借用。所有権を奪うわけではないため、\n"
+"    // 直後にもう一度借用できます。\n"
+
+#: src/scope/borrow.md:35
+msgid "// Take a reference to the data contained inside the box\n"
+msgstr "// ボックス内の要素に対する参照を取得。\n"
+
+#: src/scope/borrow.md:38
+msgid ""
+"// Error!\n"
+"        // Can't destroy `boxed_i32` while the inner value is borrowed later "
+"in scope.\n"
+msgstr ""
+"// エラー!\n"
+"        // ボックス内の要素が借用されているため、`boxed_i32`を破棄する\n"
+"        // ことはできません。\n"
+
+#: src/scope/borrow.md:43
+msgid "// Attempt to borrow `_ref_to_i32` after inner value is destroyed\n"
+msgstr ""
+
+#: src/scope/borrow.md:45
+msgid "// `_ref_to_i32` goes out of scope and is no longer borrowed.\n"
+msgstr "// ここで`_ref_to_i32`はスコープを抜け、借用もなくなります。\n"
+
+#: src/scope/borrow.md:48
+msgid ""
+"// `boxed_i32` can now give up ownership to `eat_box` and be destroyed\n"
+msgstr "// ここでようやく、`eat_box`は所有権を移譲し、破棄することができます。\n"
+
+#: src/scope/borrow/mut.md:3
+msgid ""
+"Mutable data can be mutably borrowed using `&mut T`. This is called  a "
+"_mutable reference_ and gives read/write access to the borrower. In "
+"contrast, `&T` borrows the data via an immutable reference, and  the "
+"borrower can read the data but not modify it:"
+msgstr ""
+"ミュータブルなデータは`&mut T`でミュータブルに（変更可能な形で）借用することができます。"
+"これは *ミュータブルな参照* と呼ばれ、読み込み・書き込みの権限を借用者に与えます。"
+"対照的に`&T`はデータをイミュータブルな参照を介して借用し、"
+"借用した側はデータを読み込みはできますが書き込みはできません。"
+
+#: src/scope/borrow/mut.md:12
+msgid ""
+"// `&'static str` is a reference to a string allocated in read only memory\n"
+msgstr "// `&'static str`はread-onlyメモリ上の文字列への参照。\n"
+
+#: src/scope/borrow/mut.md:17
+msgid "// This function takes a reference to a book\n"
+msgstr "// この関数はBook型への参照を取ります。\n"
+
+#: src/scope/borrow/mut.md:20
+msgid "\"I immutably borrowed {} - {} edition\""
+msgstr "\"I immutably borrowed {} - {} edition\""
+
+#: src/scope/borrow/mut.md:22
+msgid ""
+"// This function takes a reference to a mutable book and changes `year` to "
+"2014\n"
+msgstr ""
+"// この関数はミュータブルなBook型へのミュータブルな参照を取り、\n"
+"// `year`を2014へ変更します。\n"
+
+#: src/scope/borrow/mut.md:26
+msgid "\"I mutably borrowed {} - {} edition\""
+msgstr "\"I mutably borrowed {} - {} edition\""
+
+#: src/scope/borrow/mut.md:30
+msgid "// Create an immutable Book named `immutabook`\n"
+msgstr "// `immutabook`という名のイミュータブルなBookを作成。\n"
+
+#: src/scope/borrow/mut.md:32
+msgid "// string literals have type `&'static str`\n"
+msgstr "// 文字列リテラルは`&'static str`型になります。\n"
+
+#: src/scope/borrow/mut.md:33
+msgid "\"Douglas Hofstadter\""
+msgstr "\"Douglas Hofstadter\""
+
+#: src/scope/borrow/mut.md:34
+msgid "\"Gödel, Escher, Bach\""
+msgstr "\"Gödel, Escher, Bach\""
+
+#: src/scope/borrow/mut.md:38
+msgid "// Create a mutable copy of `immutabook` and call it `mutabook`\n"
+msgstr "// `immutabook`のミュータブルなコピーを作成し、`mutabook`と名付けます。\n"
+
+#: src/scope/borrow/mut.md:41
+msgid "// Immutably borrow an immutable object\n"
+msgstr "// イミュータブルなオブジェクトをイミュータブルに借用します。\n"
+
+#: src/scope/borrow/mut.md:44
+msgid "// Immutably borrow a mutable object\n"
+msgstr "// ミュータブルなオブジェクトをイミュータブルに借用します。\n"
+
+#: src/scope/borrow/mut.md:47
+msgid "// Borrow a mutable object as mutable\n"
+msgstr "// ミュータブルなオブジェクトをミュータブルに借用します。\n"
+
+#: src/scope/borrow/mut.md:50
+msgid "// Error! Cannot borrow an immutable object as mutable\n"
+msgstr "// エラー！イミュータブルなオブジェクトをミュータブルに借用できません。\n"
+
+#: src/scope/borrow/mut.md:57
+msgid "[`static`](../lifetime/static_lifetime.md)"
+msgstr "[`static`](../lifetime/static_lifetime.md)"
+
+#: src/scope/borrow/alias.md:3
+msgid ""
+"Data can be immutably borrowed any number of times, but while immutably "
+"borrowed, the original data can't be mutably borrowed. On the other hand, "
+"only _one_ mutable borrow is allowed at a time. The original data can be "
+"borrowed again only _after_ the mutable reference has been used for the last "
+"time."
+msgstr ""
+"データは一度にいくつでもイミュータブルに借用することができますが、"
+"その間オリジナルのデータをミュータブルに借用することはできません。"
+"一方でミュータブルな借用は一度に *一つ* しか借用することができません。"
+"オリジナルのデータをもう一度借用できるのはミュータブルな参照が最後に使われた場所より *あとで* なければいけません。"
+
+#: src/scope/borrow/alias.md:17
+msgid "// Data can be accessed via the references and the original owner\n"
+msgstr "// データは元々の持ち主と参照の両方からアクセスすることができます。\n"
+
+#: src/scope/borrow/alias.md:18 src/scope/borrow/alias.md:27
+#: src/scope/borrow/alias.md:49
+msgid "\"Point has coordinates: ({}, {}, {})\""
+msgstr "\"Point has coordinates: ({}, {}, {})\""
+
+#: src/scope/borrow/alias.md:21
+msgid ""
+"// Error! Can't borrow `point` as mutable because it's currently\n"
+"    // borrowed as immutable.\n"
+"    // let mutable_borrow = &mut point;\n"
+"    // TODO ^ Try uncommenting this line\n"
+msgstr ""
+"// エラー！pointはすでにイミュータブルに借用されているため、\n"
+"    // ミュータブルに借用することができません。\n"
+"    // let mutable_borrow = &mut point;\n"
+"    // TODO ^ この行をアンコメントしてみましょう。\n"
+
+#: src/scope/borrow/alias.md:26
+msgid "// The borrowed values are used again here\n"
+msgstr "// 借用された値はここで再び利用されます。\n"
+
+#: src/scope/borrow/alias.md:30
+msgid ""
+"// The immutable references are no longer used for the rest of the code so\n"
+"    // it is possible to reborrow with a mutable reference.\n"
+msgstr ""
+"// イミュータブルな参照がこれ以降のコードで利用されていないため、\n"
+"    // ミュータブルな参照として再借用できます。\n"
+
+#: src/scope/borrow/alias.md:34
+msgid "// Change data via mutable reference\n"
+msgstr "// ミュータブルな参照を介してデータを変更します。\n"
+
+#: src/scope/borrow/alias.md:39
+msgid ""
+"// Error! Can't borrow `point` as immutable because it's currently\n"
+"    // borrowed as mutable.\n"
+"    // let y = &point.y;\n"
+"    // TODO ^ Try uncommenting this line\n"
+msgstr ""
+"// エラー！`point`はすでにミュータブルに借用されているため、\n"
+"    // イミュータブルに借用することはできません。\n"
+"    // let y = &point.y;\n"
+"    // TODO ^ この行をアンコメントしてみましょう。\n"
+
+#: src/scope/borrow/alias.md:44
+msgid ""
+"// Error! Can't print because `println!` takes an immutable reference.\n"
+"    // println!(\"Point Z coordinate is {}\", point.z);\n"
+"    // TODO ^ Try uncommenting this line\n"
+msgstr ""
+"// エラー！`println!`はイミュータブルな参照を取るため、printできません。\n"
+"    // println!(\"Point Z coordinate is {}\", point.z);\n"
+"    // TODO ^ この行をアンコメントしてみましょう。\n"
+
+#: src/scope/borrow/alias.md:48
+msgid "// Ok! Mutable references can be passed as immutable to `println!`\n"
+msgstr "// OK！ミュータブルな参照は`println!`にイミュータブルな参照として渡せます。\n"
+
+#: src/scope/borrow/alias.md:52
+msgid ""
+"// The mutable reference is no longer used for the rest of the code so it\n"
+"    // is possible to reborrow\n"
+msgstr "// ミュータブルな参照がこれ以降のコードで未使用なので、再借用できます。\n"
+
+#: src/scope/borrow/alias.md:55
+msgid "\"Point now has coordinates: ({}, {}, {})\""
+msgstr "\"Point now has coordinates: ({}, {}, {})\""
+
+#: src/scope/borrow/ref.md:3
+msgid ""
+"When doing pattern matching or destructuring via the `let` binding, the "
+"`ref` keyword can be used to take references to the fields of a struct/"
+"tuple. The  example below shows a few instances where this can be useful:"
+msgstr ""
+"`let`を介してデストラクトやパターンマッチングを行う場合、"
+"`ref`キーワードを用いて構造体・タプルのフィールドへの参照を取得することができます。"
+"以下の例ではこれが有用になる例を幾つかお見せします。"
+
+#: src/scope/borrow/ref.md:14
+msgid ""
+"// A `ref` borrow on the left side of an assignment is equivalent to\n"
+"    // an `&` borrow on the right side.\n"
+msgstr "// 左辺に`ref`をつけることによる借用と、右辺に`&`をつけることによる借用は等価。\n"
+
+#: src/scope/borrow/ref.md:19
+msgid "\"ref_c1 equals ref_c2: {}\""
+msgstr "\"ref_c1 equals ref_c2: {}\""
+
+#: src/scope/borrow/ref.md:23
+msgid "// `ref` is also valid when destructuring a struct.\n"
+msgstr "// `ref`は構造体をデストラクトする際にも有用。\n"
+
+#: src/scope/borrow/ref.md:25
+msgid "// `ref_to_x` is a reference to the `x` field of `point`.\n"
+msgstr "// `ref_to_x`は`point`の`x`フィールドへの参照。\n"
+
+#: src/scope/borrow/ref.md:28
+msgid "// Return a copy of the `x` field of `point`.\n"
+msgstr "// `point`の`x`フィールドへのコピーを返します。\n"
+
+#: src/scope/borrow/ref.md:32
+msgid "// A mutable copy of `point`\n"
+msgstr "// `point`へのミュータブルなコピー\n"
+
+#: src/scope/borrow/ref.md:36
+msgid "// `ref` can be paired with `mut` to take mutable references.\n"
+msgstr "// `ref`は`mut`とともに使い、ミュータブルな参照を取ることもできます。\n"
+
+#: src/scope/borrow/ref.md:39
+msgid "// Mutate the `y` field of `mutable_point` via a mutable reference.\n"
+msgstr "// `mutable_point`の`y`というミュータブルなフィールドの値を変更します。\n"
+
+#: src/scope/borrow/ref.md:43
+msgid "\"point is ({}, {})\""
+msgstr "\"point is ({}, {})\""
+
+#: src/scope/borrow/ref.md:44
+msgid "\"mutable_point is ({}, {})\""
+msgstr "\"mutable_point is ({}, {})\""
+
+#: src/scope/borrow/ref.md:46
+msgid "// A mutable tuple that includes a pointer\n"
+msgstr "// ポインタを含むミュータブルなタプル\n"
+
+#: src/scope/borrow/ref.md:50
+msgid "// Destructure `mutable_tuple` to change the value of `last`.\n"
+msgstr "// `mutable_tuple`をデストラクトして、`last`の値を変更。\n"
+
+#: src/scope/borrow/ref.md:55
+msgid "\"tuple is {:?}\""
+msgstr "\"tuple is {:?}\""
+
+#: src/scope/lifetime.md:3
+msgid ""
+"A _lifetime_ is a construct the compiler (or more specifically, its _borrow "
+"checker_) uses to ensure all borrows are valid. Specifically, a variable's "
+"lifetime begins when it is created and ends when it is destroyed. While "
+"lifetimes and scopes are often referred to together, they are not the same."
+msgstr ""
+"*ライフタイム* はコンパイラ（借用チェッカーと呼ばれる場合もあります）が、"
+"全ての借用に問題がないことを確認するために使用する仕組みです。"
+"正確にいうと、変数のライフタイムは作成時に開始し、破棄された時に終了します。"
+"ライフタイムとスコープは同時に語られることが多いですが、同じものではありません。"
+
+#: src/scope/lifetime.md:8
+msgid ""
+"Take, for example, the case where we borrow a variable via `&`. The borrow "
+"has a lifetime that is determined by where it is declared. As a result, the "
+"borrow is valid as long as it ends before the lender is destroyed. However, "
+"the scope of the borrow is determined by where the reference is used."
+msgstr ""
+"例として`&`を用いて変数を借用する場合をあげましょう。"
+"借用のライフタイムは宣言時に決定し、そこから貸し手が破棄されるまで続きます。"
+"しかしながら、借用のスコープは参照が使われる際に決定します。"
+
+#: src/scope/lifetime.md:13
+msgid ""
+"In the following example and in the rest of this section, we will see how "
+"lifetimes relate to scopes, as well as how the two differ."
+msgstr ""
+"以下の例からこのセクションの残りでは、ライフタイムとスコープの関係、"
+"そしてそれらがいかに異なるものであるかを見ていきます。"
+
+#: src/scope/lifetime.md:17
+msgid ""
+"// Lifetimes are annotated below with lines denoting the creation\n"
+"// and destruction of each variable.\n"
+"// `i` has the longest lifetime because its scope entirely encloses \n"
+"// both `borrow1` and `borrow2`. The duration of `borrow1` compared \n"
+"// to `borrow2` is irrelevant since they are disjoint.\n"
+msgstr ""
+"// 以下では、変数の作成から破棄までのライフタイムを線で示しています。\n"
+"// `i`は最長のライフタイムを持ち、そのスコープは`borrow1`および`borrow2`\n"
+"// のスコープを完全に包含します。\n"
+"// `borrow1`と`borrow2`の存続期間は一切重なりません。\n"
+
+#: src/scope/lifetime.md:23
+msgid ""
+"// Lifetime for `i` starts. ────────────────┐\n"
+"    //                                                     │\n"
+msgstr ""
+"// `i`のライフタイム開始 ───────────────────┐\n"
+"    //                                                     │\n"
+
+#: src/scope/lifetime.md:25 src/scope/lifetime.md:32
+msgid "//                                                   │\n"
+msgstr "//                                                   │\n"
+
+#: src/scope/lifetime.md:26
+msgid ""
+"// `borrow1` lifetime starts. ──┐│\n"
+"        //                                                ││\n"
+msgstr ""
+"// `borrow1`のライフタイム開始──┐│\n"
+"        //                                                ││\n"
+
+#: src/scope/lifetime.md:28
+msgid "\"borrow1: {}\""
+msgstr "\"borrow1: {}\""
+
+#: src/scope/lifetime.md:28 src/scope/lifetime.md:35
+msgid "//              ││\n"
+msgstr "//              ││\n"
+
+#: src/scope/lifetime.md:29
+msgid ""
+"// `borrow1` ends. ─────────────────────────────────┘│\n"
+"    //                                                     │\n"
+"    //                                                     │\n"
+msgstr ""
+"// `borrow1` 終了 ──────────────────────────────────┘│\n"
+"    //                                                     │\n"
+"    //                                                     │\n"
+
+#: src/scope/lifetime.md:33
+msgid ""
+"// `borrow2` lifetime starts. ──┐│\n"
+"        //                                                ││\n"
+msgstr ""
+"// `borrow2`のライフタイム開始──┐│\n"
+"        //                                                ││\n"
+
+#: src/scope/lifetime.md:35
+msgid "\"borrow2: {}\""
+msgstr "\"borrow2: {}\""
+
+#: src/scope/lifetime.md:36
+msgid ""
+"// `borrow2` ends. ─────────────────────────────────┘│\n"
+"    //                                                     │\n"
+msgstr ""
+"// `borrow2` 終了 ──────────────────────────────────┘│\n"
+"    //                                                     │\n"
+
+#: src/scope/lifetime.md:38
+msgid "// Lifetime ends. ─────────────────────────────────────┘\n"
+msgstr "// ライフタイム終了 ───────────────────────────────────┘\n"
+
+#: src/scope/lifetime.md:41
+msgid ""
+"Note that no names or types are assigned to label lifetimes. This restricts "
+"how lifetimes will be able to be used as we will see."
+msgstr ""
+"ここで、一切の名前や型がライフタイムに代入されていないことに注意しましょう。"
+"これにより、ライフタイムの使われ方がこれから見ていくようなやり方に制限されます。"
+
+#: src/scope/lifetime/explicit.md:3
+msgid ""
+"The borrow checker uses explicit lifetime annotations to determine how long "
+"references should be valid. In cases where lifetimes are not elided[^1], "
+"Rust requires explicit annotations to determine what the  lifetime of a "
+"reference should be. The syntax for explicitly annotating  a lifetime uses "
+"an apostrophe character as follows: "
+msgstr ""
+"借用チェッカーは参照がどれだけの間有効かを決定するために、明示的なアノテーションを使用します。"
+"ライフタイムが省略[^1]されなかった場合、Rustは参照のライフタイムがどのようなものであるか、"
+"明示的なアノテーションを必要とします。"
+
+#: src/scope/lifetime/explicit.md:10
+msgid "// `foo` has a lifetime parameter `'a`\n"
+msgstr "// `foo`は`'a`というライフタイムパラメータを持ちます。\n"
+
+#: src/scope/lifetime/explicit.md:14
+msgid ""
+"Similar to [closures](../../fn/closures/anonymity.md), using lifetimes "
+"requires generics.  Additionally, this lifetime syntax indicates that the "
+"lifetime of `foo`  may not exceed that of `'a`. Explicit annotation of a "
+"type has the form  `&'a T` where `'a` has already been introduced."
+msgstr ""
+"[クロージャ](../../fn/closures/anonymity.md)と同様、ライフタイムの使用はジェネリクスを必要とします。"
+"もう少し詳しく言うと、この書き方は「`foo`のライフタイムは`'a`のそれを超えることはない。」"
+"ということを示しており、型を明示した場合`'a`は`&'a T`となるということです。"
+
+#: src/scope/lifetime/explicit.md:19
+msgid "In cases with multiple lifetimes, the syntax is similar:"
+msgstr "ライフタイムが複数ある場合も、同じような構文になります。"
+
+#: src/scope/lifetime/explicit.md:22
+msgid "// `foo` has lifetime parameters `'a` and `'b`\n"
+msgstr "// `foo`は`'a`と`'b`というライフタイムパラメータを持ちます。\n"
+
+#: src/scope/lifetime/explicit.md:26
+msgid ""
+"In this case, the lifetime of `foo` cannot exceed that of either `'a` _or_ "
+"`'b`."
+msgstr "この場合は、`foo`のライフタイムは`'a`、`'b`の *いずれよりも* 長くなってはなりません。"
+
+#: src/scope/lifetime/explicit.md:28
+msgid "See the following example for explicit lifetime annotation in use:"
+msgstr "以下はライフタイムを明示的に書く場合の例です。"
+
+#: src/scope/lifetime/explicit.md:31
+msgid ""
+"// `print_refs` takes two references to `i32` which have different\n"
+"// lifetimes `'a` and `'b`. These two lifetimes must both be at\n"
+"// least as long as the function `print_refs`.\n"
+msgstr ""
+"// `print_refs`は`i32`への参照を2つとり、それぞれ`'a`と`'b`という\n"
+"// ライフタイムを持ちます。これらのライフタイムは最短でも`print_refs`\n"
+"// 関数と同じになります。\n"
+
+#: src/scope/lifetime/explicit.md:35
+msgid "\"x is {} and y is {}\""
+msgstr "\"x is {} and y is {}\""
+
+#: src/scope/lifetime/explicit.md:37
+msgid ""
+"// A function which takes no arguments, but has a lifetime parameter `'a`.\n"
+msgstr "// 引数を取らないがライフタイムパラメータ`'a`を持つ関数\n"
+
+#: src/scope/lifetime/explicit.md:42
+msgid "// ERROR: `_x` does not live long enough\n"
+msgstr "// エラー：`_x`の寿命が短すぎる。\n"
+
+#: src/scope/lifetime/explicit.md:44
+msgid ""
+"// Attempting to use the lifetime `'a` as an explicit type annotation \n"
+"    // inside the function will fail because the lifetime of `&_x` is "
+"shorter\n"
+"    // than that of `_y`. A short lifetime cannot be coerced into a longer "
+"one.\n"
+msgstr ""
+"// `&_x`のライフタイムは`y`のそれよりも短いため、関数内で`'a`を使用して\n"
+"    // 変数のライフタイムを指定しようとすると失敗します。つまり、短いライフタイム\n"
+"    // を持つ参照をより長いものに強制的に代入することはできません。\n"
+
+#: src/scope/lifetime/explicit.md:50
+msgid "// Create variables to be borrowed below.\n"
+msgstr "// 下で借用するための変数を作成。\n"
+
+#: src/scope/lifetime/explicit.md:53
+msgid "// Borrows (`&`) of both variables are passed into the function.\n"
+msgstr "// 2つの変数の借用（`&`）が関数に渡されます。\n"
+
+#: src/scope/lifetime/explicit.md:55
+msgid ""
+"// Any input which is borrowed must outlive the borrower. \n"
+"    // In other words, the lifetime of `four` and `nine` must \n"
+"    // be longer than that of `print_refs`.\n"
+msgstr ""
+"// 借用された変数の寿命は、借り手のそれよりも長くなくてはなりません。\n"
+"    // つまり、`four`、`nine`のライフタイムは`print_refs`のそれよりも\n"
+"    // 長くなくてはなりません。\n"
+
+#: src/scope/lifetime/explicit.md:60
+msgid ""
+"// `failed_borrow` contains no references to force `'a` to be \n"
+"    // longer than the lifetime of the function, but `'a` is longer.\n"
+"    // Because the lifetime is never constrained, it defaults to `'static`.\n"
+msgstr ""
+"// `failed_borrow`は関数のライフタイムよりも`'a`を長くさせるような\n"
+"    // 参照を持ちませんが、それでも`'a`のほうが長くなります。なぜならそのような\n"
+"    // 場合`'a`はデフォルトで`'static`になるからです。\n"
+
+#: src/scope/lifetime/explicit.md:66
+msgid ""
+"[elision](elision.md) implicitly annotates lifetimes and so is different."
+msgstr ""
+"[省略](elision.md) はライフタイムが暗黙のうちに（プログラマから見えない形で）アノテートされることを指します。"
+
+#: src/scope/lifetime/explicit.md:70
+msgid "[generics](../../generics.md) and [closures](../../fn/closures.md)"
+msgstr "[ジェネリクス](../../generics.md), [クロージャ](../../fn/closures.md)"
+
+#: src/scope/lifetime/fn.md:3
+msgid ""
+"Ignoring [elision](elision.md), function signatures with lifetimes have a "
+"few constraints: "
+msgstr ""
+"[省略](elision.md)をしない場合、ライフタイムのシグネチャ（e.g. `<'a>`）を持つ関数にはいくつかの制限があります。"
+
+#: src/scope/lifetime/fn.md:5
+msgid "any reference _must_ have an annotated lifetime."
+msgstr "全ての参照においてライフタイムを明示しなくてはなりません。"
+
+#: src/scope/lifetime/fn.md:6
+msgid ""
+"any reference being returned _must_ have the same lifetime as an input or be "
+"`static`."
+msgstr "返り値となる参照はすべて引数と同じライフタイムか、`static`ライフタイムを持たなくてはなりません"
+
+#: src/scope/lifetime/fn.md:9
+msgid ""
+"Additionally, note that returning references without input is banned if it "
+"would result in returning references to invalid data. The following example "
+"shows off some valid forms of functions with lifetimes:"
+msgstr ""
+"加えて、引数のない関数から参照を返すことは、それが結果的に無効なデータへの参照になるならば、禁止されています。"
+"ライフタイムを持つ関数の例をいくつか示します。"
+
+#: src/scope/lifetime/fn.md:14
+msgid ""
+"// One input reference with lifetime `'a` which must live\n"
+"// at least as long as the function.\n"
+msgstr ""
+"// 引数として`'a`のライフタイムで参照を一つ取ります。最低でもこの関数\n"
+"// と同じだけの長さでなくてはなりません。\n"
+
+#: src/scope/lifetime/fn.md:17
+msgid "\"`print_one`: x is {}\""
+msgstr "\"`print_one`: x is {}\""
+
+#: src/scope/lifetime/fn.md:19
+msgid "// Mutable references are possible with lifetimes as well.\n"
+msgstr "// ミュータブルな参照でも同様。\n"
+
+#: src/scope/lifetime/fn.md:24
+msgid ""
+"// Multiple elements with different lifetimes. In this case, it\n"
+"// would be fine for both to have the same lifetime `'a`, but\n"
+"// in more complex cases, different lifetimes may be required.\n"
+msgstr ""
+"// 異なるライフタイムを持つ複数の引数がある場合。\n"
+"// ここでは1種類のライフタイムでも問題ありませんが、より複雑なケースでは\n"
+"// 異なるライフタイムが必要になる場合があります。\n"
+
+#: src/scope/lifetime/fn.md:29
+msgid "\"`print_multi`: x is {}, y is {}\""
+msgstr "\"`print_multi`: x is {}, y is {}\""
+
+#: src/scope/lifetime/fn.md:31
+msgid ""
+"// Returning references that have been passed in is acceptable.\n"
+"// However, the correct lifetime must be returned.\n"
+msgstr ""
+"// 受け取った参照をそのまま返すことに問題ありませんが、適切なライフタイム\n"
+"// でなくてはなりません。\n"
+
+#: src/scope/lifetime/fn.md:35
+msgid ""
+"//fn invalid_output<'a>() -> &'a String { &String::from(\"foo\") }\n"
+"// The above is invalid: `'a` must live longer than the function.\n"
+"// Here, `&String::from(\"foo\")` would create a `String`, followed by a\n"
+"// reference. Then the data is dropped upon exiting the scope, leaving\n"
+"// a reference to invalid data to be returned.\n"
+msgstr ""
+"// `'a`は関数より長くなくてはならないため上の関数は正しくありません。\n"
+"// ここでは、`&String::from(\"foo\")`は`String`のデータとそれへの参照を作ります。\n"
+"// その後データはスコープを抜けるとともに破棄されます。そのため、\n"
+"// 不適切なデータに対する参照を返すことになってしまいます。\n"
+
+#: src/scope/lifetime/fn.md:60
+msgid "[Functions](../../fn.md)"
+msgstr "[関数](../../fn.md)"
+
+#: src/scope/lifetime/methods.md:3
+msgid "Methods are annotated similarly to functions:"
+msgstr "メソッドのライフタイムは関数に似ています。"
+
+#: src/scope/lifetime/methods.md:9
+msgid "// Annotate lifetimes as in a standalone function.\n"
+msgstr "// 通常の関数と同様にライフタイムを明示。\n"
+
+#: src/scope/lifetime/methods.md:12
+msgid "\"`print`: {}\""
+msgstr "\"`print`: {}\""
+
+#: src/scope/lifetime/methods.md:26
+msgid "[methods](../../fn/methods.md)"
+msgstr "[メソッド](../../fn/methods.md)"
+
+#: src/scope/lifetime/struct.md:3
+msgid "Annotation of lifetimes in structures are also similar to functions:"
+msgstr "構造体におけるライフタイムも関数のそれと似ています。"
+
+#: src/scope/lifetime/struct.md:6
+msgid ""
+"// A type `Borrowed` which houses a reference to an\n"
+"// `i32`. The reference to `i32` must outlive `Borrowed`.\n"
+msgstr ""
+"// `i32`への参照をメンバに持つ`Borrowed`型。\n"
+"// 参照は`Borrowed`自体よりも長生きでなくてはなりません。\n"
+
+#: src/scope/lifetime/struct.md:10
+msgid "// Similarly, both references here must outlive this structure.\n"
+msgstr "// 同様に、ここでも参照は構造体よりも長生きでなくてはなりません。\n"
+
+#: src/scope/lifetime/struct.md:17
+msgid "// An enum which is either an `i32` or a reference to one.\n"
+msgstr "// `i32`、あるいは`i32`への参照のいずれかとなる列挙型\n"
+
+#: src/scope/lifetime/struct.md:34 src/scope/lifetime/struct.md:36
+msgid "\"x is borrowed in {:?}\""
+msgstr "\"x is borrowed in {:?}\""
+
+#: src/scope/lifetime/struct.md:35
+msgid "\"x and y are borrowed in {:?}\""
+msgstr "\"x and y are borrowed in {:?}\""
+
+#: src/scope/lifetime/struct.md:37
+msgid "\"y is *not* borrowed in {:?}\""
+msgstr "\"y is *not* borrowed in {:?}\""
+
+#: src/scope/lifetime/struct.md:43
+msgid "[`struct`s](../../custom_types/structs.md)"
+msgstr "[構造体](../../custom_types/structs.md)"
+
+#: src/scope/lifetime/trait.md:3
+msgid ""
+"Annotation of lifetimes in trait methods basically are similar to functions. "
+"Note that `impl` may have annotation of lifetimes too."
+msgstr ""
+"トレイトのメソッドにおけるライフタイムのアノテーションは、"
+"基本的には関数に似ています。"
+"`impl`にもライフタイムのアノテーションがあることに注意してください。"
+
+#: src/scope/lifetime/trait.md:7
+msgid "// A struct with annotation of lifetimes.\n"
+msgstr "// ライフタイムのアノテーションつき構造体\n"
+
+#: src/scope/lifetime/trait.md:12
+msgid "// Annotate lifetimes to impl.\n"
+msgstr "// ライフタイムのアノテーションつきimpl\n"
+
+#: src/scope/lifetime/trait.md:24
+msgid "\"b is {:?}\""
+msgstr "\"b is {:?}\""
+
+#: src/scope/lifetime/trait.md:30
+msgid "[`trait`s](../../trait.md)"
+msgstr "[トレイト](../../trait.md)"
+
+#: src/scope/lifetime/lifetime_bounds.md:3
+msgid ""
+"Just like generic types can be bounded, lifetimes (themselves generic) use "
+"bounds as well. The `:` character has a slightly different meaning here,  "
+"but `+` is the same. Note how the following read:"
+msgstr ""
+"ジェネリック型に境界を与え、特定のトレイトを実装していることを保証できるのと同様、"
+"ライフタイム（それ自身ジェネリック型）にも境界を与えることができます。"
+"`:`は、ここでは多少異なる意味を持ちますが`+`は同じです。以下の構文の意味をチェックしてください。"
+
+#: src/scope/lifetime/lifetime_bounds.md:7
+msgid "`T: 'a`: _All_ references in `T` must outlive lifetime `'a`."
+msgstr "`T: 'a`：`T`内の *全ての* 参照は`'a`よりも長生きでなくてはなりません。"
+
+#: src/scope/lifetime/lifetime_bounds.md:8
+msgid ""
+"`T: Trait + 'a`: Type `T` must implement trait `Trait` and _all_ references "
+"in `T` must outlive `'a`."
+msgstr "`T: Trait + 'a`：上に加えて`T`は`Trait`という名のトレイトを実装してなくてはなりません。"
+
+#: src/scope/lifetime/lifetime_bounds.md:11
+msgid ""
+"The example below shows the above syntax in action used after keyword "
+"`where`:"
+msgstr "上記の構文を実際に動く例で見ていきましょう。`where`キーワードの後に注目してください。"
+
+#: src/scope/lifetime/lifetime_bounds.md:14
+msgid "// Trait to bound with.\n"
+msgstr "// ライフタイムを紐付けるトレイト\n"
+
+#: src/scope/lifetime/lifetime_bounds.md:17
+msgid ""
+"// `Ref` contains a reference to a generic type `T` that has\n"
+"// an unknown lifetime `'a`. `T` is bounded such that any\n"
+"// *references* in `T` must outlive `'a`. Additionally, the lifetime\n"
+"// of `Ref` may not exceed `'a`.\n"
+msgstr ""
+"// `Ref`は`'a`というライフタイムを持つジェネリック型`T`に対する参照を持ち、\n"
+"// `T`の値に対する *参照* は必ず`'a`よりも長生きでなくてはなりません。\n"
+"// さらに、`Ref`のライフタイムは`'a`を超えてはなりません。\n"
+
+#: src/scope/lifetime/lifetime_bounds.md:22
+msgid "// A generic function which prints using the `Debug` trait.\n"
+msgstr "// `Debug`トレイトを利用して出力を行うジェネリック関数\n"
+
+#: src/scope/lifetime/lifetime_bounds.md:26
+msgid "\"`print`: t is {:?}\""
+msgstr "\"`print`: t is {:?}\""
+
+#: src/scope/lifetime/lifetime_bounds.md:28
+msgid ""
+"// Here a reference to `T` is taken where `T` implements\n"
+"// `Debug` and all *references* in `T` outlive `'a`. In\n"
+"// addition, `'a` must outlive the function.\n"
+msgstr ""
+"// `Debug`を実装している`T`への参照を取りません。`T`への *参照* は\n"
+"// 必ず`'a`よりも長生きでなくてはなりません。さらに、`'a`は\n"
+"// 関数自体よりも長生きでなくてはなりません。\n"
+
+#: src/scope/lifetime/lifetime_bounds.md:34
+msgid "\"`print_ref`: t is {:?}\""
+msgstr "\"`print_ref`: t is {:?}\""
+
+#: src/scope/lifetime/lifetime_bounds.md:48
+msgid ""
+"[generics](../../generics.md), [bounds in generics](../../generics/bounds."
+"md), and  [multiple bounds in generics](../../generics/multi_bounds.md)"
+msgstr ""
+"[ジェネリクス](../../generics.md), [ジェネリック境界](../../generics/bounds."
+"md), [複数の境界](../../generics/multi_bounds.md)"
+
+#: src/scope/lifetime/lifetime_coercion.md:3
+msgid ""
+"A longer lifetime can be coerced into a shorter one  so that it works inside "
+"a scope it normally wouldn't work in. This comes in the form of inferred "
+"coercion by the Rust compiler, and also in the form of declaring a lifetime "
+"difference:"
+msgstr ""
+"長いライフタイムは、短いものに圧縮することで、そのままでは動作しないスコープの中でも使用できるようになります。"
+"これは、Rustコンパイラが推論の結果として圧縮する場合と、複数のライフタイムを比較して圧縮する場合があります。"
+
+#: src/scope/lifetime/lifetime_coercion.md:9
+msgid ""
+"// Here, Rust infers a lifetime that is as short as possible.\n"
+"// The two references are then coerced to that lifetime.\n"
+msgstr ""
+"// ここではRustはライフタイムを出来る限り短く見積もり、\n"
+"// 2つの参照をそのライフタイムに押し込めます。\n"
+
+#: src/scope/lifetime/lifetime_coercion.md:14
+msgid ""
+"// `<'a: 'b, 'b>` reads as lifetime `'a` is at least as long as `'b`.\n"
+"// Here, we take in an `&'a i32` and return a `&'b i32` as a result of "
+"coercion.\n"
+msgstr ""
+"// `<'a: 'b, 'b>`は「ライフタイム`'a`は最低でも`'b`と同じ長さ」と読めます。\n"
+"// ここでは、`&'a i32`をとり、`&'b i32`に圧縮して返します。\n"
+
+#: src/scope/lifetime/lifetime_coercion.md:22
+msgid "// Longer lifetime\n"
+msgstr "// 長いライフタイム\n"
+
+#: src/scope/lifetime/lifetime_coercion.md:25
+msgid "// Shorter lifetime\n"
+msgstr "// 短いライフタイム\n"
+
+#: src/scope/lifetime/lifetime_coercion.md:27
+msgid "\"The product is {}\""
+msgstr "\"The product is {}\""
+
+#: src/scope/lifetime/lifetime_coercion.md:28
+msgid "\"{} is the first\""
+msgstr "\"{} is the first\""
+
+#: src/scope/lifetime/static_lifetime.md:3
+msgid ""
+"Rust has a few reserved lifetime names. One of those is `'static`. You might "
+"encounter it in two situations:"
+msgstr ""
+"Rustにはいくつかの予約されたライフタイム名があります。"
+"その1つが`static`で、2つの状況で使用することがあります。"
+
+#: src/scope/lifetime/static_lifetime.md:7
+msgid "// A reference with 'static lifetime:\n"
+msgstr ""
+
+#: src/scope/lifetime/static_lifetime.md:8
+msgid "\"hello world\""
+msgstr "\"hello world\""
+
+#: src/scope/lifetime/static_lifetime.md:9
+msgid "// 'static as part of a trait bound:\n"
+msgstr ""
+
+#: src/scope/lifetime/static_lifetime.md:14
+msgid ""
+"Both are related but subtly different and this is a common source for "
+"confusion when learning Rust. Here are some examples for each situation:"
+msgstr ""
+"2つの状況における`static`は微妙に異なる意味を持っており、Rustを学ぶときの混乱の元になっています。"
+"いくつかの例とともにそれぞれの使い方を見てみましょう。"
+
+#: src/scope/lifetime/static_lifetime.md:17
+msgid "Reference lifetime"
+msgstr "参照のライフタイム"
+
+#: src/scope/lifetime/static_lifetime.md:19
+msgid ""
+"As a reference lifetime `'static` indicates that the data pointed to by the "
+"reference lives for the remaining lifetime of the running program. It can "
+"still be coerced to a shorter lifetime."
+msgstr ""
+"参照のライフタイムが`'static`であることは、参照が指し示す値がプログラムの実行中に渡って生き続けることを示します。"
+"また、より短いライフタイムに圧縮することも可能です。"
+
+#: src/scope/lifetime/static_lifetime.md:23
+msgid ""
+"There are two common ways to make a variable with `'static` lifetime, and "
+"both are stored in the read-only memory of the binary:"
+msgstr ""
+"`'static`ライフタイムを持つ変数を作るには下記の2つ方法があります。"
+"どちらの場合も、値は読み取り専用のメモリ領域に格納されます。"
+
+#: src/scope/lifetime/static_lifetime.md:26
+msgid "Make a constant with the `static` declaration."
+msgstr "`static`宣言とともに定数を作成します。"
+
+#: src/scope/lifetime/static_lifetime.md:27
+msgid "Make a `string` literal which has type: `&'static str`."
+msgstr "文字列リテラルで`&'static str`型を持つ変数を作成します。"
+
+#: src/scope/lifetime/static_lifetime.md:29
+msgid "See the following example for a display of each method:"
+msgstr "では、それぞれの方法の例を見ていきましょう。"
+
+#: src/scope/lifetime/static_lifetime.md:32
+msgid "// Make a constant with `'static` lifetime.\n"
+msgstr "// `'static`ライフタイムを持つ定数を作成。\n"
+
+#: src/scope/lifetime/static_lifetime.md:34
+msgid ""
+"// Returns a reference to `NUM` where its `'static`\n"
+"// lifetime is coerced to that of the input argument.\n"
+msgstr ""
+"// `NUM`への参照を返します。ライフタイムは`'static`から引数の\n"
+"// ライフタイムへと圧縮されています。\n"
+
+#: src/scope/lifetime/static_lifetime.md:43
+msgid "// Make a `string` literal and print it:\n"
+msgstr "// 文字列リテラルを用いて変数を作成し、出力します。\n"
+
+#: src/scope/lifetime/static_lifetime.md:44
+msgid "\"I'm in read-only memory\""
+msgstr "\"I'm in read-only memory\""
+
+#: src/scope/lifetime/static_lifetime.md:45
+msgid "\"static_string: {}\""
+msgstr "\"static_string: {}\""
+
+#: src/scope/lifetime/static_lifetime.md:47
+msgid ""
+"// When `static_string` goes out of scope, the reference\n"
+"        // can no longer be used, but the data remains in the binary.\n"
+msgstr ""
+"// `static_string`がスコープから抜けると、参照は使用することが\n"
+"        // できなくなりますが、データはバイナリ中に残ります。\n"
+
+#: src/scope/lifetime/static_lifetime.md:52
+msgid "// Make an integer to use for `coerce_static`:\n"
+msgstr "// `coerce_static`関数を呼び出すために、整数を作成。\n"
+
+#: src/scope/lifetime/static_lifetime.md:55
+msgid "// Coerce `NUM` to lifetime of `lifetime_num`:\n"
+msgstr "// `NUM`を`lifetime_num`のライフタイムへと圧縮。\n"
+
+#: src/scope/lifetime/static_lifetime.md:58
+msgid "\"coerced_static: {}\""
+msgstr "\"coerced_static: {}\""
+
+#: src/scope/lifetime/static_lifetime.md:61
+msgid "\"NUM: {} stays accessible!\""
+msgstr "\"NUM: {} stays accessible!\""
+
+#: src/scope/lifetime/static_lifetime.md:65
+msgid ""
+"Since `'static` references only need to be valid for the _remainder_ of a "
+"program's life, they can be created while the program is executed. Just to "
+"demonstrate, the below example uses [`Box::leak`](https://doc.rust-lang.org/"
+"std/boxed/struct.Box.html#method.leak) to dynamically create `'static` "
+"references. In that case it definitely doesn't live for the entire duration, "
+"but only for the leaking point onward."
+msgstr ""
+
+#: src/scope/lifetime/static_lifetime.md:90
+msgid "Trait bound"
+msgstr "トレイト境界"
+
+#: src/scope/lifetime/static_lifetime.md:92
+msgid ""
+"As a trait bound, it means the type does not contain any non-static "
+"references. Eg. the receiver can hold on to the type for as long as they "
+"want and it will never become invalid until they drop it."
+msgstr ""
+"トレイト境界としての`'static`は型が非静的な参照を含まないことを意味します。"
+"言い換えると、レシーバはその型をいくらでも長く保持することができ、"
+"意図的にドロップするまでは決して無効になることはないということです。"
+
+#: src/scope/lifetime/static_lifetime.md:96
+msgid ""
+"It's important to understand this means that any owned data always passes a "
+"`'static` lifetime bound, but a reference to that owned data generally does "
+"not:"
+msgstr ""
+"次のポイントを押さえておきましょう。所有権のある値が`'static`ライフタイム境界をパスするとしても、"
+"その値への参照が`'static`ライフタイム境界をパスするとは限りません。"
+
+#: src/scope/lifetime/static_lifetime.md:104
+msgid "\"'static value passed in is: {:?}\""
+msgstr "\"'static value passed in is: {:?}\""
+
+#: src/scope/lifetime/static_lifetime.md:108
+msgid "// i is owned and contains no references, thus it's 'static:\n"
+msgstr "// i は所有されていて、かつ参照を含まないので 'static。\n"
+
+#: src/scope/lifetime/static_lifetime.md:112
+msgid ""
+"// oops, &i only has the lifetime defined by the scope of\n"
+"    // main(), so it's not 'static:\n"
+msgstr ""
+"// おっと、&i は main() のスコープで定義された\n"
+"    // ライフタイムしかもたないため 'static ではありません。\n"
+
+#: src/scope/lifetime/static_lifetime.md:117
+msgid "The compiler will tell you:"
+msgstr "コンパイラのメッセージはこのようになります。"
+
+#: src/scope/lifetime/static_lifetime.md:133
+msgid "[`'static` constants](../../custom_types/constants.md)"
+msgstr "[`'static` 定数](../../custom_types/constants.md)"
+
+#: src/scope/lifetime/elision.md:3
+msgid ""
+"Some lifetime patterns are overwhelmingly common and so the borrow checker "
+"will allow you to omit them to save typing and to improve readability. This "
+"is known as elision. Elision exists in Rust solely because these patterns "
+"are common."
+msgstr ""
+"ライフタイムのパターンのうちのいくつかは、他と比べてあまりにも一般的に使用されるため、"
+"タイプ量を減らし可読性を上げるために省くことができます。"
+"これは省略として知られており、それらのパターンが一般的であるというだけの理由で存在しています。"
+
+#: src/scope/lifetime/elision.md:8
+msgid ""
+"The following code shows a few examples of elision. For a more comprehensive "
+"description of elision, see [lifetime elision](https://doc.rust-lang.org/"
+"book/ch10-03-lifetime-syntax.html#lifetime-elision) in the book."
+msgstr ""
+"以下のコードでは省略の例を幾つかお見せします。"
+"より完全な説明を見たい場合は、「プログラミング言語Rust」の"
+"[ライフタイムの省略](https://doc.rust-lang.org/book/ch10-03-lifetime-syntax.html#lifetime-elision)の項を見てください。"
+
+#: src/scope/lifetime/elision.md:12
+msgid ""
+"// `elided_input` and `annotated_input` essentially have identical "
+"signatures\n"
+"// because the lifetime of `elided_input` is inferred by the compiler:\n"
+msgstr ""
+"// `elided_input`のライフタイムはコンパイラによって自動的に付与されるため\n"
+"// 以下の2つは同一のライフタイムシグネチャを持ちます。\n"
+
+#: src/scope/lifetime/elision.md:15
+msgid "\"`elided_input`: {}\""
+msgstr "\"`elided_input`: {}\""
+
+#: src/scope/lifetime/elision.md:19
+msgid "\"`annotated_input`: {}\""
+msgstr "\"`annotated_input`: {}\""
+
+#: src/scope/lifetime/elision.md:21
+msgid ""
+"// Similarly, `elided_pass` and `annotated_pass` have identical signatures\n"
+"// because the lifetime is added implicitly to `elided_pass`:\n"
+msgstr "// 同様に、以下の2つの関数も全く同じライフタイムシグネチャを持ちます。\n"
+
+#: src/scope/lifetime/elision.md:34
+msgid "\"`elided_pass`: {}\""
+msgstr "\"`elided_pass`: {}\""
+
+#: src/scope/lifetime/elision.md:35
+msgid "\"`annotated_pass`: {}\""
+msgstr "\"`annotated_pass`: {}\""
+
+#: src/scope/lifetime/elision.md:41
+msgid ""
+"[elision](https://doc.rust-lang.org/book/ch10-03-lifetime-syntax."
+"html#lifetime-elision)"
+msgstr ""
+"[省略](https://doc.rust-lang.org/book/ch10-03-lifetime-syntax."
+"html#lifetime-elision)"
+
+#: src/trait.md:3
+msgid ""
+"A `trait` is a collection of methods defined for an unknown type: `Self`. "
+"They can access other methods declared in the same trait."
+msgstr ""
+"トレイトとは任意の型となりうる`Self`に対して定義されたメソッドの集合のことです。"
+"同じトレイト内で宣言されたメソッド同士はお互いにアクセスすることができます。"
+
+#: src/trait.md:6
+msgid ""
+"Traits can be implemented for any data type. In the example below, we define "
+"`Animal`, a group of methods. The `Animal` `trait` is  then implemented for "
+"the `Sheep` data type, allowing the use of  methods from `Animal` with a "
+"`Sheep`."
+msgstr ""
+"トレイトはあらゆるデータ型に実装することができます。"
+"以下の例ではまず`Animal`というメソッドの集合を定義し、"
+"その後`Animal`トレイトを`Sheep`というデータ型に対して実装します。"
+"これにより`Animal`のメソッドを`Sheep`が使用することが可能になります。"
+
+#: src/trait.md:15
+msgid ""
+"// Associated function signature; `Self` refers to the implementor type.\n"
+msgstr ""
+"// 関連関数のシグネチャ\n"
+"    // `Self` はこのトレイトを実装している型になります。\n"
+
+#: src/trait.md:18
+msgid "// Method signatures; these will return a string.\n"
+msgstr ""
+"// メソッドのシグネチャ\n"
+"    // これらの関数は文字列を返します。\n"
+
+#: src/trait.md:22
+msgid "// Traits can provide default method definitions.\n"
+msgstr "// メソッドのデフォルトの挙動を定義することもできます。\n"
+
+#: src/trait.md:24
+msgid "\"{} says {}\""
+msgstr "\"{} says {}\""
+
+#: src/trait.md:35
+msgid "// Implementor methods can use the implementor's trait methods.\n"
+msgstr ""
+"// メソッドをある型に実装する際に、その型のトレイトメソッドを\n"
+"            // 使用することができます。\n"
+
+#: src/trait.md:36
+msgid "\"{} is already naked...\""
+msgstr "\"{} is already naked...\""
+
+#: src/trait.md:38
+msgid "\"{} gets a haircut!\""
+msgstr "\"{} gets a haircut!\""
+
+#: src/trait.md:44 src/trait/dyn.md:17
+msgid "// Implement the `Animal` trait for `Sheep`.\n"
+msgstr "// `Animal`というトレイトを`Sheep`に実装します。\n"
+
+#: src/trait.md:47
+msgid "// `Self` is the implementor type: `Sheep`.\n"
+msgstr "// `Self`は実装対象の型：ここでは`Sheep`\n"
+
+#: src/trait.md:58
+msgid "\"baaaaah?\""
+msgstr "\"baaaaah?\""
+
+#: src/trait.md:60 src/trait/dyn.md:21
+msgid "\"baaaaah!\""
+msgstr "\"baaaaah!\""
+
+#: src/trait.md:64
+msgid "// Default trait methods can be overridden.\n"
+msgstr "// デフォルトのトレイトメソッドはオーバーライドすることができます。\n"
+
+#: src/trait.md:66
+msgid "// For example, we can add some quiet contemplation.\n"
+msgstr "// 例えば、静かに熟考させてみます。\n"
+
+#: src/trait.md:67
+msgid "\"{} pauses briefly... {}\""
+msgstr "\"{} pauses briefly... {}\""
+
+#: src/trait.md:72
+msgid "// Type annotation is necessary in this case.\n"
+msgstr "// この場合、型アノテーションが必須。\n"
+
+#: src/trait.md:73
+msgid "\"Dolly\""
+msgstr "\"Dolly\""
+
+#: src/trait.md:74
+msgid "// TODO ^ Try removing the type annotations.\n"
+msgstr "// TODO ^ ここの型アノテーションを消してみましょう。\n"
+
+#: src/trait/derive.md:3
+msgid ""
+"The compiler is capable of providing basic implementations for some traits "
+"via the `#[derive]` [attribute](../attribute.md). These traits can still be "
+"manually implemented if a more complex behavior is required."
+msgstr ""
+"コンパイラには、`#[derive]`[アトリビュート](../attribute.md)を用いることで型に対して"
+"特定のトレイトの標準的な実装を提供する機能があります。"
+"より複雑なことを行わせたい場合には、同名のトレイトを手動で実装することも可能です。"
+
+#: src/trait/derive.md:7
+msgid "The following is a list of derivable traits:"
+msgstr "以下はderive可能なトレイトの一覧です。"
+
+#: src/trait/derive.md:8
+msgid ""
+"Comparison traits: [`Eq`](https://doc.rust-lang.org/std/cmp/trait.Eq.html), "
+"[`PartialEq`](https://doc.rust-lang.org/std/cmp/trait.PartialEq.html), "
+"[`Ord`](https://doc.rust-lang.org/std/cmp/trait.Ord.html), [`PartialOrd`]"
+"(https://doc.rust-lang.org/std/cmp/trait.PartialOrd.html)."
+msgstr ""
+"型の比較に関連するトレイト: [`Eq`](https://doc.rust-lang.org/std/cmp/trait.Eq.html), "
+"[`PartialEq`](https://doc.rust-lang.org/std/cmp/trait.PartialEq.html), "
+"[`Ord`](https://doc.rust-lang.org/std/cmp/trait.Ord.html), [`PartialOrd`]"
+"(https://doc.rust-lang.org/std/cmp/trait.PartialOrd.html)."
+
+#: src/trait/derive.md:10
+msgid ""
+"[`Clone`](https://doc.rust-lang.org/std/clone/trait.Clone.html), to create "
+"`T` from `&T` via a copy."
+msgstr ""
+"[`Clone`](https://doc.rust-lang.org/std/clone/trait.Clone.html)："
+"これはコピーによって`&T`から`T`を作成するトレイト"
+
+#: src/trait/derive.md:11
+msgid ""
+"[`Copy`](https://doc.rust-lang.org/core/marker/trait.Copy.html), to give a "
+"type 'copy semantics' instead of 'move semantics'."
+msgstr ""
+"[`Copy`](https://doc.rust-lang.org/core/marker/trait.Copy.html)："
+"これはムーブセマンティクスの代わりにコピーセマンティクスにするためのトレイト"
+
+#: src/trait/derive.md:12
+msgid ""
+"[`Hash`](https://doc.rust-lang.org/std/hash/trait.Hash.html), to compute a "
+"hash from `&T`."
+msgstr ""
+"[`Hash`](https://doc.rust-lang.org/std/hash/trait.Hash.html)："
+"これは`&T`からハッシュ値を計算するためのトレイト"
+
+#: src/trait/derive.md:13
+msgid ""
+"[`Default`](https://doc.rust-lang.org/std/default/trait.Default.html), to "
+"create an empty instance of a data type."
+msgstr ""
+"[`Default`](https://doc.rust-lang.org/std/default/trait.Default.html)："
+"これは空っぽのインスタンスを作成するためのトレイト"
+
+#: src/trait/derive.md:14
+msgid ""
+"[`Debug`](https://doc.rust-lang.org/std/fmt/trait.Debug.html), to format a "
+"value using the `{:?}` formatter."
+msgstr ""
+"[`Debug`](https://doc.rust-lang.org/std/fmt/trait.Debug.html)："
+"これは`{:?}`フォーマッタを利用して値をフォーマットするためのトレイト"
+
+#: src/trait/derive.md:17
+msgid "// `Centimeters`, a tuple struct that can be compared\n"
+msgstr "// `Centimeters`は比較可能なタプルになります。\n"
+
+#: src/trait/derive.md:20
+msgid "// `Inches`, a tuple struct that can be printed\n"
+msgstr "// `Inches`は出力可能なタプルになります。\n"
+
+#: src/trait/derive.md:32
+msgid "// `Seconds`, a tuple struct with no additional attributes\n"
+msgstr "// `Seconds`には特にアトリビュートを付け加えません。\n"
+
+#: src/trait/derive.md:39
+msgid ""
+"// Error: `Seconds` can't be printed; it doesn't implement the `Debug` "
+"trait\n"
+"    //println!(\"One second looks like: {:?}\", _one_second);\n"
+"    // TODO ^ Try uncommenting this line\n"
+msgstr ""
+"// エラー：`Debug`トレイトを実装していないため`Seconds`は出力できません。\n"
+"    //println!(\"One second looks like: {:?}\", _one_second);\n"
+"    // TODO ^ この行をアンコメントしてみましょう。\n"
+
+#: src/trait/derive.md:43
+msgid ""
+"// Error: `Seconds` can't be compared; it doesn't implement the `PartialEq` "
+"trait\n"
+"    //let _this_is_true = (_one_second == _one_second);\n"
+"    // TODO ^ Try uncommenting this line\n"
+msgstr ""
+"// エラー`PartialEq`トレイトを実装していないため`Seconds`は比較できません。\n"
+"    //let _this_is_true = (_one_second == _one_second);\n"
+"    // TODO ^ この行をアンコメントしてみましょう。\n"
+
+#: src/trait/derive.md:49
+msgid "\"One foot equals {:?}\""
+msgstr "\"One foot equals {:?}\""
+
+#: src/trait/derive.md:55
+msgid "\"smaller\""
+msgstr "\"smaller\""
+
+#: src/trait/derive.md:57
+msgid "\"bigger\""
+msgstr "\"bigger\""
+
+#: src/trait/derive.md:60
+msgid "\"One foot is {} than one meter.\""
+msgstr "\"One foot is {} than one meter.\""
+
+#: src/trait/derive.md:65
+msgid "[`derive`](https://doc.rust-lang.org/reference/attributes.html#derive)"
+msgstr "[導出](https://doc.rust-lang.org/reference/attributes.html#derive)"
+
+#: src/trait/dyn.md:3
+msgid ""
+"The Rust compiler needs to know how much space every function's return type "
+"requires. This means all your functions have to return a concrete type. "
+"Unlike other languages, if you have a trait like `Animal`, you can't write a "
+"function that returns `Animal`, because its different implementations will "
+"need different amounts of memory. "
+msgstr ""
+"Rustのコンパイラはあらゆる関数のリターン型に必要なスペースを知っておく必要があります。"
+"つまり、すべての関数は具体的な型を返す必要があるのです。"
+"他の言語と違って、`Animal`のようなトレイトがある場合に、`Animal`を返す関数を書くことはできません。"
+"なぜなら、そのトレイトの異なる実装はそれぞれ別の量のメモリを必要とするからです。"
+
+#: src/trait/dyn.md:5
+msgid ""
+"However, there's an easy workaround. Instead of returning a trait object "
+"directly, our functions return a `Box` which _contains_ some `Animal`. A "
+"`box` is just a reference to some memory in the heap. Because a reference "
+"has a statically-known size, and the compiler can guarantee it points to a "
+"heap-allocated `Animal`, we can return a trait from our function!"
+msgstr ""
+"しかし、簡単な回避策があります。"
+"直接トレイトオブジェクトを返す代わりに、`Animal`を _含む_ `Box`を返すのです。"
+"`Box`はヒープ中のメモリへの単なる参照です。"
+"参照のサイズは静的に知ることができ、コンパイラは参照がヒープに割り当てられた`Animal`を指していると保証できるので、"
+"私たちは関数からトレイトを返すことができます。"
+
+#: src/trait/dyn.md:7
+msgid ""
+"Rust tries to be as explicit as possible whenever it allocates memory on the "
+"heap. So if your function returns a pointer-to-trait-on-heap in this way, "
+"you need to write the return type with the `dyn` keyword, e.g. `Box<dyn "
+"Animal>`."
+msgstr ""
+"ヒープにメモリを割り当てる際、Rustは可能な限り明示的であろうとします。"
+"なので、もしあなたの関数がヒープ上のトレイトへのポインタを返す場合、"
+"例えば`Box<dyn Animal>`のように、リターン型に`dyn`キーワードをつける必要があります。"
+
+#: src/trait/dyn.md:14
+msgid "// Instance method signature\n"
+msgstr "// インスタンスメソッドのシグネチャ\n"
+
+#: src/trait/dyn.md:24
+msgid "// Implement the `Animal` trait for `Cow`.\n"
+msgstr "// `Cow`に`Animal`トレイトを実装します。\n"
+
+#: src/trait/dyn.md:28
+msgid "\"moooooo!\""
+msgstr "\"moooooo!\""
+
+#: src/trait/dyn.md:31
+msgid ""
+"// Returns some struct that implements Animal, but we don't know which one "
+"at compile time.\n"
+msgstr ""
+"// Animalを実装した何らかの構造体を返します。\n"
+"// ただし、コンパイル時にはどの実装か分かりません。\n"
+
+#: src/trait/dyn.md:44
+msgid "\"You've randomly chosen an animal, and it says {}\""
+msgstr "\"You've randomly chosen an animal, and it says {}\""
+
+#: src/trait/ops.md:3
+msgid ""
+"In Rust, many of the operators can be overloaded via traits. That is, some "
+"operators can be used to accomplish different tasks based on their input "
+"arguments. This is possible because operators are syntactic sugar for method "
+"calls. For example, the `+` operator in `a + b` calls the `add` method (as "
+"in `a.add(b)`). This `add` method is part of the `Add` trait. Hence, the `+` "
+"operator can be used by any implementor of the `Add` trait."
+msgstr ""
+"Rustでは、多くの演算子はトレイトによってオーバーロードすることができます。"
+"つまり、一部の演算子は引数となる値の型に応じて異なる役割を果たすことができるということです。"
+"これが可能なのは、演算子が実際にはメソッド呼び出しの糖衣構文にすぎないからです。"
+"例えば`a + b`における`+`演算子は`add`メソッドを（`a.add(b)`の形で）呼び出します。"
+"この`add`メソッドは`Add`トレイトの一部です。"
+"それ故、`+`は`Add`トレイトを実装している全ての型に対して有効なのです。"
+
+#: src/trait/ops.md:9
+msgid ""
+"A list of the traits, such as `Add`, that overload operators can be found in "
+"[`core::ops`](https://doc.rust-lang.org/core/ops/)."
+msgstr ""
+"`Add`などの、演算子をオーバーロードするトレイトの一覧は"
+"[`core::ops`](https://doc.rust-lang.org/core/ops/)にあります。"
+
+#: src/trait/ops.md:22
+msgid ""
+"// The `std::ops::Add` trait is used to specify the functionality of `+`.\n"
+"// Here, we make `Add<Bar>` - the trait for addition with a RHS of type "
+"`Bar`.\n"
+"// The following block implements the operation: Foo + Bar = FooBar\n"
+msgstr ""
+"// `std::ops::Add`トレイトは`+`の振る舞いを規定するために使用されます。\n"
+"// ここでは`Foo`に対して`Add<Bar>`を実装します。これは加算時の右辺が`Bar`型\n"
+"// の時に呼び出されるトレイトです。\n"
+"// つまり以下は`Foo + Bar = FooBar`という振る舞いをもたらします。\n"
+
+#: src/trait/ops.md:30
+msgid "\"> Foo.add(Bar) was called\""
+msgstr "\"> Foo.add(Bar) was called\""
+
+#: src/trait/ops.md:35
+msgid ""
+"// By reversing the types, we end up implementing non-commutative addition.\n"
+"// Here, we make `Add<Foo>` - the trait for addition with a RHS of type "
+"`Foo`.\n"
+"// This block implements the operation: Bar + Foo = BarFoo\n"
+msgstr ""
+"// 型を反転することで、非可換の加算を実装できます。ここでは`Bar`に対して\n"
+"// `Add<Foo>`を実装します。\n"
+"// これは加算時の右辺が`Foo`型の時に呼び出されるメソッドです。\n"
+"// つまり以下は`Bar + Foo = BarFoo`という結果をもたらします。\n"
+
+#: src/trait/ops.md:43
+msgid "\"> Bar.add(Foo) was called\""
+msgstr "\"> Bar.add(Foo) was called\""
+
+#: src/trait/ops.md:50
+msgid "\"Foo + Bar = {:?}\""
+msgstr "\"Foo + Bar = {:?}\""
+
+#: src/trait/ops.md:51
+msgid "\"Bar + Foo = {:?}\""
+msgstr "\"Bar + Foo = {:?}\""
+
+#: src/trait/ops.md:55 src/testing.md:16 src/testing/doc_testing.md:104
+#: src/testing/dev_dependencies.md:36
+msgid "See Also"
+msgstr "参照"
+
+#: src/trait/ops.md:57
+msgid ""
+"[Add](https://doc.rust-lang.org/core/ops/trait.Add.html), [Syntax Index]"
+"(https://doc.rust-lang.org/book/appendix-02-operators.html)"
+msgstr ""
+"[Add](https://doc.rust-lang.org/core/ops/trait.Add.html), [構文の索引]"
+"(https://doc.rust-lang.org/book/appendix-02-operators.html)"
+
+#: src/trait/drop.md:3
+msgid ""
+"The [`Drop`](https://doc.rust-lang.org/std/ops/trait.Drop.html) trait only "
+"has one method: `drop`, which is called automatically  when an object goes "
+"out of scope. The main use of the `Drop` trait is to free the resources that "
+"the implementor instance owns."
+msgstr ""
+"[`Drop`](https://doc.rust-lang.org/std/ops/trait.Drop.html)トレイトにはメソッドが一つだけしかありません。"
+"`drop`です。これは、オブジェクトがスコープから抜けた時に自動で呼ばれます。"
+"`Drop`トレイトの主な使用目的は、インスタンスが所有する資源を開放することです。"
+
+#: src/trait/drop.md:7
+msgid ""
+"`Box`, `Vec`, `String`, `File`, and `Process` are some examples of types "
+"that implement the `Drop` trait to free resources. The `Drop` trait can also "
+"be manually implemented for any custom data type."
+msgstr ""
+"`Drop`トレイトを実装している型の例としては`Box`、`Vec`、`String`、`File`、`Process`等があげられます。"
+"`Drop`トレイトは任意の型に対して手動で実装することができます。"
+
+#: src/trait/drop.md:11
+msgid ""
+"The following example adds a print to console to the `drop` function to "
+"announce when it is called."
+msgstr ""
+"以下の例では`drop`メソッドにコンソールへの出力を追加することで、"
+"`drop`が呼ばれたタイミングが分かるようにしています。"
+
+#: src/trait/drop.md:18
+msgid "// This trivial implementation of `drop` adds a print to console.\n"
+msgstr "// このちょっとした実装で、`drop`にコンソール出力機能がつきます。\n"
+
+#: src/trait/drop.md:22
+msgid "\"> Dropping {}\""
+msgstr "\"> Dropping {}\""
+
+#: src/trait/drop.md:27 src/std_misc/path.md:33 src/std_misc/fs.md:44
+#: src/std_misc/fs.md:87
+msgid "\"a\""
+msgstr "\"a\""
+
+#: src/trait/drop.md:29
+msgid "// block A\n"
+msgstr ""
+
+#: src/trait/drop.md:31 src/std_misc/path.md:33
+msgid "\"b\""
+msgstr "\"b\""
+
+#: src/trait/drop.md:33
+msgid "// block B\n"
+msgstr ""
+
+#: src/trait/drop.md:35 src/std_misc/path.md:36
+msgid "\"c\""
+msgstr "\"c\""
+
+#: src/trait/drop.md:36
+msgid "\"d\""
+msgstr "\"d\""
+
+#: src/trait/drop.md:38
+msgid "\"Exiting block B\""
+msgstr "\"Exiting block B\""
+
+#: src/trait/drop.md:40
+msgid "\"Just exited block B\""
+msgstr "\"Just exited block B\""
+
+#: src/trait/drop.md:42
+msgid "\"Exiting block A\""
+msgstr "\"Exiting block A\""
+
+#: src/trait/drop.md:44
+msgid "\"Just exited block A\""
+msgstr "\"Just exited block A\""
+
+#: src/trait/drop.md:46
+msgid "// Variable can be manually dropped using the `drop` function\n"
+msgstr "// `drop`関数を用いて変数を手動で開放することもできます。\n"
+
+#: src/trait/drop.md:48
+msgid "// TODO ^ Try commenting this line\n"
+msgstr "// TODO ^ この行をコメントアウトしてみましょう。\n"
+
+#: src/trait/drop.md:50
+msgid "\"end of the main function\""
+msgstr "\"end of the main function\""
+
+#: src/trait/drop.md:52
+msgid ""
+"// `_a` *won't* be `drop`ed again here, because it already has been\n"
+"    // (manually) `drop`ed\n"
+msgstr ""
+"// `_a`はここで`drop`されることは *ありません* 。なぜならば、上ですでに\n"
+"    // （手動で）`drop`されているためです。\n"
+
+#: src/trait/iter.md:3
+msgid ""
+"The [`Iterator`](https://doc.rust-lang.org/core/iter/trait.Iterator.html) "
+"trait is used to implement iterators over collections such as arrays."
+msgstr ""
+"[`Iterator`](https://doc.rust-lang.org/core/iter/trait.Iterator.html)"
+"トレイトは、例えば配列のような、要素の集合に対してイテレータを実装するためのトレイトです。"
+
+#: src/trait/iter.md:6
+msgid ""
+"The trait requires only a method to be defined for the `next` element, which "
+"may be manually defined in an `impl` block or automatically defined (as in "
+"arrays and ranges)."
+msgstr ""
+"このトレイトは`next`の要素に相当するものを決定するためのメソッドのみを要求します。"
+"このメソッドは`impl`ブロック内で手動で実装するか、あるいは（配列やrangeのように）自動で定義されます。"
+
+#: src/trait/iter.md:10
+msgid ""
+"As a point of convenience for common situations, the `for` construct turns "
+"some collections into iterators using the [`.into_iter()`](https://doc.rust-"
+"lang.org/std/iter/trait.IntoIterator.html) method."
+msgstr ""
+"サッとイテレータを使いたい時は、`for`文で集合からイテレータを作成することが良くあります。"
+"これは[`.into_iter()`](https://doc.rust-lang.org/std/iter/trait.IntoIterator.html)メソッドを呼び出しています。"
+
+#: src/trait/iter.md:18
+msgid ""
+"// Implement `Iterator` for `Fibonacci`.\n"
+"// The `Iterator` trait only requires a method to be defined for the `next` "
+"element.\n"
+msgstr ""
+"// `Iterator`を`Fibonacci`に対して実装します。\n"
+"// `Iterator`トレイトは次の要素を取得するメソッドの定義だけを要求します。\n"
+
+#: src/trait/iter.md:22
+msgid "// We can refer to this type using Self::Item\n"
+msgstr ""
+
+#: src/trait/iter.md:25
+msgid ""
+"// Here, we define the sequence using `.curr` and `.next`.\n"
+"    // The return type is `Option<T>`:\n"
+"    //     * When the `Iterator` is finished, `None` is returned.\n"
+"    //     * Otherwise, the next value is wrapped in `Some` and returned.\n"
+"    // We use Self::Item in the return type, so we can change\n"
+"    // the type without having to update the function signatures.\n"
+msgstr ""
+"// ここではイテレーションの流れを`.curr`と`.next`を使用して定義しています。\n"
+"    // 返り値の型は`Option<T>`で、これは：\n"
+"    //     * `Iterator`が終了した時は`None`を返します。\n"
+"    //     * そうでなければ`Some`でラップされた値を返します。\n"
+
+#: src/trait/iter.md:37
+msgid ""
+"// Since there's no endpoint to a Fibonacci sequence, the `Iterator` \n"
+"        // will never return `None`, and `Some` is always returned.\n"
+msgstr ""
+"// フィボナッチ数列には終端がないので、`Iterator`は決して\n"
+"        // `None`を返さず、常に`Some`が返されます。\n"
+
+#: src/trait/iter.md:42
+msgid "// Returns a Fibonacci sequence generator\n"
+msgstr "// フィボナッチ数列のジェネレータを返します。\n"
+
+#: src/trait/iter.md:49
+msgid "// `0..3` is an `Iterator` that generates: 0, 1, and 2.\n"
+msgstr "// `0..3`は0, 1, 2をジェネレートする`Iterator`。\n"
+
+#: src/trait/iter.md:52
+msgid "\"Four consecutive `next` calls on 0..3\""
+msgstr "\"Four consecutive `next` calls on 0..3\""
+
+#: src/trait/iter.md:53 src/trait/iter.md:54 src/trait/iter.md:55
+#: src/trait/iter.md:56 src/std_misc/fs.md:90
+msgid "\"> {:?}\""
+msgstr "\"> {:?}\""
+
+#: src/trait/iter.md:58
+msgid ""
+"// `for` works through an `Iterator` until it returns `None`.\n"
+"    // Each `Some` value is unwrapped and bound to a variable (here, `i`).\n"
+msgstr ""
+"// `for`は`None`を返すまで、イテレータを舐めていき、出てきた`Some`を\n"
+"    // アンラップして変数（ここでは`i`）に束縛します。\n"
+
+#: src/trait/iter.md:60
+msgid "\"Iterate through 0..3 using `for`\""
+msgstr "\"Iterate through 0..3 using `for`\""
+
+#: src/trait/iter.md:62 src/trait/iter.md:68 src/trait/iter.md:74
+#: src/trait/iter.md:82 src/std/vec.md:49 src/std/str.md:22
+#: src/std_misc/fs.md:82
+msgid "\"> {}\""
+msgstr "\"> {}\""
+
+#: src/trait/iter.md:65
+msgid "// The `take(n)` method reduces an `Iterator` to its first `n` terms.\n"
+msgstr "// `take(n)`メソッドは`Iterator`を先頭から`n`番目の要素までに減らします。\n"
+
+#: src/trait/iter.md:66
+msgid "\"The first four terms of the Fibonacci sequence are: \""
+msgstr "\"The first four terms of the Fibonacci sequence are: \""
+
+#: src/trait/iter.md:71
+msgid ""
+"// The `skip(n)` method shortens an `Iterator` by dropping its first `n` "
+"terms.\n"
+msgstr "// `skip(n)`メソッドは`Iterator`の先頭から`n`番目までの要素をとばします。\n"
+
+#: src/trait/iter.md:72
+msgid "\"The next four terms of the Fibonacci sequence are: \""
+msgstr "\"The next four terms of the Fibonacci sequence are: \""
+
+#: src/trait/iter.md:79
+msgid "// The `iter` method produces an `Iterator` over an array/slice.\n"
+msgstr "// `iter`メソッドは配列やスライスからイテレータを作成します。\n"
+
+#: src/trait/iter.md:80
+msgid "\"Iterate the following array {:?}\""
+msgstr "\"Iterate the following array {:?}\""
+
+#: src/trait/impl_trait.md:3
+msgid "`impl Trait` can be used in two locations:"
+msgstr "`impl Trait`は2つの利用方法があります："
+
+#: src/trait/impl_trait.md:5
+msgid "as an argument type"
+msgstr "引数の型"
+
+#: src/trait/impl_trait.md:6
+msgid "as a return type"
+msgstr "リターン型"
+
+#: src/trait/impl_trait.md:8
+msgid "As an argument type"
+msgstr "引数の型"
+
+#: src/trait/impl_trait.md:10
+msgid ""
+"If your function is generic over a trait but you don't mind the specific "
+"type, you can simplify the function declaration using `impl Trait` as the "
+"type of the argument."
+msgstr ""
+"あなたの関数がジェネリックなトレイトを使用していて、"
+"特定の型を意識していない場合、`impl Trait`を引数の型として利用して、"
+"関数宣言をシンプルにできます。"
+
+#: src/trait/impl_trait.md:12
+msgid "For example, consider the following code:"
+msgstr "例えば、次のコードを考えてみましょう："
+
+#: src/trait/impl_trait.md:18 src/trait/impl_trait.md:37
+msgid "// For each line in the source\n"
+msgstr "// ソースのそれぞれの行について\n"
+
+#: src/trait/impl_trait.md:20 src/trait/impl_trait.md:39
+msgid ""
+"// If the line was read successfully, process it, if not, return the error\n"
+msgstr "// 行を読み込んだら処理します。そうでなければエラーを返します。\n"
+
+#: src/trait/impl_trait.md:21 src/trait/impl_trait.md:40 src/std/str.md:41
+msgid "','"
+msgstr "','"
+
+#: src/trait/impl_trait.md:21 src/trait/impl_trait.md:40
+msgid "// Split the line separated by commas\n"
+msgstr "// 行をカンマで分割します。\n"
+
+#: src/trait/impl_trait.md:22 src/trait/impl_trait.md:41
+msgid "// Remove leading and trailing whitespace\n"
+msgstr "// 前後の空白を削除します。\n"
+
+#: src/trait/impl_trait.md:23 src/trait/impl_trait.md:42
+msgid "// Collect all strings in a row into a Vec<String>\n"
+msgstr "// 各行の全ての文字列をVec<String>に集めます。\n"
+
+#: src/trait/impl_trait.md:26 src/trait/impl_trait.md:45
+msgid "// Collect all lines into a Vec<Vec<String>>\n"
+msgstr "// 全ての行をVec<Vec<String>>に集めます。\n"
+
+#: src/trait/impl_trait.md:30
+msgid ""
+"`parse_csv_document` is generic, allowing it to take any type which "
+"implements BufRead, such as `BufReader<File>` or `[u8]`, but it's not "
+"important what type `R` is, and `R` is only used to declare the type of "
+"`src`, so the function can also be written as:"
+msgstr ""
+"`parse_csv_document`はジェネリックなので、BufReadを実装する任意の型を取ることができます。"
+"例えば、`BufReader<File>`や`[u8]`です。"
+"`R`がどんな型かは重要ではなく、`src`の型宣言に使われているだけなので、"
+"この関数は以下のように書くこともできます："
+
+#: src/trait/impl_trait.md:49
+msgid ""
+"Note that using `impl Trait` as an argument type means that you cannot "
+"explicitly state what form of the function you use, i.e. "
+"`parse_csv_document::<std::io::Empty>(std::io::empty())` will not work with "
+"the second example."
+msgstr ""
+"`impl Trait`を引数の型として利用するということは、どのような形式の関数であるか明示できないので、注意してください。"
+"例えば、`parse_csv_document::<std::io::Empty>(std::io::empty())`は2番目の例では動作しません。"
+
+#: src/trait/impl_trait.md:52
+msgid "As a return type"
+msgstr "リターン型"
+
+#: src/trait/impl_trait.md:54
+msgid ""
+"If your function returns a type that implements `MyTrait`, you can write its "
+"return type as `-> impl MyTrait`. This can help simplify your type "
+"signatures quite a lot!"
+msgstr ""
+"あなたの関数が`MyTrait`を実装する型を返す場合、"
+"リターン型を`-> impl MyTrait`のように書けます。"
+"これで型シグネチャをとてもシンプルにできます。"
+
+#: src/trait/impl_trait.md:60
+msgid ""
+"// This function combines two `Vec<i32>` and returns an iterator over it.\n"
+"// Look how complicated its return type is!\n"
+msgstr ""
+"// この関数は2つの`Vec<i32>を組み合わせて、そのイテレータを返します。\n"
+"// リターン型がとても複雑です！\n"
+
+#: src/trait/impl_trait.md:69
+msgid ""
+"// This is the exact same function, but its return type uses `impl Trait`.\n"
+"// Look how much simpler it is!\n"
+msgstr ""
+"// これは全く同じ関数ですが、リターン型に`impl Trait`を使っています。\n"
+"// とてもシンプルですね！\n"
+
+#: src/trait/impl_trait.md:88
+msgid "\"all done\""
+msgstr "\"all done\""
+
+#: src/trait/impl_trait.md:92
+msgid ""
+"More importantly, some Rust types can't be written out. For example, every "
+"closure has its own unnamed concrete type. Before `impl Trait` syntax, you "
+"had to allocate on the heap in order to return a closure. But now you can do "
+"it all statically, like this:"
+msgstr ""
+"より重要なことに、Rustの型には書き表せないものがあるのです。"
+"例えば、あらゆるクロージャは独自の無名な具象型を持ちます。"
+"`impl Trait`構文がない時は、クロージャを返すにはヒープ上に置かねばなりませんでした。"
+"しかし今では次のようにすべて静的に行えます。"
+
+#: src/trait/impl_trait.md:98
+msgid "// Returns a function that adds `y` to its input\n"
+msgstr "// 入力に`y`を加える関数を返します。\n"
+
+#: src/trait/impl_trait.md:110
+msgid ""
+"You can also use `impl Trait` to return an iterator that uses `map` or "
+"`filter` closures! This makes using `map` and `filter` easier. Because "
+"closure types don't have names, you can't write out an explicit return type "
+"if your function returns iterators with closures. But with `impl Trait` you "
+"can do this easily:"
+msgstr ""
+"`impl Trait`を使って、`map`や`filter`クロージャを使うイテレータを返すこともできます。"
+"おかげで`map`や`filter`を簡単に使えます。"
+"クロージャ型は名前を持たないので、あなたの関数がクロージャを持つイテレータを返す場合、"
+"明示的なリターン型を書くことはできません。"
+"しかし`impl Trait`を使うことで簡単にできます："
+
+#: src/trait/clone.md:3
+msgid ""
+"When dealing with resources, the default behavior is to transfer them during "
+"assignments or function calls. However, sometimes we need to make a copy of "
+"the resource as well."
+msgstr ""
+"メモリ上の資源を扱う際、変数束縛や関数呼び出しを介して移動させるのがデフォルトの挙動です。"
+"しかしながら、場合によっては資源のコピーを作るのが適切なこともあります。"
+
+#: src/trait/clone.md:7
+msgid ""
+"The [`Clone`](https://doc.rust-lang.org/std/clone/trait.Clone.html) trait "
+"helps us do exactly this. Most commonly, we can use the `.clone()` method "
+"defined by the `Clone` trait."
+msgstr ""
+"[`Clone`](https://doc.rust-lang.org/std/clone/trait.Clone.html)トレイト"
+"はまさにこのためにあります。普通は`Clone`トレイトで定義されている`.clone()`を用います。"
+
+#: src/trait/clone.md:11
+msgid "// A unit struct without resources\n"
+msgstr "// いかなる資源も持たない構造体\n"
+
+#: src/trait/clone.md:14
+msgid "// A tuple struct with resources that implements the `Clone` trait\n"
+msgstr "// `Clone`トレイトを実装する型の変数を資源として持つタプル\n"
+
+#: src/trait/clone.md:20
+msgid "// Instantiate `Unit`\n"
+msgstr "// `Unit`のインスタンスを作成。\n"
+
+#: src/trait/clone.md:22
+msgid "// Copy `Unit`, there are no resources to move\n"
+msgstr "// `Unit`をコピー、移動させる資源は存在しません。\n"
+
+#: src/trait/clone.md:25
+msgid "// Both `Unit`s can be used independently\n"
+msgstr "// いずれの`Unit`も独立に使用できます。\n"
+
+#: src/trait/clone.md:26 src/trait/clone.md:31
+msgid "\"original: {:?}\""
+msgstr "\"original: {:?}\""
+
+#: src/trait/clone.md:27
+msgid "\"copy: {:?}\""
+msgstr "\"copy: {:?}\""
+
+#: src/trait/clone.md:29
+msgid "// Instantiate `Pair`\n"
+msgstr "// `Pair`のインスタンスを作成。\n"
+
+#: src/trait/clone.md:33
+msgid "// Move `pair` into `moved_pair`, moves resources\n"
+msgstr "// `pair`を`moved_pair`に移動、資源は移動します。\n"
+
+#: src/trait/clone.md:35
+msgid "\"moved: {:?}\""
+msgstr "\"moved: {:?}\""
+
+#: src/trait/clone.md:37
+msgid ""
+"// Error! `pair` has lost its resources\n"
+"    //println!(\"original: {:?}\", pair);\n"
+"    // TODO ^ Try uncommenting this line\n"
+msgstr ""
+"// エラー！`pair`は資源を失っています。\n"
+"    //println!(\"original: {:?}\", pair);\n"
+"    // TODO ^ この行をアンコメントしてみましょう。\n"
+
+#: src/trait/clone.md:41
+msgid "// Clone `moved_pair` into `cloned_pair` (resources are included)\n"
+msgstr "// `moved_pair`を`cloned_pair`にクローンします。（資源もクローンされます。）\n"
+
+#: src/trait/clone.md:43
+msgid "// Drop the moved original pair using std::mem::drop\n"
+msgstr "// std::mem::dropを用いて元のpairをドロップします。\n"
+
+#: src/trait/clone.md:46
+msgid ""
+"// Error! `moved_pair` has been dropped\n"
+"    //println!(\"moved and dropped: {:?}\", moved_pair);\n"
+"    // TODO ^ Try uncommenting this line\n"
+msgstr ""
+"// エラー！`moved_pair`はドロップされています。\n"
+"    //println!(\"moved and dropped: {:?}\", moved_pair);\n"
+"    // TODO ^ この行をアンコメントしてみましょう。\n"
+
+#: src/trait/clone.md:50
+msgid "// The result from .clone() can still be used!\n"
+msgstr "// .clone()した値はまだ使用可能！\n"
+
+#: src/trait/clone.md:51
+msgid "\"clone: {:?}\""
+msgstr "\"clone: {:?}\""
+
+#: src/trait/supertraits.md:3
+msgid ""
+"Rust doesn't have \"inheritance\", but you can define a trait as being a "
+"superset of another trait. For example:"
+msgstr ""
+"Rustには\"継承\"はありませんが、あるトレイトを別のトレイトの上位集合として定義できます。"
+"例えば："
+
+#: src/trait/supertraits.md:10
+msgid ""
+"// Person is a supertrait of Student.\n"
+"// Implementing Student requires you to also impl Person.\n"
+msgstr ""
+"// PersonはStudentのスーパートレイトです。\n"
+"// Studentを実装するにはPersonも実装する必要があります。\n"
+
+#: src/trait/supertraits.md:20
+msgid ""
+"// CompSciStudent (computer science student) is a subtrait of both "
+"Programmer \n"
+"// and Student. Implementing CompSciStudent requires you to impl both "
+"supertraits.\n"
+msgstr ""
+"// CompSciStudent（コンピュータサイエンスの学生）はProgrammerとStudent両方のサブトレイトです。\n"
+"// CompSciStudentを実装するには、両方のスーパートレイトを実装する必要があります。\n"
+
+#: src/trait/supertraits.md:29
+msgid ""
+"\"My name is {} and I attend {}. My favorite language is {}. My Git username "
+"is {}\""
+msgstr ""
+"\"My name is {} and I attend {}. My favorite language is {}. My Git username "
+"is {}\""
+
+#: src/trait/supertraits.md:42
+msgid ""
+"[The Rust Programming Language chapter on supertraits](https://doc.rust-lang."
+"org/book/ch19-03-advanced-traits.html#using-supertraits-to-require-one-"
+"traits-functionality-within-another-trait)"
+msgstr ""
+
+#: src/trait/disambiguating.md:3
+msgid ""
+"A type can implement many different traits. What if two traits both require "
+"the same name for a function? For example, many traits might have a method  "
+"named `get()`. They might even have different return types!"
+msgstr ""
+
+#: src/trait/disambiguating.md:7
+msgid ""
+"Good news: because each trait implementation gets its own `impl` block, it's "
+"clear which trait's `get` method you're implementing."
+msgstr ""
+
+#: src/trait/disambiguating.md:10
+msgid ""
+"What about when it comes time to _call_ those methods? To disambiguate "
+"between them, we have to use Fully Qualified Syntax."
+msgstr ""
+
+#: src/trait/disambiguating.md:15
+msgid "// Get the selected username out of this widget\n"
+msgstr ""
+
+#: src/trait/disambiguating.md:20
+msgid "// Get the selected age out of this widget\n"
+msgstr ""
+
+#: src/trait/disambiguating.md:23
+msgid "// A form with both a UsernameWidget and an AgeWidget\n"
+msgstr ""
+
+#: src/trait/disambiguating.md:44 src/trait/disambiguating.md:54
+msgid "\"rustacean\""
+msgstr "\"rustacean\""
+
+#: src/trait/disambiguating.md:48
+msgid ""
+"// If you uncomment this line, you'll get an error saying\n"
+"    // \"multiple `get` found\". Because, after all, there are multiple "
+"methods\n"
+"    // named `get`.\n"
+"    // println!(\"{}\", form.get());\n"
+msgstr ""
+
+#: src/trait/disambiguating.md:62
+msgid ""
+"[The Rust Programming Language chapter on Fully Qualified syntax](https://"
+"doc.rust-lang.org/book/ch19-03-advanced-traits.html#fully-qualified-syntax-"
+"for-disambiguation-calling-methods-with-the-same-name)"
+msgstr ""
+
+#: src/macros.md:3
+msgid ""
+"Rust provides a powerful macro system that allows metaprogramming. As you've "
+"seen in previous chapters, macros look like functions, except that their "
+"name ends with a bang `!`, but instead of generating a function call, macros "
+"are expanded into source code that gets compiled with the rest of the "
+"program. However, unlike macros in C and other languages, Rust macros are "
+"expanded into abstract syntax trees, rather than string preprocessing, so "
+"you don't get unexpected precedence bugs."
+msgstr ""
+"Rustはメタプログラミングを可能にする、パワフルなマクロシステムを備えています。"
+"これまで見てきたように、マクロは`!`で終わることを除けば関数のように見えます。"
+"関数と違うのは関数呼び出しを生成する代わりに、"
+"ソースコード中に展開され、周囲のプログラムとともにコンパイルされる点です。"
+"しかし、Cやその他の言語のマクロが文字列のプリプロセッシングをするのと異なり、"
+"Rustのマクロは抽象構文木へと展開されるので、予期せぬ演算子の優先順位のバグに出くわすことがありません。"
+
+#: src/macros.md:11
+msgid "Macros are created using the `macro_rules!` macro."
+msgstr "マクロを作成するには`macro_rules!`というマクロを使用します。"
+
+#: src/macros.md:14
+msgid "// This is a simple macro named `say_hello`.\n"
+msgstr "// `say_hello`という名のシンプルなマクロ\n"
+
+#: src/macros.md:16
+msgid "// `()` indicates that the macro takes no argument.\n"
+msgstr "// `()`はマクロが引数をとらないことを示します。\n"
+
+#: src/macros.md:18
+msgid "// The macro will expand into the contents of this block.\n"
+msgstr ""
+"// マクロは（訳注: プリコンパイルの段階で）\n"
+"        // このブロックの内容に展開されます。\n"
+
+#: src/macros.md:19
+msgid "\"Hello!\""
+msgstr "\"Hello!\""
+
+#: src/macros.md:24
+msgid "// This call will expand into `println!(\"Hello\")`\n"
+msgstr "// この呼び出しは`println!(\"Hello\");`に置き換えられます。\n"
+
+#: src/macros.md:29
+msgid "So why are macros useful?"
+msgstr "ではどうしてマクロは便利なのでしょうか？"
+
+#: src/macros.md:31
+msgid ""
+"Don't repeat yourself. There are many cases where you may need similar "
+"functionality in multiple places but with different types. Often, writing a "
+"macro is a useful way to avoid repeating code. (More on this later)"
+msgstr ""
+"同じことを繰り返し書いてはいけないから。"
+"複数の場所で、別の型だけれど似たような機能が必要な時がよくあります。"
+"しばしば、マクロはコードを繰り返し書くのを避ける有用な手段なのです（あとで詳述）。"
+
+#: src/macros.md:35
+msgid ""
+"Domain-specific languages. Macros allow you to define special syntax for a "
+"specific purpose. (More on this later)"
+msgstr "ドメイン特化言語であるから。マクロを使うと、特定の目的のための特定の構文を定義することができます（あとで詳述）。"
+
+#: src/macros.md:38
+msgid ""
+"Variadic interfaces. Sometimes you want to define an interface that takes a "
+"variable number of arguments. An example is `println!` which could take any "
+"number of arguments, depending on the format string. (More on this later)"
+msgstr ""
+"可変個引数によるインターフェース。"
+"取る引数の数が可変であるようなインターフェースを定義したくなることもあるでしょう。"
+"例えば、`println!`は、フォーマット文字列に依存した任意の数の引数を取ることができます（あとで詳述）！"
+
+#: src/macros/syntax.md:3
+msgid ""
+"In following subsections, we will show how to define macros in Rust. There "
+"are three basic ideas:"
+msgstr ""
+"以下のサブセクションでは、Rustにおいてマクロを定義する方法を示します。"
+"3つの基本的な考え方があります："
+
+#: src/macros/syntax.md:6
+msgid "[Patterns and Designators](designators.md)"
+msgstr "[パターンと識別子](designators.md)"
+
+#: src/macros/syntax.md:7
+msgid "[Overloading](overload.md)"
+msgstr "[オーバーロード](overload.md)"
+
+#: src/macros/syntax.md:8
+msgid "[Repetition](repeat.md)"
+msgstr "[繰り返し](repeat.md)"
+
+#: src/macros/designators.md:3
+msgid ""
+"The arguments of a macro are prefixed by a dollar sign `$` and type "
+"annotated with a _designator_:"
+msgstr "macroの引数は`$`が頭につきます。型は *識別子* でアノテーションされます。"
+
+#: src/macros/designators.md:8
+msgid ""
+"// This macro takes an argument of designator `ident` and\n"
+"    // creates a function named `$func_name`.\n"
+"    // The `ident` designator is used for variable/function names.\n"
+msgstr ""
+"// このマクロは`ident`識別子に対応する値を引数として取り\n"
+"    // `$func_name`という名の関数を作成します。\n"
+"    // `ident`識別子は関数・変数の名前用の識別子です。\n"
+
+#: src/macros/designators.md:13
+msgid "// The `stringify!` macro converts an `ident` into a string.\n"
+msgstr "// `stringify!`というマクロは`ident`を文字列に変えます。\n"
+
+#: src/macros/designators.md:14
+msgid "\"You called {:?}()\""
+msgstr "\"You called {:?}()\""
+
+#: src/macros/designators.md:19
+msgid "// Create functions named `foo` and `bar` with the above macro.\n"
+msgstr "// 上のマクロを利用して`foo`、`bar`という名の関数を作成します。\n"
+
+#: src/macros/designators.md:25
+msgid ""
+"// This macro takes an expression of type `expr` and prints\n"
+"    // it as a string along with its result.\n"
+"    // The `expr` designator is used for expressions.\n"
+msgstr ""
+"// このマクロは`expr`識別子に対応する値を引数として取り、\n"
+"    // その結果を文字列として出力します。\n"
+"    // `expr`識別子は式に対応します。\n"
+
+#: src/macros/designators.md:29
+msgid "// `stringify!` will convert the expression *as it is* into a string.\n"
+msgstr "// `stringify!`は式を *そのままの形で* 文字列に変換します\n"
+
+#: src/macros/designators.md:30
+msgid "\"{:?} = {:?}\""
+msgstr "\"{:?} = {:?}\""
+
+#: src/macros/designators.md:42
+msgid "// Recall that blocks are expressions too!\n"
+msgstr "// ブロックも式の一種であることを思い出しましょう！\n"
+
+#: src/macros/designators.md:51
+msgid "These are some of the available designators:"
+msgstr "使用できる識別子には以下のようなものがあります。"
+
+#: src/macros/designators.md:53
+msgid "`block`"
+msgstr "`block`"
+
+#: src/macros/designators.md:54
+msgid "`expr` is used for expressions"
+msgstr "`expr` 式に使用。"
+
+#: src/macros/designators.md:55
+msgid "`ident` is used for variable/function names"
+msgstr "`ident` 関数、変数の名前に使用。"
+
+#: src/macros/designators.md:56
+msgid "`item`"
+msgstr "`item`"
+
+#: src/macros/designators.md:57
+msgid "`literal` is used for literal constants"
+msgstr "`literal` はリテラル定数。"
+
+#: src/macros/designators.md:58
+msgid "`pat` (_pattern_)"
+msgstr "`pat`（*パターン*）"
+
+#: src/macros/designators.md:59
+msgid "`path`"
+msgstr "`path`"
+
+#: src/macros/designators.md:60
+msgid "`stmt` (_statement_)"
+msgstr "`stmt`（*宣言*）"
+
+#: src/macros/designators.md:61
+msgid "`tt` (_token tree_)"
+msgstr "`tt`（*トークンツリー*）"
+
+#: src/macros/designators.md:62
+msgid "`ty` (_type_)"
+msgstr "`ty`（*型*）"
+
+#: src/macros/designators.md:63
+msgid "`vis` (_visibility qualifier_)"
+msgstr "`vis`（*可視性修飾子*）（訳注：`pub (crate)`とか）"
+
+#: src/macros/designators.md:65
+msgid ""
+"For a complete list, see the [Rust Reference](https://doc.rust-lang.org/"
+"reference/macros-by-example.html)."
+msgstr ""
+"完全なリストを見るには、"
+"[Rustリファレンス](https://doc.rust-lang.org/reference/macros-by-example.html)を読んでください。"
+
+#: src/macros/overload.md:3
+msgid ""
+"Macros can be overloaded to accept different combinations of arguments.  In "
+"that regard, `macro_rules!` can work similarly to a match block:"
+msgstr ""
+"マクロは異なる引数の組み合わせを取るようにオーバーロードすることができるため、"
+"`macro_rules!`はマッチと似たような使い方をすることができます。"
+
+#: src/macros/overload.md:7
+msgid ""
+"// `test!` will compare `$left` and `$right`\n"
+"// in different ways depending on how you invoke it:\n"
+msgstr ""
+"// `test!`は`$left`と`$right`を異なる呼び出し方に応じて\n"
+"// 比較します。\n"
+
+#: src/macros/overload.md:10
+msgid ""
+"// Arguments don't need to be separated by a comma.\n"
+"    // Any template can be used!\n"
+msgstr ""
+"// 引数はカンマで区切らなくても構いません。\n"
+"    // テンプレートの形態は自由！\n"
+
+#: src/macros/overload.md:13
+msgid "\"{:?} and {:?} is {:?}\""
+msgstr "\"{:?} and {:?} is {:?}\""
+
+#: src/macros/overload.md:18
+msgid "// ^ each arm must end with a semicolon.\n"
+msgstr "// ^ それぞれの`=>`節はセミコロンで終わる必要があります。\n"
+
+#: src/macros/overload.md:20
+msgid "\"{:?} or {:?} is {:?}\""
+msgstr "\"{:?} or {:?} is {:?}\""
+
+#: src/macros/repeat.md:3
+msgid ""
+"Macros can use `+` in the argument list to indicate that an argument may "
+"repeat at least once, or `*`, to indicate that the argument may repeat zero "
+"or more times."
+msgstr ""
+"マクロは引数のリストの中で`+`を使うことができ、そうすることによって、"
+"引数が少なくとも1回以上繰り返されるということを示すことができます。"
+"同様に`*`の場合は、0以上を示します。"
+
+#: src/macros/repeat.md:7
+msgid ""
+"In the following example, surrounding the matcher with `$(...),+` will match "
+"one or more expression, separated by commas. Also note that the semicolon is "
+"optional on the last case."
+msgstr ""
+"以下の例では、マッチ対象を `$(...),+`で囲むことにより、"
+"カンマで区切られた1つ以上の式とマッチします。"
+"最後のセミコロンは必須ではないことに注目しましょう。"
+
+#: src/macros/repeat.md:12
+msgid "// `find_min!` will calculate the minimum of any number of arguments.\n"
+msgstr "// `find_min!`は引数として与えられた数字の中の最低の値を計算します。\n"
+
+#: src/macros/repeat.md:14
+msgid "// Base case:\n"
+msgstr "// 基本となるケース\n"
+
+#: src/macros/repeat.md:16
+msgid "// `$x` followed by at least one `$y,`\n"
+msgstr "// `$x`に少なくとも1つの`$y`が続く場合\n"
+
+#: src/macros/repeat.md:18
+msgid "// Call `find_min!` on the tail `$y`\n"
+msgstr "// `find_min!`を残りの`$y`に対して再帰的に適用。\n"
+
+#: src/macros/dry.md:3
+msgid ""
+"Macros allow writing DRY code by factoring out the common parts of functions "
+"and/or test suites. Here is an example that implements and tests the `+=`, "
+"`*=` and `-=` operators on `Vec<T>`:"
+msgstr ""
+"マクロは関数やテストなどにおいて、共通の部分を抽出することでDRYなコードを書くのに役立ちます。"
+"ここでは`Vec<T>`に`+=`、`*=`、`-=`を実装、テストするにあたって、マクロがどのように役立つかを見ていきます。"
+
+#: src/macros/dry.md:11
+msgid ""
+"// The `tt` (token tree) designator is used for\n"
+"    // operators and tokens.\n"
+msgstr "// `tt` （トークン木）識別子は演算子とトークン用の識別子です。\n"
+
+#: src/macros/dry.md:15
+msgid "\"{:?}: dimension mismatch: {:?} {:?} {:?}\""
+msgstr "\"{:?}: dimension mismatch: {:?} {:?} {:?}\""
+
+#: src/macros/dry.md:30
+msgid "// *x = x.$method(*y);\n"
+msgstr "// *x = x.$method(*y);\n"
+
+#: src/macros/dry.md:35
+msgid "// Implement `add_assign`, `mul_assign`, and `sub_assign` functions.\n"
+msgstr "// `add_assign`、`mul_assign`、`sub_assign`、関数を実装\n"
+
+#: src/macros/dry.md:60
+msgid "// Test `add_assign`, `mul_assign`, and `sub_assign`.\n"
+msgstr "// `add_assign`と`mul_assign`と`sub_assign`をテスト\n"
+
+#: src/macros/dsl.md:1
+msgid "Domain Specific Languages (DSLs)"
+msgstr "Domain Specific Languages (ドメイン特化言語、DSLs)"
+
+#: src/macros/dsl.md:3
+msgid ""
+"A DSL is a mini \"language\" embedded in a Rust macro. It is completely "
+"valid Rust because the macro system expands into normal Rust constructs, but "
+"it looks like a small language. This allows you to define concise or "
+"intuitive syntax for some special functionality (within bounds)."
+msgstr ""
+"ここで言うDSLとはRustマクロに埋め込まれた小さな「言語」のことです。"
+"マクロ機能は通常のRustのプログラムへと展開されるので、これは完全に正当なRustなのですが、まるで小さな言語であるかのように見えます。"
+"これにより、（一定の条件のもとで）なんらかの特定の機能のための簡潔・直感的な構文を定義することができるようになります。"
+
+#: src/macros/dsl.md:8
+msgid ""
+"Suppose that I want to define a little calculator API. I would like to "
+"supply an expression and have the output printed to console."
+msgstr ""
+"ちょっとした計算機APIを定義したいとしましょう。"
+"式を与えると、出力がコンソールに書き出されるようにしたいです。"
+
+#: src/macros/dsl.md:15
+msgid "// Force types to be unsigned integers\n"
+msgstr "// 型を整数に制約。\n"
+
+#: src/macros/dsl.md:16 src/macros/variadics.md:15
+msgid "\"{} = {}\""
+msgstr "\"{} = {}\""
+
+#: src/macros/dsl.md:23
+msgid "// hehehe `eval` is _not_ a Rust keyword!\n"
+msgstr "// `eval`はRustのキーワード *じゃない* よね！\n"
+
+#: src/macros/dsl.md:32 src/macros/variadics.md:35
+msgid "Output:"
+msgstr "出力はこうなります："
+
+#: src/macros/dsl.md:39
+msgid ""
+"This was a very simple example, but much more complex interfaces have been "
+"developed, such as [`lazy_static`](https://crates.io/crates/lazy_static) or "
+"[`clap`](https://crates.io/crates/clap)."
+msgstr ""
+"これはとても単純な例ですが、[`lazy_static`](https://crates.io/crates/lazy_static)や"
+"[`clap`](https://crates.io/crates/clap)のように、もっと複雑なインターフェースも開発されています。"
+
+#: src/macros/dsl.md:43
+msgid ""
+"Also, note the two pairs of braces in the macro. The outer ones are part of "
+"the syntax of `macro_rules!`, in addition to `()` or `[]`."
+msgstr ""
+"また、マクロの中に2組の括弧があることにも注目してください。"
+"外側のは、`()`や`[]`に加え、`macro_rules!`の構文の一部です。"
+
+#: src/macros/variadics.md:1
+msgid "Variadic Interfaces"
+msgstr "可変個引数によるインターフェース"
+
+#: src/macros/variadics.md:3
+msgid ""
+"A _variadic_ interface takes an arbitrary number of arguments. For example, "
+"`println!` can take an arbitrary number of arguments, as determined by the "
+"format string."
+msgstr ""
+"*可変個引数の*インターフェースとは、任意の数の引数を取るものです。"
+"例えば、`println!`は、フォーマット文字列の定義に従い、任意の数の引数を取ることができます。"
+
+#: src/macros/variadics.md:7
+msgid ""
+"We can extend our `calculate!` macro from the previous section to be "
+"variadic:"
+msgstr "前のセクションの`calculate!`マクロを、可変個引数に拡張することができます："
+
+#: src/macros/variadics.md:11
+msgid "// The pattern for a single `eval`\n"
+msgstr "// 単一の`eval`のためのパターン\n"
+
+#: src/macros/variadics.md:14
+msgid "// Force types to be integers\n"
+msgstr "// 強制的に型を整数にします。\n"
+
+#: src/macros/variadics.md:19
+msgid "// Decompose multiple `eval`s recursively\n"
+msgstr "// 複数の`eval`を再帰的に分解します。\n"
+
+#: src/macros/variadics.md:27
+msgid "// Look ma! Variadic `calculate!`!\n"
+msgstr "// ほら！可変な`calculate!`だよ！\n"
+
+#: src/error.md:3
+msgid ""
+"Error handling is the process of handling the possibility of failure. For "
+"example, failing to read a file and then continuing to use that _bad_ input "
+"would clearly be problematic. Noticing and explicitly managing those errors "
+"saves the rest of the program from various pitfalls."
+msgstr ""
+"エラーハンドリングとは失敗の起きる可能性を扱うプロセスのことです。"
+"例えば、ファイルを読み込むのに失敗した際、その *誤った* インプットを使い続けるのは明らかに問題です。"
+"そのようなエラーを通知して明示的に扱うことで、残りのプログラムに問題が波及することを防ぐことができるようになります。"
+
+#: src/error.md:8
+msgid ""
+"There are various ways to deal with errors in Rust, which are described in "
+"the following subchapters. They all have more or less subtle differences and "
+"different use cases. As a rule of thumb:"
+msgstr ""
+"Rustには、これからこの章で見ていく通り、エラーを処理するための様々な方法が存在します。"
+"それらは全て僅かに異なり、ユースケースも異なります。経験則として："
+
+#: src/error.md:12
+msgid ""
+"An explicit `panic` is mainly useful for tests and dealing with "
+"unrecoverable errors. For prototyping it can be useful, for example when "
+"dealing with functions that haven't been implemented yet, but in those cases "
+"the more descriptive `unimplemented` is better. In tests `panic` is a "
+"reasonable way to explicitly fail."
+msgstr ""
+"明示的な`panic`はテストや復旧不可能なエラーに対して効果的です。"
+"プロトタイプにも便利で、例えば未実装の関数を扱う時などに有効ですが、"
+"このような場合にはより叙述的な`unimplemented`の方が良いでしょう。"
+"テストにおいては`panic`は明示的にテストを失敗させるための良い手法になるでしょう。"
+
+#: src/error.md:17
+msgid ""
+"The `Option` type is for when a value is optional or when the lack of a "
+"value is not an error condition. For example the parent of a directory - `/` "
+"and `C:` don't have one. When dealing with `Option`s, `unwrap` is fine for "
+"prototyping and cases where it's absolutely certain that there is guaranteed "
+"to be a value. However `expect` is more useful since it lets you specify an "
+"error message in case something goes wrong anyway."
+msgstr ""
+"`Option`型は値があるとは限らない場合や、値が無いことがエラーの条件とならない場合に有効です。"
+"例えば親ディレクトリ（`/`や`C:`はそれを持ちません）などです。"
+"`Option`を扱う際は、`unwrap`がプロトタイプや値が確実に存在することが約束されるケースに使えます。"
+"しかし、`expect`の方が何かが上手くいかなかった際にエラーメッセージを指定することができるため、より便利でしょう。"
+
+#: src/error.md:24
+msgid ""
+"When there is a chance that things do go wrong and the caller has to deal "
+"with the problem, use `Result`. You can `unwrap` and `expect` them as well "
+"(please don't do that unless it's a test or quick prototype)."
+msgstr ""
+"何かが上手くいかない可能性があったり、呼び出し元が問題を処理しなければならない時は、`Result`を使いましょう。"
+"`unwrap`や`expect`を実行することもできます（テストや短期的なプロトタイプ以外では使わないでください）。"
+
+#: src/error.md:28
+msgid ""
+"For a more rigorous discussion of error handling, refer to the error "
+"handling section in the [official book](https://doc.rust-lang.org/book/"
+"ch09-00-error-handling.html)."
+msgstr ""
+"より詳細なエラーハンドリングに関する議論については、"
+"[オフィシャルブック](https://doc.rust-lang.org/book/ch09-00-error-handling.html)"
+"の該当の章を参考にしてください。"
+
+#: src/error/panic.md:3
+msgid ""
+"The simplest error handling mechanism we will see is `panic`. It prints an "
+"error message, starts unwinding the stack, and usually exits the program. "
+"Here, we explicitly call `panic` on our error condition:"
+msgstr ""
+"`panic`は、最もシンプルなエラーハンドリングの仕組みです。"
+"エラーメッセージの出力、スタックの巻き戻し、そして多くの場合プログラムの終了を実行します。"
+"例として、エラー条件に対して明示的に`panic`を呼び出してみましょう。"
+
+#: src/error/panic.md:9 src/error/abort_unwind.md:10
+msgid "// You shouldn't drink too much sugary beverages.\n"
+msgstr "// 甘すぎる飲み物を飲むべきではありません。\n"
+
+#: src/error/panic.md:10 src/error/panic.md:17 src/error/abort_unwind.md:11
+#: src/error/abort_unwind.md:24 src/error/abort_unwind.md:42
+#: src/error/abort_unwind.md:51 src/error/option_unwrap.md:32
+#: src/error/option_unwrap.md:43 src/error/option_unwrap.md:50
+msgid "\"lemonade\""
+msgstr "\"lemonade\""
+
+#: src/error/panic.md:10 src/error/option_unwrap.md:43
+msgid "\"AAAaaaaa!!!!\""
+msgstr "\"AAAaaaaa!!!!\""
+
+#: src/error/panic.md:12 src/error/abort_unwind.md:18
+#: src/error/abort_unwind.md:45
+msgid "\"Some refreshing {} is all I need.\""
+msgstr "\"Some refreshing {} is all I need.\""
+
+#: src/error/panic.md:16 src/error/abort_unwind.md:23
+#: src/error/abort_unwind.md:50 src/error/option_unwrap.md:49
+msgid "\"water\""
+msgstr "\"water\""
+
+#: src/error/panic.md:18
+msgid "\"still water\""
+msgstr "\"still water\""
+
+#: src/error/panic.md:22
+msgid ""
+"The first call to `drink` works. The second panics and thus the third is "
+"never called."
+msgstr ""
+
+#: src/error/abort_unwind.md:1
+msgid "`abort` and `unwind`"
+msgstr ""
+
+#: src/error/abort_unwind.md:3
+msgid ""
+"The previous section illustrates the error handling mechanism `panic`.  "
+"Different code paths can be conditionally compiled based on the panic "
+"setting. The current values available are `unwind` and `abort`. "
+msgstr ""
+
+#: src/error/abort_unwind.md:6
+msgid ""
+"Building on the prior lemonade example, we explicitly use the panic strategy "
+"to exercise different lines of code."
+msgstr ""
+
+#: src/error/abort_unwind.md:12
+msgid "\"abort\""
+msgstr "\"abort\""
+
+#: src/error/abort_unwind.md:13 src/error/abort_unwind.md:38
+msgid "\"This is not your party. Run!!!!\""
+msgstr "\"This is not your party. Run!!!!\""
+
+#: src/error/abort_unwind.md:15 src/error/abort_unwind.md:33
+msgid "\"Spit it out!!!!\""
+msgstr "\"Spit it out!!!!\""
+
+#: src/error/abort_unwind.md:28
+msgid ""
+"Here is another example focusing on rewriting `drink()` and explicitly use "
+"the `unwind` keyword."
+msgstr ""
+
+#: src/error/abort_unwind.md:31 src/error/abort_unwind.md:36
+msgid "\"unwind\""
+msgstr "\"unwind\""
+
+#: src/error/abort_unwind.md:55
+msgid ""
+"The panic strategy can be set from the command line by using `abort` or "
+"`unwind`."
+msgstr ""
+
+#: src/error/option_unwrap.md:3
+msgid ""
+"In the last example, we showed that we can induce program failure at will. "
+"We told our program to `panic` if we drink a sugary lemonade. But what if we "
+"expect _some_ drink but don't receive one? That case would be just as bad, "
+"so it needs to be handled!"
+msgstr ""
+"以前の例では、甘いレモネードを飲んだ際に`panic`を呼び出すことによって、"
+"自由にプログラムの実行を失敗させられることが分かりました。"
+"では、何らかの飲み物を期待しているにもかかわらず、何も受け取らなかったらどうなるでしょう？"
+"これは悲惨なケースになるので、エラーハンドリングする必要があります！"
+
+#: src/error/option_unwrap.md:8
+msgid ""
+"We _could_ test this against the null string (`\"\"`) as we do with a "
+"lemonade. Since we're using Rust, let's instead have the compiler point out "
+"cases where there's no drink."
+msgstr ""
+"このケースに対して、レモネードと同じように、空文字列（`\"\"`）と比較することもできますが、"
+"せっかくRustを使っているので、その代わりにコンパイラに飲み物がないケースを指摘させてみましょう。"
+
+#: src/error/option_unwrap.md:12
+msgid ""
+"An `enum` called `Option<T>` in the `std` library is used when absence is a "
+"possibility. It manifests itself as one of two \"options\":"
+msgstr ""
+"`std`ライブラリの中の、`Option<T>`と呼ばれる`enum`は、"
+"任意の型`T`である変数の値が存在しない可能性がある場合に用いられます。"
+"値の状態によって、下記２つのパターンのうちの１つとして扱われます。"
+
+#: src/error/option_unwrap.md:15
+msgid "`Some(T)`: An element of type `T` was found"
+msgstr "`Some(T)`：型`T`の値がある場合"
+
+#: src/error/option_unwrap.md:16
+msgid "`None`: No element was found"
+msgstr "`None`：値が存在しない場合"
+
+#: src/error/option_unwrap.md:18
+msgid ""
+"These cases can either be explicitly handled via `match` or implicitly with "
+"`unwrap`. Implicit handling will either return the inner element or `panic`."
+msgstr ""
+"これらは`match`を用いて明示的に扱うこともできますし、"
+"`unwrap`で暗黙に処理することもできます。"
+"後者は`Some`の中の値を返すか`panic`するかのどちらかです。"
+
+#: src/error/option_unwrap.md:21
+msgid ""
+"Note that it's possible to manually customize `panic` with [expect](https://"
+"doc.rust-lang.org/std/option/enum.Option.html#method.expect), but `unwrap` "
+"otherwise leaves us with a less meaningful output than explicit handling. In "
+"the following example, explicit handling yields a more controlled result "
+"while retaining the option to `panic` if desired."
+msgstr ""
+"[expect](https://doc.rust-lang.org/std/option/enum.Option.html#method.expect)メソッドを用いて、"
+"`panic`を手動でカスタマイズできることに触れておきましょう。"
+"これは（`unwrap`をそのまま用いた場合よりも）内容が理解しやすいエラーメッセージを出力するのに役立ちます。"
+"次の例では、結果をより明示的に、可能ならいつでも`panic`できるように扱っていきます。"
+
+#: src/error/option_unwrap.md:27
+msgid ""
+"// The adult has seen it all, and can handle any drink well.\n"
+"// All drinks are handled explicitly using `match`.\n"
+msgstr ""
+"// 大人は経験豊富なので、大体どんな飲み物にも対処できます。\n"
+"// あらゆる飲み物は`match`を用いて手動で処理されます。\n"
+
+#: src/error/option_unwrap.md:30
+msgid "// Specify a course of action for each case.\n"
+msgstr ""
+
+#: src/error/option_unwrap.md:32
+msgid "\"Yuck! Too sugary.\""
+msgstr "\"Yuck! Too sugary.\""
+
+#: src/error/option_unwrap.md:33
+msgid "\"{}? How nice.\""
+msgstr "\"{}? How nice.\""
+
+#: src/error/option_unwrap.md:34
+msgid "\"No drink? Oh well.\""
+msgstr "\"No drink? Oh well.\""
+
+#: src/error/option_unwrap.md:37
+msgid ""
+"// Others will `panic` before drinking sugary drinks.\n"
+"// All drinks are handled implicitly using `unwrap`.\n"
+msgstr ""
+"// 他の人たちは甘い飲み物を飲む前に`panic`します。\n"
+"// 全ての飲み物は`unwrap`を使って暗黙的に処理されます。\n"
+
+#: src/error/option_unwrap.md:41
+msgid "// `unwrap` returns a `panic` when it receives a `None`.\n"
+msgstr "// `unwrap`を使用すると値が`None`だった際に`panic`を返します。\n"
+
+#: src/error/option_unwrap.md:45
+msgid "\"I love {}s!!!!!\""
+msgstr "\"I love {}s!!!!!\""
+
+#: src/error/option_unwrap.md:57
+msgid "\"coffee\""
+msgstr "\"coffee\""
+
+#: src/error/option_unwrap/question_mark.md:3
+msgid ""
+"You can unpack `Option`s by using `match` statements, but it's often easier "
+"to use the `?` operator. If `x` is an `Option`, then evaluating `x?` will "
+"return the underlying value if `x` is `Some`, otherwise it will terminate "
+"whatever function is being executed and return `None`."
+msgstr ""
+"`Option`をアンパックするには`match`文を使うこともできますが、`?`を使う方が簡単になることが多いでしょう。"
+"`Option`の`x`があるとすると、`x?`を評価した値は、`x`が`Some`の場合は`x`に格納された値となり、"
+"そうでなければ実行中の関数を終了させ、`None`を返します。"
+
+#: src/error/option_unwrap/question_mark.md:10
+msgid ""
+"// If `current_age` is `None`, this returns `None`.\n"
+"\t// If `current_age` is `Some`, the inner `u8` value + 1\n"
+"    // gets assigned to `next_age`\n"
+msgstr ""
+"// `current_age`が`None`の場合、`None`を返します。\n"
+"    // `current_age`が`Some`の場合、内部の`u8`型の値が`next_age`に代入されます。\n"
+
+#: src/error/option_unwrap/question_mark.md:14
+msgid "\"Next year I will be {}\""
+msgstr "\"Next year I will be {}\""
+
+#: src/error/option_unwrap/question_mark.md:18
+msgid "You can chain many `?`s together to make your code much more readable."
+msgstr "多くの`?`を共に使うことで、リーダブルなコードを書くことができます。"
+
+#: src/error/option_unwrap/question_mark.md:38
+msgid ""
+"// Gets the area code of the phone number of the person's job, if it "
+"exists.\n"
+msgstr "// その人の市外局番が存在する場合、取得します。\n"
+
+#: src/error/option_unwrap/question_mark.md:40
+msgid ""
+"// This would need many nested `match` statements without the `?` operator.\n"
+"        // It would take a lot more code - try writing it yourself and see "
+"which\n"
+"        // is easier.\n"
+msgstr ""
+"// `?`がなければ、多くのネストされた`match`文を必要とするため、\n"
+"        // より長いコードとなります。\n"
+"        // 実際に書いて、どちらの方が簡単か確かめてみましょう。\n"
+
+#: src/error/option_unwrap/map.md:3
+msgid ""
+"`match` is a valid method for handling `Option`s. However, you may  "
+"eventually find heavy usage tedious, especially with operations only valid  "
+"with an input. In these cases, [combinators](https://doc.rust-lang.org/"
+"reference/glossary.html#combinator) can be used to  manage control flow in a "
+"modular fashion."
+msgstr ""
+"`match`は`Option`を扱うのに適したメソッドです。"
+"しかし、大量にこれを使用しているとじきに億劫になってくるでしょう。"
+"引数の値が有効である（訳注: この場合は`None`でない）必要がある関数を扱う際には特にそうです。"
+"そうした場合には、[コンビネータ](https://doc.rust-lang.org/reference/glossary.html#combinator)"
+"を使うと、処理の流れをモジュール化されたやり方で管理できます。"
+
+#: src/error/option_unwrap/map.md:8
+msgid ""
+"`Option` has a built in method called `map()`, a combinator for the simple  "
+"mapping of `Some -> Some` and `None -> None`. Multiple `map()` calls can be  "
+"chained together for even more flexibility."
+msgstr ""
+"`Some -> Some`あるいは`None -> None`の単純な操作を適用する必要がある場合には、"
+"`Option`は`map()`というビルトインのメソッドを提供していますので、これを使用しましょう。"
+"`map()`のフレキシビリティは、複数の`map()`をチェインしなければならない場合にさらに際立ちます。"
+
+#: src/error/option_unwrap/map.md:12
+msgid ""
+"In the following example, `process()` replaces all functions previous to it "
+"while staying compact."
+msgstr ""
+"以下の例では、`process()`が直前の関数全てを用いた場合と同じ機能を、"
+"よりコンパクトに果たしているのがわかります。"
+
+#: src/error/option_unwrap/map.md:23
+msgid ""
+"// Peeling food. If there isn't any, then return `None`.\n"
+"// Otherwise, return the peeled food.\n"
+msgstr ""
+"// 食べ物の皮をむく。存在しない場合は単純に`None`を返します。\n"
+"// そうでなければ皮を向いた食べ物を返します。\n"
+
+#: src/error/option_unwrap/map.md:32
+msgid ""
+"// Chopping food. If there isn't any, then return `None`.\n"
+"// Otherwise, return the chopped food.\n"
+msgstr "// 上と同じように、食べ物を切る前に、皮を向いた食べ物の有無を知る必要があります。\n"
+
+#: src/error/option_unwrap/map.md:41
+msgid ""
+"// Cooking food. Here, we showcase `map()` instead of `match` for case "
+"handling.\n"
+msgstr "// 上のチェックと同様ですが`match`の代わりに`map()`を使用しています。\n"
+
+#: src/error/option_unwrap/map.md:46
+msgid ""
+"// A function to peel, chop, and cook food all in sequence.\n"
+"// We chain multiple uses of `map()` to simplify the code.\n"
+msgstr "// 複数の`map()`をチェインさせて、上のプロセスをシンプルにすることもできます。\n"
+
+#: src/error/option_unwrap/map.md:54
+msgid "// Check whether there's food or not before trying to eat it!\n"
+msgstr "// 食べる前に、食べ物の有無をチェックするのは大事ですよね!\n"
+
+#: src/error/option_unwrap/map.md:58
+msgid "\"Mmm. I love {:?}\""
+msgstr "\"Mmm. I love {:?}\""
+
+#: src/error/option_unwrap/map.md:59
+msgid "\"Oh no! It wasn't edible.\""
+msgstr "\"Oh no! It wasn't edible.\""
+
+#: src/error/option_unwrap/map.md:70
+msgid "// Let's try the simpler looking `process()` now.\n"
+msgstr "// よりシンプルな見た目の`process()`を使用しましょう。\n"
+
+#: src/error/option_unwrap/map.md:81
+msgid ""
+"[closures](../../fn/closures.md), [`Option`](https://doc.rust-lang.org/std/"
+"option/enum.Option.html), [`Option::map()`](https://doc.rust-lang.org/std/"
+"option/enum.Option.html#method.map)"
+msgstr ""
+"[クロージャ](../../fn/closures.md), [`Option`](https://doc.rust-lang.org/std/"
+"option/enum.Option.html), [`Option::map()`](https://doc.rust-lang.org/std/"
+"option/enum.Option.html#method.map)"
+
+#: src/error/option_unwrap/and_then.md:3
+msgid ""
+"`map()` was described as a chainable way to simplify `match` statements.  "
+"However, using `map()` on a function that returns an `Option<T>` results  in "
+"the nested `Option<Option<T>>`. Chaining multiple calls together can  then "
+"become confusing. That's where another combinator called `and_then()`,  "
+"known in some languages as flatmap, comes in."
+msgstr ""
+"先ほどは`map()`を、チェイン構文を用いて`match`文を単純化する物として説明しました。"
+"しかし`Option<T>`を返す関数に対しての`map()`の使用はネストした`Option<Option<T>>`を生じさせます。"
+"ですので、複数の関数呼び出しをチェインさせることは混乱を招く場合があります。"
+"そんな時こそ`and_then()`の出番です。他の言語ではflatmapと呼ばれることもあります。"
+
+#: src/error/option_unwrap/and_then.md:9
+msgid ""
+"`and_then()` calls its function input with the wrapped value and returns the "
+"result. If the `Option` is `None`, then it returns `None` instead."
+msgstr ""
+"`and_then()`は引数として与えられた関数にラップされた値を渡しますが、"
+"その値が`None`だった場合は`None`を返します。"
+
+#: src/error/option_unwrap/and_then.md:11
+msgid ""
+"In the following example, `cookable_v3()` results in an `Option<Food>`.  "
+"Using `map()` instead of `and_then()` would have given an  "
+"`Option<Option<Food>>`, which is an invalid type for `eat()`."
+msgstr ""
+"以下の例では`cookable_v3()`は`Option<Food>`を返すため、"
+"`and_then()`ではなく`map()`を使用すると最終的に`Option<Option<Food>>`になります。"
+"これは`eat()`には不適切な型です。"
+
+#: src/error/option_unwrap/and_then.md:20
+msgid "// We don't have the ingredients to make Sushi.\n"
+msgstr "// 我々は寿司の材料を持っていません。\n"
+
+#: src/error/option_unwrap/and_then.md:28
+msgid "// We have the recipe for everything except Cordon Bleu.\n"
+msgstr "// コルドン・ブルーのレシピも持っていません。\n"
+
+#: src/error/option_unwrap/and_then.md:36
+msgid ""
+"// To make a dish, we need both the recipe and the ingredients.\n"
+"// We can represent the logic with a chain of `match`es:\n"
+msgstr ""
+"// 料理を作るためには、材料とレシピの両方が必要。\n"
+"// ロジックの流れを`match`のチェインで表します。\n"
+
+#: src/error/option_unwrap/and_then.md:45
+msgid ""
+"// This can conveniently be rewritten more compactly with `and_then()`:\n"
+msgstr "// `and_then()`を用いることで、同じことをよりコンパクトに表現できます。\n"
+
+#: src/error/option_unwrap/and_then.md:50
+msgid ""
+"// Otherwise we'd need to `flatten()` an `Option<Option<Food>>`\n"
+"// to get an `Option<Food>`:\n"
+msgstr ""
+
+#: src/error/option_unwrap/and_then.md:59
+msgid "\"Yay! On {:?} we get to eat {:?}.\""
+msgstr "\"Yay! On {:?} we get to eat {:?}.\""
+
+#: src/error/option_unwrap/and_then.md:60
+msgid "\"Oh no. We don't get to eat on {:?}?\""
+msgstr "\"Oh no. We don't get to eat on {:?}?\""
+
+#: src/error/option_unwrap/and_then.md:75
+msgid ""
+"[closures](../../fn/closures.md), [`Option`](https://doc.rust-lang.org/std/"
+"option/enum.Option.html), [`Option::and_then()`](https://doc.rust-lang.org/"
+"std/option/enum.Option.html#method.and_then), and [`Option::flatten()`]"
+"(https://doc.rust-lang.org/std/option/enum.Option.html#method.flatten)"
+msgstr ""
+"[クロージャ](../../fn/closures.md), [`Option`](https://doc.rust-lang.org/std/"
+"option/enum.Option.html), [`Option::and_then()`](https://doc.rust-lang.org/"
+"std/option/enum.Option.html#method.and_then), [`Option::flatten()`]"
+"(https://doc.rust-lang.org/std/option/enum.Option.html#method.flatten)"
+
+#: src/error/option_unwrap/defaults.md:1
+msgid "Unpacking options and defaults"
+msgstr ""
+
+#: src/error/option_unwrap/defaults.md:3
+msgid ""
+"There is more than one way to unpack an `Option` and fall back on a default "
+"if it is `None`. To choose the one that meets our needs, we need to consider "
+"the following:"
+msgstr ""
+
+#: src/error/option_unwrap/defaults.md:4
+msgid "do we need eager or lazy evaluation?"
+msgstr ""
+
+#: src/error/option_unwrap/defaults.md:5
+msgid ""
+"do we need to keep the original empty value intact, or modify it in place?"
+msgstr ""
+
+#: src/error/option_unwrap/defaults.md:7
+msgid "`or()` is chainable, evaluates eagerly, keeps empty value intact"
+msgstr ""
+
+#: src/error/option_unwrap/defaults.md:9
+msgid ""
+"`or()`is chainable and eagerly evaluates its argument, as is shown in the "
+"following example. Note that because `or`'s arguments are evaluated eagerly, "
+"the variable passed to `or` is moved."
+msgstr ""
+
+#: src/error/option_unwrap/defaults.md:21
+#: src/error/option_unwrap/defaults.md:54
+msgid "\"first_available_fruit: {:?}\""
+msgstr "\"first_available_fruit: {:?}\""
+
+#: src/error/option_unwrap/defaults.md:22
+msgid "// first_available_fruit: Some(Orange)\n"
+msgstr ""
+
+#: src/error/option_unwrap/defaults.md:24
+msgid ""
+"// `or` moves its argument.\n"
+"    // In the example above, `or(orange)` returned a `Some`, so `or(apple)` "
+"was not invoked.\n"
+"    // But the variable named `apple` has been moved regardless, and cannot "
+"be used anymore.\n"
+"    // println!(\"Variable apple was moved, so this line won't compile: "
+"{:?}\", apple);\n"
+"    // TODO: uncomment the line above to see the compiler error\n"
+msgstr ""
+
+#: src/error/option_unwrap/defaults.md:32
+msgid "`or_else()` is chainable, evaluates lazily, keeps empty value intact"
+msgstr ""
+
+#: src/error/option_unwrap/defaults.md:34
+msgid ""
+"Another alternative is to use `or_else`, which is also chainable, and "
+"evaluates lazily, as is shown in the following example:"
+msgstr ""
+
+#: src/error/option_unwrap/defaults.md:43
+msgid "\"Providing kiwi as fallback\""
+msgstr "\"Providing kiwi as fallback\""
+
+#: src/error/option_unwrap/defaults.md:47
+#: src/error/option_unwrap/defaults.md:91
+msgid "\"Providing lemon as fallback\""
+msgstr "\"Providing lemon as fallback\""
+
+#: src/error/option_unwrap/defaults.md:55
+msgid ""
+"// Providing kiwi as fallback\n"
+"    // first_available_fruit: Some(Kiwi)\n"
+msgstr ""
+
+#: src/error/option_unwrap/defaults.md:60
+msgid "`get_or_insert()` evaluates eagerly, modifies empty value in place"
+msgstr ""
+
+#: src/error/option_unwrap/defaults.md:62
+msgid ""
+"To make sure that an `Option` contains a value, we can use `get_or_insert` "
+"to modify it in place with a fallback value, as is shown in the following "
+"example. Note that `get_or_insert` eagerly evaluates its parameter, so "
+"variable `apple` is moved:"
+msgstr ""
+
+#: src/error/option_unwrap/defaults.md:72
+#: src/error/option_unwrap/defaults.md:96
+msgid "\"first_available_fruit is: {:?}\""
+msgstr "\"first_available_fruit is: {:?}\""
+
+#: src/error/option_unwrap/defaults.md:73
+#: src/error/option_unwrap/defaults.md:97
+msgid "\"my_fruit is: {:?}\""
+msgstr "\"my_fruit is: {:?}\""
+
+#: src/error/option_unwrap/defaults.md:74
+msgid ""
+"// first_available_fruit is: Apple\n"
+"    // my_fruit is: Some(Apple)\n"
+"    //println!(\"Variable named `apple` is moved: {:?}\", apple);\n"
+"    // TODO: uncomment the line above to see the compiler error\n"
+msgstr ""
+
+#: src/error/option_unwrap/defaults.md:81
+msgid "`get_or_insert_with()` evaluates lazily, modifies empty value in place"
+msgstr ""
+
+#: src/error/option_unwrap/defaults.md:83
+msgid ""
+"Instead of explicitly providing a value to fall back on, we can pass a "
+"closure to `get_or_insert_with`, as follows:"
+msgstr ""
+
+#: src/error/option_unwrap/defaults.md:98
+msgid ""
+"// Providing lemon as fallback\n"
+"    // first_available_fruit is: Lemon\n"
+"    // my_fruit is: Some(Lemon)\n"
+msgstr ""
+
+#: src/error/option_unwrap/defaults.md:102
+msgid ""
+"// If the Option has a value, it is left unchanged, and the closure is not "
+"invoked\n"
+msgstr ""
+
+#: src/error/option_unwrap/defaults.md:105
+msgid "\"should_be_apple is: {:?}\""
+msgstr "\"should_be_apple is: {:?}\""
+
+#: src/error/option_unwrap/defaults.md:106
+msgid "\"my_apple is unchanged: {:?}\""
+msgstr "\"my_apple is unchanged: {:?}\""
+
+#: src/error/option_unwrap/defaults.md:107
+msgid ""
+"// The output is a follows. Note that the closure `get_lemon_as_fallback` is "
+"not invoked\n"
+"    // should_be_apple is: Apple\n"
+"    // my_apple is unchanged: Some(Apple)\n"
+msgstr ""
+
+#: src/error/option_unwrap/defaults.md:115
+msgid ""
+"[`closures`](https://doc.rust-lang.org/book/ch13-01-closures.html), "
+"[`get_or_insert`](https://doc.rust-lang.org/core/option/enum.Option."
+"html#method.get_or_insert), [`get_or_insert_with`](https://doc.rust-lang.org/"
+"core/option/enum.Option.html#method.get_or_insert_with), [`moved variables`]"
+"(https://doc.rust-lang.org/book/ch04-02-references-and-borrowing.html), "
+"[`or`](https://doc.rust-lang.org/core/option/enum.Option.html#method.or), "
+"[`or_else`](https://doc.rust-lang.org/core/option/enum.Option.html#method."
+"or_else)"
+msgstr ""
+
+#: src/error/result.md:3
+msgid ""
+"[`Result`](https://doc.rust-lang.org/std/result/enum.Result.html) is a "
+"richer version of the [`Option`](https://doc.rust-lang.org/std/option/enum."
+"Option.html) type that describes possible _error_ instead of possible "
+"_absence_."
+msgstr ""
+"[`Result`](https://doc.rust-lang.org/std/result/enum.Result.html)は、"
+"リッチなバージョンの[`Option`](https://doc.rust-lang.org/std/option/enum.Option.html)型で"
+"*値の不在*の可能性の代わりに*エラー*の可能性を示します。"
+
+#: src/error/result.md:6
+msgid "That is, `Result<T, E>` could have one of two outcomes:"
+msgstr "つまり、`Result<T, E>`は以下の２つの結果を持ちます。"
+
+#: src/error/result.md:8
+msgid "`Ok(T)`: An element `T` was found"
+msgstr "`Ok<T>`：要素`T`が見つかった場合"
+
+#: src/error/result.md:9
+msgid "`Err(E)`: An error was found with element `E`"
+msgstr "`Err<E>`：要素`E`とともにエラーが見つかった場合"
+
+#: src/error/result.md:11
+msgid ""
+"By convention, the expected outcome is `Ok` while the unexpected outcome is "
+"`Err`."
+msgstr "慣例により、`Ok`が期待される結果であり、`Err`は期待されない結果です。"
+
+#: src/error/result.md:13
+msgid ""
+"Like `Option`, `Result` has many methods associated with it. `unwrap()`, for "
+"example, either yields the element `T` or `panic`s. For case handling, there "
+"are many combinators between `Result` and `Option` that overlap."
+msgstr ""
+"`Option`と同様、`Result`は多くのメソッドを持ちます。"
+"例えば`unwrap()`は、`T`もしくは`panic`をもたらします。"
+"エラーハンドリングでは、`Result`と`Option`で重複するコンビネータが多くあります。"
+
+#: src/error/result.md:17
+msgid ""
+"In working with Rust, you will likely encounter methods that return the "
+"`Result` type, such as the [`parse()`](https://doc.rust-lang.org/std/"
+"primitive.str.html#method.parse) method. It might not always be possible to "
+"parse a string into the other type, so `parse()` returns a `Result` "
+"indicating possible failure."
+msgstr ""
+"Rustを書いていく中で、[`parse()`](https://doc.rust-lang.org/std/primitive.str.html#method.parse)メソッドなど、"
+"`Result`型を返すメソッドを目にするでしょう。"
+"文字列を他の型にパースすることは必ずしも成功する訳ではないため、"
+"`Result`を返すことで失敗するケースについてもカバーできるのです。"
+
+#: src/error/result.md:22
+msgid ""
+"Let's see what happens when we successfully and unsuccessfully `parse()` a "
+"string:"
+msgstr "早速、文字列を`parse()`した場合の成功例と失敗例を見てみましょう。"
+
+#: src/error/result.md:26
+msgid "// Let's try using `unwrap()` to get the number out. Will it bite us?\n"
+msgstr "// `unwrap()`で数字を取り出してみましょう。痛い目を見るでしょうか？\n"
+
+#: src/error/result.md:33 src/error/result.md:36
+#: src/error/result/result_map.md:42 src/error/result/result_map.md:46
+#: src/error/result/result_map.md:75 src/error/result/result_map.md:79
+#: src/error/result/result_alias.md:36 src/error/result/result_alias.md:37
+#: src/error/result/early_returns.md:36 src/error/result/early_returns.md:37
+#: src/error/result/enter_question_mark.md:34
+#: src/error/result/enter_question_mark.md:35
+#: src/error/result/enter_question_mark.md:67
+#: src/error/result/enter_question_mark.md:68
+msgid "\"2\""
+msgstr "\"2\""
+
+#: src/error/result.md:34 src/error/result.md:37
+msgid "\"double is {}\""
+msgstr "\"double is {}\""
+
+#: src/error/result.md:36 src/error/result/result_map.md:46
+#: src/error/result/result_map.md:79 src/error/result/result_alias.md:37
+#: src/error/result/early_returns.md:37
+#: src/error/result/enter_question_mark.md:35
+#: src/error/result/enter_question_mark.md:68
+msgid "\"t\""
+msgstr "\"t\""
+
+#: src/error/result.md:41
+msgid ""
+"In the unsuccessful case, `parse()` leaves us with an error for `unwrap()` "
+"to `panic` on. Additionally, the `panic` exits our program and provides an "
+"unpleasant error message."
+msgstr ""
+"失敗例では、`parse()`がエラーを返すため`unwrap()`がパニックします。"
+"そして、`panic`はプログラムを終了させて不快なエラーメッセージを出力します。"
+
+#: src/error/result.md:45
+msgid ""
+"To improve the quality of our error message, we should be more specific "
+"about the return type and consider explicitly handling the error."
+msgstr ""
+"エラーメッセージを改善するために、リターン型に対してもっと明確になるべきで、"
+"またエラーを明示的に処理することを考えるべきです。"
+
+#: src/error/result.md:48
+msgid "Using `Result` in `main`"
+msgstr "`main`内で使う`Result`"
+
+#: src/error/result.md:50
+msgid ""
+"The `Result` type can also be the return type of the `main` function if "
+"specified explicitly. Typically the `main` function will be of the form:"
+msgstr ""
+"`Result`型は、明示的な指定により`main`関数のリターン型にもなります。"
+"一般に、`main`関数は以下のような形になるでしょう。"
+
+#: src/error/result.md:59
+msgid ""
+"However `main` is also able to have a return type of `Result`. If an error "
+"occurs within the `main` function it will return an error code and print a "
+"debug representation of the error (using the [`Debug`](https://doc.rust-lang."
+"org/std/fmt/trait.Debug.html) trait). The following example shows such a "
+"scenario and touches on aspects covered in [the following section](result/"
+"early_returns.md)."
+msgstr ""
+"一方`main`で`Result`をリターン型とすることも可能です。"
+"エラーが`main`関数内で発生した時、エラーコードを返し、エラーに関するデバッグ表記を"
+"（[`Debug`](https://doc.rust-lang.org/std/fmt/trait.Debug.html)トレイトを使って）"
+"出力します。以下の例ではそのようなシナリオを示し、[この先の節](result/early_returns.md)"
+"でカバーする内容に触れていきます。"
+
+#: src/error/result/result_map.md:3
+msgid ""
+"Panicking in the previous example's `multiply` does not make for robust "
+"code. Generally, we want to return the error to the caller so it can decide "
+"what is the right way to respond to errors."
+msgstr ""
+"前の例で見た`multiply`でのパニックは、コードを強固にするためには書きません。"
+"一般に、呼び出した側がエラーをどのように対処するべきかを自由に決められるように、"
+"エラーを呼び出した場所に返すのが好ましいです。"
+
+#: src/error/result/result_map.md:7
+msgid ""
+"We first need to know what kind of error type we are dealing with. To "
+"determine the `Err` type, we look to [`parse()`](https://doc.rust-lang.org/"
+"std/primitive.str.html#method.parse), which is implemented with the "
+"[`FromStr`](https://doc.rust-lang.org/std/str/trait.FromStr.html) trait for "
+"[`i32`](https://doc.rust-lang.org/std/primitive.i32.html). As a result, the "
+"`Err` type is specified as [`ParseIntError`](https://doc.rust-lang.org/std/"
+"num/struct.ParseIntError.html)."
+msgstr ""
+"まずは、どのようなエラー型を扱っているのかを知る必要があります。"
+"`Err`型を定めるために、[`i32`](https://doc.rust-lang.org/std/primitive.i32.html)"
+"に対し[`FromStr`](https://doc.rust-lang.org/std/str/trait.FromStr.html)トレイトを使って実装された"
+"[`parse()`](https://doc.rust-lang.org/std/primitive.str.html#method.parse)を見てみましょう。"
+"結果、`Err`型は[`ParseIntError`](https://doc.rust-lang.org/std/num/struct.ParseIntError.html)"
+"というものであることが分かります。"
+
+#: src/error/result/result_map.md:12
+msgid ""
+"In the example below, the straightforward `match` statement leads to code "
+"that is overall more cumbersome."
+msgstr "以下の例では、単純な`match`文が全体として扱いづらいコードにしています。"
+
+#: src/error/result/result_map.md:17
+msgid ""
+"// With the return type rewritten, we use pattern matching without "
+"`unwrap()`.\n"
+msgstr "// リターン型を再度記述することで、パターンマッチングを`unwrap()`なしで行います。\n"
+
+#: src/error/result/result_map.md:35 src/error/result/result_map.md:68
+#: src/error/result/result_alias.md:30 src/error/result/early_returns.md:30
+#: src/error/result/enter_question_mark.md:28
+#: src/error/result/enter_question_mark.md:61
+msgid "\"n is {}\""
+msgstr "\"n is {}\""
+
+#: src/error/result/result_map.md:36 src/error/result/result_map.md:69
+#: src/error/result/result_alias.md:31 src/error/result/early_returns.md:31
+#: src/error/result/enter_question_mark.md:29
+#: src/error/result/enter_question_mark.md:62
+#: src/error/multiple_error_types/define_error_type.md:55
+#: src/error/multiple_error_types/boxing_errors.md:42
+#: src/error/multiple_error_types/reenter_question_mark.md:54
+#: src/error/multiple_error_types/wrap_error.md:68
+msgid "\"Error: {}\""
+msgstr "\"Error: {}\""
+
+#: src/error/result/result_map.md:41 src/error/result/result_map.md:74
+msgid "// This still presents a reasonable answer.\n"
+msgstr "// ここは以前と変わらず、妥当な解を与えます。\n"
+
+#: src/error/result/result_map.md:45 src/error/result/result_map.md:78
+msgid "// The following now provides a much more helpful error message.\n"
+msgstr "// こちらは今度は有益なエラーメッセージを与えます。\n"
+
+#: src/error/result/result_map.md:51
+msgid ""
+"Luckily, `Option`'s `map`, `and_then`, and many other combinators are also "
+"implemented for `Result`. [`Result`](https://doc.rust-lang.org/std/result/"
+"enum.Result.html) contains a complete listing."
+msgstr ""
+"幸運にも、`Option`の`map`、`and_then`、その他多くのコンビネータも`Result`のために実装されています。"
+"[`Result`](https://doc.rust-lang.org/std/result/enum.Result.html)に全てのリストが記載されています。"
+
+#: src/error/result/result_map.md:56
+msgid ""
+"// As with `Option`, we can use combinators such as `map()`.\n"
+"// This function is otherwise identical to the one above and reads:\n"
+"// Multiply if both values can be parsed from str, otherwise pass on the "
+"error.\n"
+msgstr ""
+"// `Option`と同様、`map()`などのコンビネータを使うことができます。\n"
+"// この関数は`map()`を使っている点以外は上記の関数と同じで、\n"
+"// 両方の値がstrからパース可能であればそれらを乗算し、無効であればエラーをそのまま見送ります。\n"
+
+#: src/error/result/result_alias.md:3
+msgid ""
+"How about when we want to reuse a specific `Result` type many times? Recall "
+"that Rust allows us to create [aliases](../../types/alias.md). Conveniently, "
+"we can define one for the specific `Result` in question."
+msgstr ""
+"特定の`Result`型を何度も使いたくなるのはどんな時でしょう？"
+"Rustは[エイリアス](../../types/alias.md)の作成をサポートしていたことを思い出してください。"
+"便利なことに、特定の`Result`型に対しても定義することができます。"
+
+#: src/error/result/result_alias.md:7
+msgid ""
+"At a module level, creating aliases can be particularly helpful. Errors "
+"found in a specific module often have the same `Err` type, so a single alias "
+"can succinctly define _all_ associated `Results`. This is so useful that the "
+"`std` library even supplies one: [`io::Result`](https://doc.rust-lang.org/"
+"std/io/type.Result.html)!"
+msgstr ""
+"モジュールレベルでは、エイリアスの作成は非常に役に立ちます。"
+"特定のモジュールで見られるエラーは同じ`Err`型を持つため、"
+"単一のエイリアスで簡潔に`Results`に関わる*全て*を定義できます。"
+"`std`ライブラリが提供するもの（[`io::Result`](https://doc.rust-lang.org/std/io/type.Result.html)）もあるほど有益なのです！"
+
+#: src/error/result/result_alias.md:12
+msgid "Here's a quick example to show off the syntax:"
+msgstr "簡単な例で構文を見てみましょう。"
+
+#: src/error/result/result_alias.md:16
+msgid ""
+"// Define a generic alias for a `Result` with the error type "
+"`ParseIntError`.\n"
+msgstr "// `ParseIntError`を`Err`の型として持つ全ての`Result`のジェネリックエイリアス\n"
+
+#: src/error/result/result_alias.md:19
+msgid "// Use the above alias to refer to our specific `Result` type.\n"
+msgstr "// 上で定義したエイリアス（この場所特有の`Result`型）を使用。\n"
+
+#: src/error/result/result_alias.md:26
+msgid "// Here, the alias again allows us to save some space.\n"
+msgstr "// もう一度使用。エイリアスによって再度明記する必要性がありません。\n"
+
+#: src/error/result/result_alias.md:43
+msgid "[`io::Result`](https://doc.rust-lang.org/std/io/type.Result.html)"
+msgstr "[`io::Result`](https://doc.rust-lang.org/std/io/type.Result.html)"
+
+#: src/error/result/early_returns.md:3
+msgid ""
+"In the previous example, we explicitly handled the errors using combinators. "
+"Another way to deal with this case analysis is to use a combination of "
+"`match` statements and _early returns_."
+msgstr ""
+"前の例では、コンビネータの活用によりエラーを明示的に処理しました。"
+"場合分けに対する別の対処法として、`match`文と早期リターンを組み合わせて使うこともできます。"
+
+#: src/error/result/early_returns.md:7
+msgid ""
+"That is, we can simply stop executing the function and return the error if "
+"one occurs. For some, this form of code can be easier to both read and "
+"write. Consider this version of the previous example, rewritten using early "
+"returns:"
+msgstr ""
+"つまり、エラーが発生した時点で関数の実行を止め、エラーを返してしまうという単純な方法が使えるということです。"
+"この方法の方がより読みやすく書きやすい場合があります。"
+"早期リターンを使って実装された、前の例の新たなバージョンを考えてみましょう。"
+
+#: src/error/result/early_returns.md:41
+msgid ""
+"At this point, we've learned to explicitly handle errors using combinators "
+"and early returns. While we generally want to avoid panicking, explicitly "
+"handling all of our errors is cumbersome."
+msgstr ""
+"ここまでで、コンビネータと早期リターンによる明示的なエラーハンドリングについて学びました。"
+"しかし、パニックは一般に避けたいですが、全てのエラーを明示的に処理するのも厄介でしょう。"
+
+#: src/error/result/early_returns.md:45
+msgid ""
+"In the next section, we'll introduce `?` for the cases where we simply need "
+"to `unwrap` without possibly inducing `panic`."
+msgstr ""
+"次の節では、`panic`を発生させずに`unwrap`する必要があるケースのための`?`について紹介していきます。"
+
+#: src/error/result/enter_question_mark.md:3
+msgid ""
+"Sometimes we just want the simplicity of `unwrap` without the possibility of "
+"a `panic`. Until now, `unwrap` has forced us to nest deeper and deeper when "
+"what we really wanted was to get the variable _out_. This is exactly the "
+"purpose of `?`."
+msgstr ""
+"時には`panic`の可能性を無視して、`unwrap`のシンプルさを活用したいこともあるでしょう。"
+"今までの`unwrap`は、値を*取り出す*ためだけであろうとも、ネストを深く書くことを要求しました。"
+"そして、これがまさに`?`の目的です。"
+
+#: src/error/result/enter_question_mark.md:7
+msgid "Upon finding an `Err`, there are two valid actions to take:"
+msgstr "`Err`を見つけるにあたり、２つのとるべき行動があります。"
+
+#: src/error/result/enter_question_mark.md:9
+msgid "`panic!` which we already decided to try to avoid if possible"
+msgstr "可能な限り避けたいと決めた`panic!`"
+
+#: src/error/result/enter_question_mark.md:10
+msgid "`return` because an `Err` means it cannot be handled"
+msgstr "`Err`は処理できないことを意味するため`return`"
+
+#: src/error/result/enter_question_mark.md:12
+msgid ""
+"`?` is _almost_[^†] exactly equivalent to an `unwrap` which `return`s "
+"instead of `panic`king on `Err`s. Let's see how we can simplify the earlier "
+"example that used combinators:"
+msgstr ""
+"`?`は*ほぼ*[^†]まさしく、`Err`に対して`panic`するより`return`するという点で`unwrap`と同等です。"
+"コンビネータを使った以前の例をどれだけ簡潔に書けるか見てみましょう。"
+
+#: src/error/result/enter_question_mark.md:39
+msgid "The `try!` macro"
+msgstr "`try!`マクロ"
+
+#: src/error/result/enter_question_mark.md:41
+msgid ""
+"Before there was `?`, the same functionality was achieved with the `try!` "
+"macro. The `?` operator is now recommended, but you may still find `try!` "
+"when looking at older code. The same `multiply` function from the previous "
+"example would look like this using `try!`:"
+msgstr ""
+"`?`ができる前、同様の動作を`try!`マクロによって行うことができました。"
+"現在は`?`演算子が推奨されていますが、古いコードでは`try!`に出会うこともあります。"
+"`try!`を使って前の例と同じ`multiply`関数を実装すると、以下のようになるでしょう。"
+
+#: src/error/result/enter_question_mark.md:47
+msgid ""
+"// To compile and run this example without errors, while using Cargo, change "
+"the value \n"
+"// of the `edition` field, in the `[package]` section of the `Cargo.toml` "
+"file, to \"2015\".\n"
+msgstr ""
+"// Cargoを使いながらこの例をエラーなくコンパイル、及び実行する場合、\n"
+"// `Cargo.toml`ファイル内、`[package]`セクションの`edition`の値を\"2015\"に変更してください。\n"
+
+#: src/error/result/enter_question_mark.md:73
+msgid ""
+"See [re-enter ?](../multiple_error_types/reenter_question_mark.md) for more "
+"details."
+msgstr "詳細は[re-enter ?](../multiple_error_types/reenter_question_mark.md)を参照。"
+
+#: src/error/multiple_error_types.md:3
+msgid ""
+"The previous examples have always been very convenient; `Result`s interact "
+"with other `Result`s and `Option`s interact with other `Option`s."
+msgstr ""
+"`Result`が他の`Result`と連携したり、`Option`が他の`Option`と連携するなど、"
+"今までの例はとても便利な物でした。"
+
+#: src/error/multiple_error_types.md:6
+msgid ""
+"Sometimes an `Option` needs to interact with a `Result`, or a `Result<T, "
+"Error1>` needs to interact with a `Result<T, Error2>`. In those cases, we "
+"want to manage our different error types in a way that makes them composable "
+"and easy to interact with."
+msgstr ""
+"時には`Option`が`Result`と連携したり、`Result<T, Error1>`が`Result<T, Error2>`と連携する必要もあるでしょう。"
+"そのような場面では、異なるエラー型を構成しやすく、かつ連携しやすく管理したいです。"
+
+#: src/error/multiple_error_types.md:11
+msgid ""
+"In the following code, two instances of `unwrap` generate different error "
+"types. `Vec::first` returns an `Option`, while `parse::<i32>` returns a "
+"`Result<i32, ParseIntError>`:"
+msgstr ""
+"以下のコードは`unwrap`の２つのインスタンスが異なるエラー型を生成します。"
+"`Vec::first`は`Option`を返し、一方で`parse::<i32>`は`Result<i32, ParseIntError>`を返しています。"
+
+#: src/error/multiple_error_types.md:17
+msgid "// Generate error 1\n"
+msgstr "// エラー１の生成\n"
+
+#: src/error/multiple_error_types.md:18
+msgid "// Generate error 2\n"
+msgstr "// エラー２の生成\n"
+
+#: src/error/multiple_error_types.md:22
+#: src/error/multiple_error_types/option_result.md:16
+#: src/error/multiple_error_types/option_result.md:46
+#: src/error/multiple_error_types/define_error_type.md:60
+#: src/error/multiple_error_types/boxing_errors.md:47
+#: src/error/multiple_error_types/reenter_question_mark.md:59
+#: src/error/multiple_error_types/wrap_error.md:77 src/error/iter_result.md:40
+msgid "\"42\""
+msgstr "\"42\""
+
+#: src/error/multiple_error_types.md:22 src/error/multiple_error_types.md:24
+#: src/error/multiple_error_types/option_result.md:16
+#: src/error/multiple_error_types/option_result.md:18
+#: src/error/multiple_error_types/option_result.md:46
+#: src/error/multiple_error_types/option_result.md:48
+#: src/error/multiple_error_types/define_error_type.md:60
+#: src/error/multiple_error_types/define_error_type.md:62
+#: src/error/multiple_error_types/boxing_errors.md:47
+#: src/error/multiple_error_types/boxing_errors.md:49
+#: src/error/multiple_error_types/reenter_question_mark.md:59
+#: src/error/multiple_error_types/reenter_question_mark.md:61
+#: src/error/multiple_error_types/wrap_error.md:77
+#: src/error/multiple_error_types/wrap_error.md:79 src/error/iter_result.md:7
+#: src/error/iter_result.md:24 src/error/iter_result.md:40
+#: src/error/iter_result.md:60 src/error/iter_result.md:75
+#: src/error/iter_result.md:90
+msgid "\"93\""
+msgstr "\"93\""
+
+#: src/error/multiple_error_types.md:22 src/error/multiple_error_types.md:24
+#: src/error/multiple_error_types/option_result.md:16
+#: src/error/multiple_error_types/option_result.md:18
+#: src/error/multiple_error_types/option_result.md:46
+#: src/error/multiple_error_types/option_result.md:48
+#: src/error/multiple_error_types/define_error_type.md:60
+#: src/error/multiple_error_types/define_error_type.md:62
+#: src/error/multiple_error_types/boxing_errors.md:47
+#: src/error/multiple_error_types/boxing_errors.md:49
+#: src/error/multiple_error_types/reenter_question_mark.md:59
+#: src/error/multiple_error_types/reenter_question_mark.md:61
+#: src/error/multiple_error_types/wrap_error.md:77
+#: src/error/multiple_error_types/wrap_error.md:79 src/error/iter_result.md:7
+#: src/error/iter_result.md:24 src/error/iter_result.md:40
+#: src/error/iter_result.md:60 src/error/iter_result.md:75
+#: src/error/iter_result.md:90
+msgid "\"18\""
+msgstr "\"18\""
+
+#: src/error/multiple_error_types.md:24
+#: src/error/multiple_error_types/option_result.md:18
+#: src/error/multiple_error_types/option_result.md:48
+#: src/error/multiple_error_types/define_error_type.md:62
+#: src/error/multiple_error_types/boxing_errors.md:49
+#: src/error/multiple_error_types/reenter_question_mark.md:61
+#: src/error/multiple_error_types/wrap_error.md:79 src/error/iter_result.md:7
+#: src/error/iter_result.md:24 src/error/iter_result.md:40
+#: src/error/iter_result.md:60 src/error/iter_result.md:75
+#: src/error/iter_result.md:90
+msgid "\"tofu\""
+msgstr "\"tofu\""
+
+#: src/error/multiple_error_types.md:26 src/error/multiple_error_types.md:28
+#: src/error/multiple_error_types.md:31
+#: src/error/multiple_error_types/define_error_type.md:54
+#: src/error/multiple_error_types/boxing_errors.md:41
+#: src/error/multiple_error_types/reenter_question_mark.md:53
+#: src/error/multiple_error_types/wrap_error.md:66
+msgid "\"The first doubled is {}\""
+msgstr "\"The first doubled is {}\""
+
+#: src/error/multiple_error_types.md:29
+#: src/error/multiple_error_types/option_result.md:23
+msgid "// Error 1: the input vector is empty\n"
+msgstr "// エラー１：入力が空ベクタ\n"
+
+#: src/error/multiple_error_types.md:32
+#: src/error/multiple_error_types/option_result.md:26
+msgid "// Error 2: the element doesn't parse to a number\n"
+msgstr "// エラー２：要素が数字としてパースできない。\n"
+
+#: src/error/multiple_error_types.md:36
+msgid ""
+"Over the next sections, we'll see several strategies for handling these kind "
+"of problems."
+msgstr "この先の節では、これらの問題を処理する方法について見ていきます。"
+
+#: src/error/multiple_error_types/option_result.md:3
+msgid ""
+"The most basic way of handling mixed error types is to just embed them in "
+"each other."
+msgstr "混在するエラー型に対する最も基本的な対処法は、単にお互いを埋め込んでしまうことです。"
+
+#: src/error/multiple_error_types/option_result.md:20
+#: src/error/multiple_error_types/option_result.md:22
+#: src/error/multiple_error_types/option_result.md:25
+#: src/error/multiple_error_types/option_result.md:50
+#: src/error/multiple_error_types/option_result.md:51
+#: src/error/multiple_error_types/option_result.md:52
+msgid "\"The first doubled is {:?}\""
+msgstr "\"The first doubled is {:?}\""
+
+#: src/error/multiple_error_types/option_result.md:30
+msgid ""
+"There are times when we'll want to stop processing on errors (like with [`?`]"
+"(../result/enter_question_mark.md)) but keep going when the `Option` is "
+"`None`. A couple of combinators come in handy to swap the `Result` and "
+"`Option`."
+msgstr ""
+"中には、`Option`の中身が`None`の場合はそのまま処理を進め、"
+"エラーの検出に限り実行を止めたいという場合もあるでしょう"
+"（[`?`](../result/enter_question_mark.md)を使った時のように）。"
+"いくつかのコンビネータによって簡単に`Result`と`Option`をスワップすることができます。"
+
+#: src/error/multiple_error_types/define_error_type.md:3
+msgid ""
+"Sometimes it simplifies the code to mask all of the different errors with a "
+"single type of error.  We'll show this with a custom error."
+msgstr ""
+"異なるエラー型をマスクし単一のエラー型として扱えるようにすると、"
+"コードがシンプルになる場合があります。ここでは自前のエラー型でそれを示してみます。"
+
+#: src/error/multiple_error_types/define_error_type.md:6
+msgid ""
+"Rust allows us to define our own error types. In general, a \"good\" error "
+"type:"
+msgstr "Rustはユーザーによる新たなエラー型の定義をサポートします。一般に「良い」エラー型は、"
+
+#: src/error/multiple_error_types/define_error_type.md:8
+msgid "Represents different errors with the same type"
+msgstr "異なるエラーをまとめて同じ型として扱う。"
+
+#: src/error/multiple_error_types/define_error_type.md:9
+msgid "Presents nice error messages to the user"
+msgstr "ユーザーに優しいエラーメッセージを提供する。"
+
+#: src/error/multiple_error_types/define_error_type.md:10
+msgid "Is easy to compare with other types"
+msgstr "他の型との比較を楽にする。"
+
+#: src/error/multiple_error_types/define_error_type.md:11
+msgid "Good: `Err(EmptyVec)`"
+msgstr "良い例：`Err(EmptyVec)`"
+
+#: src/error/multiple_error_types/define_error_type.md:12
+msgid ""
+"Bad: `Err(\"Please use a vector with at least one element\".to_owned())`"
+msgstr "悪い例：`Err(\"Please use a vector with at least one element\".to_owned())`"
+
+#: src/error/multiple_error_types/define_error_type.md:13
+msgid "Can hold information about the error"
+msgstr "エラーについての情報を保持できる。"
+
+#: src/error/multiple_error_types/define_error_type.md:14
+msgid "Good: `Err(BadChar(c, position))`"
+msgstr "良い例：`Err(BadChar(c, position))`"
+
+#: src/error/multiple_error_types/define_error_type.md:15
+msgid "Bad: `Err(\"+ cannot be used here\".to_owned())`"
+msgstr "悪い例：`Err(\"+ cannot be used here\".to_owned())`"
+
+#: src/error/multiple_error_types/define_error_type.md:16
+msgid "Composes well with other errors"
+msgstr "他のエラーと問題なく連携できる。"
+
+#: src/error/multiple_error_types/define_error_type.md:22
+msgid ""
+"// Define our error types. These may be customized for our error handling "
+"cases.\n"
+"// Now we will be able to write our own errors, defer to an underlying "
+"error\n"
+"// implementation, or do something in between.\n"
+msgstr ""
+"// 自前のエラー型の定義。エラーハンドリングのケースの応じてカスタマイズできます。\n"
+"// ここで新たなエラーを書くことができ、元のエラーの実装に処理を委譲したり、\n"
+"// その手前で何らかの処理を挟むことができます。\n"
+
+#: src/error/multiple_error_types/define_error_type.md:28
+msgid ""
+"// Generation of an error is completely separate from how it is displayed.\n"
+"// There's no need to be concerned about cluttering complex logic with the "
+"display style.\n"
+"//\n"
+"// Note that we don't store any extra info about the errors. This means we "
+"can't state\n"
+"// which string failed to parse without modifying our types to carry that "
+"information.\n"
+msgstr ""
+"// エラーの生成は、それがどのように表示されるかとは別物です。\n"
+"// そのため、エラーの表示スタイルに関する複雑なロジックを煩雑になる\n"
+"// などと気にする必要はありません。\n"
+"//\n"
+"// エラーに関する余分な情報を持たせていないことに注意してください。\n"
+"// どの文字列がパースに失敗したかなどを出力することは、\n"
+"// その情報を保持させるようにエラーの定義を修正しない限りできません。\n"
+
+#: src/error/multiple_error_types/define_error_type.md:36
+#: src/error/multiple_error_types/boxing_errors.md:23
+#: src/error/multiple_error_types/reenter_question_mark.md:37
+msgid "\"invalid first item to double\""
+msgstr "\"invalid first item to double\""
+
+#: src/error/multiple_error_types/define_error_type.md:42
+msgid "// Change the error to our new type.\n"
+msgstr "// エラーを新たな型に変更します。\n"
+
+#: src/error/multiple_error_types/define_error_type.md:46
+msgid "// Update to the new error type here also.\n"
+msgstr "// ここでも新たなエラー型に更新します。\n"
+
+#: src/error/multiple_error_types/boxing_errors.md:3
+msgid ""
+"A way to write simple code while preserving the original errors is to [`Box`]"
+"(https://doc.rust-lang.org/std/boxed/struct.Box.html) them.  The drawback is "
+"that the underlying error type is only known at runtime and not [statically "
+"determined](https://doc.rust-lang.org/book/ch17-02-trait-objects.html#trait-"
+"objects-perform-dynamic-dispatch)."
+msgstr ""
+"元のエラーを維持しながらシンプルなコードを書くには、"
+"[`Box`](https://doc.rust-lang.org/std/boxed/struct.Box.html)してしまうと良いでしょう。"
+"欠点として、元のエラー型はランタイムまで判明せず、"
+"[静的に決定](https://doc.rust-lang.org/book/ch17-02-trait-objects.html#trait-objects-perform-dynamic-dispatch)"
+"されないことが挙げられます。"
+
+#: src/error/multiple_error_types/boxing_errors.md:7
+msgid ""
+"The stdlib helps in boxing our errors by having `Box` implement conversion "
+"from any type that implements the `Error` trait into the trait object "
+"`Box<Error>`, via [`From`](https://doc.rust-lang.org/std/convert/trait.From."
+"html)."
+msgstr ""
+"標準ライブラリは`Box`に、[`From`](https://doc.rust-lang.org/std/convert/trait.From.html)"
+"を介してあらゆる`Error`トレイトを実装した型から`Box<Error>`トレイトオブジェクトへの変換を実装させることで、"
+"エラーをboxしやすくしてくれます。"
+
+#: src/error/multiple_error_types/boxing_errors.md:14
+#: src/error/multiple_error_types/reenter_question_mark.md:28
+msgid "// Change the alias to use `Box<dyn error::Error>`.\n"
+msgstr "// エイリアスを`Box<error::Error>`に変更します。\n"
+
+#: src/error/multiple_error_types/boxing_errors.md:31
+#: src/error/multiple_error_types/boxing_errors.md:34
+msgid "// Converts to Box\n"
+msgstr "// Boxに変換。\n"
+
+#: src/error/multiple_error_types/boxing_errors.md:59
+msgid ""
+"[Dynamic dispatch](https://doc.rust-lang.org/book/ch17-02-trait-objects."
+"html#trait-objects-perform-dynamic-dispatch) and [`Error` trait](https://doc."
+"rust-lang.org/std/error/trait.Error.html)"
+msgstr ""
+"[動的ディスパッチ](https://doc.rust-lang.org/book/ch17-02-trait-objects."
+"html#trait-objects-perform-dynamic-dispatch), [`Error` トレイト](https://doc."
+"rust-lang.org/std/error/trait.Error.html)"
+
+#: src/error/multiple_error_types/reenter_question_mark.md:3
+msgid ""
+"Notice in the previous example that our immediate reaction to calling "
+"`parse` is to `map` the error from a library error into a boxed error:"
+msgstr ""
+"以前の例では`parse`の呼び出しに対するその場での対応として、"
+"エラーをライブラリのエラーからboxされたエラーへと`map`していました。"
+
+#: src/error/multiple_error_types/reenter_question_mark.md:12
+msgid ""
+"Since this is a simple and common operation, it would be convenient if it "
+"could be elided. Alas, because `and_then` is not sufficiently flexible, it "
+"cannot. However, we can instead use `?`."
+msgstr ""
+"簡単でよくあるオペレーションのため、可能なら省略してしまえると便利だったでしょう。"
+"でも残念、`and_then`が十分にフレキシブルでないため、それはできません。ただその代わり、`?`なら使えます。"
+
+#: src/error/multiple_error_types/reenter_question_mark.md:16
+msgid ""
+"`?` was previously explained as either `unwrap` or `return Err(err)`. This "
+"is only mostly true. It actually means `unwrap` or `return Err(From::"
+"from(err))`. Since `From::from` is a conversion utility between different "
+"types, this means that if you `?` where the error is convertible to the "
+"return type, it will convert automatically."
+msgstr ""
+"`?`の挙動は、`unwrap`または`return Err(err)`として説明されていました。"
+"これはほぼ正解で、本当は`unwrap`、もしくは`return Err(From::from(err))`という意味があります。"
+"`From::from`は異なる型の間での変換ユーティリティであることから、"
+"エラーがリターン型に変換可能な場合に`?`を使うことで、その変換を自動的に行ってくれます。"
+
+#: src/error/multiple_error_types/reenter_question_mark.md:22
+msgid ""
+"Here, we rewrite the previous example using `?`. As a result, the `map_err` "
+"will go away when `From::from` is implemented for our error type:"
+msgstr ""
+"前の例を`?`を使ったものに書き換えてみましょう。"
+"その結果、`From::from`がエラー型に実装されている時`map_err`は消えてなくなります。"
+
+#: src/error/multiple_error_types/reenter_question_mark.md:42
+msgid ""
+"// The same structure as before but rather than chain all `Results`\n"
+"// and `Options` along, we `?` to get the inner value out immediately.\n"
+msgstr ""
+"// 前と同じ構造ですが、`Results`と`Option`を繋げていく代わりに、\n"
+"// `?`で内部の値をその場で取得します。\n"
+
+#: src/error/multiple_error_types/reenter_question_mark.md:69
+msgid ""
+"This is actually fairly clean now. Compared with the original `panic`, it is "
+"very similar to replacing the `unwrap` calls with `?` except that the return "
+"types are `Result`. As a result, they must be destructured at the top level."
+msgstr ""
+"これでかなり綺麗になりました。"
+"元の`panic`と比べ、リターン型が`Result`であることを除けば、"
+"`unwrap`の呼び出しを`?`で置き換えたものに非常に似ています。"
+"結果、その`Result`は上のレベルで分解されなければなりません。"
+
+#: src/error/multiple_error_types/reenter_question_mark.md:76
+msgid ""
+"[`From::from`](https://doc.rust-lang.org/std/convert/trait.From.html) and [`?"
+"`](https://doc.rust-lang.org/reference/expressions/operator-expr.html#the-"
+"question-mark-operator)"
+msgstr ""
+"[`From::from`](https://doc.rust-lang.org/std/convert/trait.From.html), [`?"
+"`](https://doc.rust-lang.org/reference/expressions/operator-expr.html#the-"
+"question-mark-operator)"
+
+#: src/error/multiple_error_types/wrap_error.md:3
+msgid "An alternative to boxing errors is to wrap them in your own error type."
+msgstr "Boxする方法の代替として、エラーを自前のエラー型としてラップする方法もあります。"
+
+#: src/error/multiple_error_types/wrap_error.md:16
+msgid ""
+"// We will defer to the parse error implementation for their error.\n"
+"    // Supplying extra info requires adding more data to the type.\n"
+msgstr ""
+"// パースエラーの実装まで処理を委譲します。\n"
+"    // 追加の情報を提供するには、型により多くのデータを追加する必要があります。\n"
+
+#: src/error/multiple_error_types/wrap_error.md:25
+msgid "\"please use a vector with at least one element\""
+msgstr "\"please use a vector with at least one element\""
+
+#: src/error/multiple_error_types/wrap_error.md:26
+msgid ""
+"// The wrapped error contains additional information and is available\n"
+"            // via the source() method.\n"
+msgstr ""
+"// ラップされたエラーは追加情報を含み、\n"
+"            // source メソッドから取り出すことができます。\n"
+
+#: src/error/multiple_error_types/wrap_error.md:29
+msgid "\"the provided string could not be parsed as int\""
+msgstr "\"the provided string could not be parsed as int\""
+
+#: src/error/multiple_error_types/wrap_error.md:38
+msgid ""
+"// The cause is the underlying implementation error type. Is implicitly\n"
+"            // cast to the trait object `&error::Error`. This works because "
+"the\n"
+"            // underlying type already implements the `Error` trait.\n"
+msgstr ""
+"// 元の実装のエラー型が原因。\n"
+"            // `&error::Error`トレイトオブジェクトに暗にキャストされます。\n"
+"            // 元となる型が`Error`トレイトをすでに実装しているため問題ありません。\n"
+
+#: src/error/multiple_error_types/wrap_error.md:45
+msgid ""
+"// Implement the conversion from `ParseIntError` to `DoubleError`.\n"
+"// This will be automatically called by `?` if a `ParseIntError`\n"
+"// needs to be converted into a `DoubleError`.\n"
+msgstr ""
+"// `ParseIntError`から`DoubleError`への変換の実装。\n"
+"// `ParseIntError`が`DoubleError`に変換される必要がある時、\n"
+"// 自動的に`?`から呼び出されます。\n"
+
+#: src/error/multiple_error_types/wrap_error.md:57
+msgid ""
+"// Here we implicitly use the `ParseIntError` implementation of `From` "
+"(which\n"
+"    // we defined above) in order to create a `DoubleError`.\n"
+msgstr ""
+
+#: src/error/multiple_error_types/wrap_error.md:70
+msgid "\"  Caused by: {}\""
+msgstr "\"  Caused by: {}\""
+
+#: src/error/multiple_error_types/wrap_error.md:87
+msgid ""
+"This adds a bit more boilerplate for handling errors and might not be needed "
+"in all applications. There are some libraries that can take care of the "
+"boilerplate for you."
+msgstr ""
+"これはエラーの処理のボイラープレートを増やしてしまい、"
+"全てのアプリケーションで必要になる訳では無いでしょう。"
+"これらのボイラープレートの処理を代わりにやってくれるようなライブラリもあります。"
+
+#: src/error/multiple_error_types/wrap_error.md:93
+msgid ""
+"[`From::from`](https://doc.rust-lang.org/std/convert/trait.From.html) and "
+"[`Enums`](../../custom_types/enum.md)"
+msgstr ""
+"[`From::from`](https://doc.rust-lang.org/std/convert/trait.From.html), "
+"[列挙型](../../custom_types/enum.md)"
+
+#: src/error/iter_result.md:3
+msgid "An `Iter::map` operation might fail, for example:"
+msgstr "`Iter::map`オペレーションは失敗することもあります。例えば、"
+
+#: src/error/iter_result.md:12 src/error/iter_result.md:29
+#: src/error/iter_result.md:65
+msgid "\"Results: {:?}\""
+msgstr "\"Results: {:?}\""
+
+#: src/error/iter_result.md:16
+msgid "Let's step through strategies for handling this."
+msgstr "ここでは、この対処法についてみてみましょう。"
+
+#: src/error/iter_result.md:18
+msgid "Ignore the failed items with `filter_map()`"
+msgstr "`filter_map()`を使って失敗した要素のみを無視する"
+
+#: src/error/iter_result.md:20
+msgid ""
+"`filter_map` calls a function and filters out the results that are `None`."
+msgstr "`filter_map`は関数を呼び出し、結果が`None`になるものだけ取り除きます。"
+
+#: src/error/iter_result.md:33
+msgid "Collect the failed items with `map_err()` and `filter_map()`"
+msgstr ""
+
+#: src/error/iter_result.md:35
+msgid ""
+"`map_err` calls a function with the error, so by adding that to the previous "
+"`filter_map` solution we can save them off to the side while iterating."
+msgstr ""
+
+#: src/error/iter_result.md:40
+msgid "\"999\""
+msgstr "\"999\""
+
+#: src/error/iter_result.md:47 src/error/iter_result.md:80
+#: src/error/iter_result.md:97
+msgid "\"Numbers: {:?}\""
+msgstr "\"Numbers: {:?}\""
+
+#: src/error/iter_result.md:48 src/error/iter_result.md:81
+#: src/error/iter_result.md:98
+msgid "\"Errors: {:?}\""
+msgstr "\"Errors: {:?}\""
+
+#: src/error/iter_result.md:52
+msgid "Fail the entire operation with `collect()`"
+msgstr "`collect()`で処理全体を失敗させる"
+
+#: src/error/iter_result.md:54
+msgid ""
+"`Result` implements `FromIterator` so that a vector of results "
+"(`Vec<Result<T, E>>`) can be turned into a result with a vector "
+"(`Result<Vec<T>, E>`). Once an `Result::Err` is found, the iteration will "
+"terminate."
+msgstr ""
+"`Result`は、それらのベクタ(`Vec<Result<T, E>>`)からベクタのそれ(`Result<Vec<T>, E>`)へと変換できるようにするため、"
+"`FromIterator`を実装します。`Result::Err`が見つかり次第、イテレーションは終了します。"
+
+#: src/error/iter_result.md:69
+msgid "This same technique can be used with `Option`."
+msgstr "同じテクニックは、`Option`を用いて行うこともできます。"
+
+#: src/error/iter_result.md:71
+msgid "Collect all valid values and failures with `partition()`"
+msgstr "`partition()`を使って全ての正常な値と失敗をまとめる"
+
+#: src/error/iter_result.md:85
+msgid ""
+"When you look at the results, you'll note that everything is still wrapped "
+"in `Result`.  A little more boilerplate is needed for this."
+msgstr ""
+"結果を見てみると、まだ全て`Result`にラップされていることに気づくでしょう。"
+"もう少しのボイラープレートが必要です。"
+
+#: src/std.md:3
+msgid ""
+"The `std` library provides many custom types which expands drastically on "
+"the `primitives`. Some of these include:"
+msgstr "`std`ライブラリは、基本データ型を劇的に拡張するカスタム型を数多く提供します。例えば以下です。"
+
+#: src/std.md:6
+msgid "growable `String`s like: `\"hello world\"`"
+msgstr "拡張可能な文字列である`String`。例えば：`\"hello world\"`"
+
+#: src/std.md:7
+msgid "growable vectors: `[1, 2, 3]`"
+msgstr ""
+
+#: src/std.md:8
+msgid "optional types: `Option<i32>`"
+msgstr "オプション型：`Option<i32>`"
+
+#: src/std.md:9
+msgid "error handling types: `Result<i32, i32>`"
+msgstr "エラーハンドリング用の`Result<i32, i32>`"
+
+#: src/std.md:10
+msgid "heap allocated pointers: `Box<i32>`"
+msgstr "ヒープ上の資源へのポインタ：`Box<i32>`"
+
+#: src/std.md:14 src/std_misc.md:14
+msgid ""
+"[primitives](primitives.md) and [the std library](https://doc.rust-lang.org/"
+"std/)"
+msgstr ""
+"[基本データ型](primitives.md), [`std` ライブラリ](https://doc.rust-lang.org/"
+"std/)"
+
+#: src/std/box.md:3
+msgid ""
+"All values in Rust are stack allocated by default. Values can be _boxed_ "
+"(allocated on the heap) by creating a `Box<T>`. A box is a smart pointer to "
+"a heap allocated value of type `T`. When a box goes out of scope, its "
+"destructor is called, the inner object is destroyed, and the memory on the "
+"heap is freed."
+msgstr ""
+"Rustにおいて、すべての値はデフォルトでスタックに割り当てられます。"
+"`Box<T>`を作成することで、値を *ボックス化* 、すなわちヒープ上に割り当てることができます。"
+"ボックスとは正確にはヒープ上におかれた`T`の値へのスマートポインタです。"
+"ボックスがスコープを抜けると、デストラクタが呼ばれて内包するオブジェクトが破棄され、ヒープメモリが解放されます。"
+
+#: src/std/box.md:8
+msgid ""
+"Boxed values can be dereferenced using the `*` operator; this removes one "
+"layer of indirection. "
+msgstr ""
+"ボックス化された値は`*`演算子を用いてデリファレンスすることができます。"
+"これにより一段と直接的な操作が可能になります。"
+
+#: src/std/box.md:20
+msgid ""
+"// A Rectangle can be specified by where its top left and bottom right \n"
+"// corners are in space\n"
+msgstr "// 長方形は左上の角と右下の角がどこにあるかによって特定できます。\n"
+
+#: src/std/box.md:34
+msgid "// Allocate this point on the heap, and return a pointer to it\n"
+msgstr "// このPointをヒープ上に割り当て、ポインタを返します。\n"
+
+#: src/std/box.md:39
+msgid ""
+"// (all the type annotations are superfluous)\n"
+"    // Stack allocated variables\n"
+msgstr ""
+"// （以下では型を全て明示していますが、必須ではありません。）\n"
+"    // この変数ははすべてスタック上に割り当てられます。\n"
+
+#: src/std/box.md:47
+msgid "// Heap allocated rectangle\n"
+msgstr "// ヒープ上に割り当てられたRectangle\n"
+
+#: src/std/box.md:53
+msgid "// The output of functions can be boxed\n"
+msgstr "// 関数の返り値をボックス化。\n"
+
+#: src/std/box.md:56
+msgid "// Double indirection\n"
+msgstr "// 間にもう一つポインタを挟みます。\n"
+
+#: src/std/box.md:59
+msgid "\"Point occupies {} bytes on the stack\""
+msgstr "\"Point occupies {} bytes on the stack\""
+
+#: src/std/box.md:61
+msgid "\"Rectangle occupies {} bytes on the stack\""
+msgstr "\"Rectangle occupies {} bytes on the stack\""
+
+#: src/std/box.md:64
+msgid "// box size == pointer size\n"
+msgstr "// ボックスのサイズはポインタのサイズに等しい。\n"
+
+#: src/std/box.md:65
+msgid "\"Boxed point occupies {} bytes on the stack\""
+msgstr "\"Boxed point occupies {} bytes on the stack\""
+
+#: src/std/box.md:67
+msgid "\"Boxed rectangle occupies {} bytes on the stack\""
+msgstr "\"Boxed rectangle occupies {} bytes on the stack\""
+
+#: src/std/box.md:69
+msgid "\"Boxed box occupies {} bytes on the stack\""
+msgstr "\"Boxed box occupies {} bytes on the stack\""
+
+#: src/std/box.md:72
+msgid "// Copy the data contained in `boxed_point` into `unboxed_point`\n"
+msgstr "// `boxed_point`の保持するデータを`unboxed_point`にコピーします。\n"
+
+#: src/std/box.md:74
+msgid "\"Unboxed point occupies {} bytes on the stack\""
+msgstr "\"Unboxed point occupies {} bytes on the stack\""
+
+#: src/std/vec.md:3
+msgid ""
+"Vectors are re-sizable arrays. Like slices, their size is not known at "
+"compile time, but they can grow or shrink at any time. A vector is "
+"represented using 3 parameters: "
+msgstr ""
+"「ベクタ」はサイズを変更可能な配列です。スライスと同様、そのサイズはコンパイル時には不定ですが、"
+"いつでも要素を追加したり削除したりすることができます。"
+"ベクタは3つの要素で、その特徴が完全に決まります。"
+
+#: src/std/vec.md:6
+msgid "pointer to the data"
+msgstr "データへのポインタ"
+
+#: src/std/vec.md:7
+msgid "length"
+msgstr "長さ"
+
+#: src/std/vec.md:8
+msgid "capacity "
+msgstr "容量"
+
+#: src/std/vec.md:10
+msgid ""
+"The capacity indicates how much memory is reserved for the vector. The "
+"vector  can grow as long as the length is smaller than the capacity. When "
+"this threshold  needs to be surpassed, the vector is reallocated with a "
+"larger capacity."
+msgstr ""
+"ベクタはその容量を超えない限りにおいて長くしていくことができます。"
+"超えた場合には、より大きな容量を持つように割り当てなおされます。"
+
+#: src/std/vec.md:16
+msgid "// Iterators can be collected into vectors\n"
+msgstr "// イテレータは要素を収集してベクタにすることができます。\n"
+
+#: src/std/vec.md:18
+msgid "\"Collected (0..10) into: {:?}\""
+msgstr "\"Collected (0..10) into: {:?}\""
+
+#: src/std/vec.md:20
+msgid "// The `vec!` macro can be used to initialize a vector\n"
+msgstr "// ベクタの初期化には`vec!`マクロが使用できます。\n"
+
+#: src/std/vec.md:22
+msgid "\"Initial vector: {:?}\""
+msgstr "\"Initial vector: {:?}\""
+
+#: src/std/vec.md:24
+msgid "// Insert new element at the end of the vector\n"
+msgstr "// 新しい要素をベクタの最後に挿入することができます。\n"
+
+#: src/std/vec.md:25
+msgid "\"Push 4 into the vector\""
+msgstr "\"Push 4 into the vector\""
+
+#: src/std/vec.md:27
+msgid "\"Vector: {:?}\""
+msgstr "\"Vector: {:?}\""
+
+#: src/std/vec.md:29
+msgid "// Error! Immutable vectors can't grow\n"
+msgstr "// エラー！イミュータブルなベクタは成長できません\n"
+
+#: src/std/vec.md:33
+msgid ""
+"// The `len` method yields the number of elements currently stored in a "
+"vector\n"
+msgstr "// `len`メソッドは現在のベクタのサイズを返します。\n"
+
+#: src/std/vec.md:34
+msgid "\"Vector length: {}\""
+msgstr "\"Vector length: {}\""
+
+#: src/std/vec.md:36
+msgid "// Indexing is done using the square brackets (indexing starts at 0)\n"
+msgstr ""
+"// 鍵括弧を用いてインデックスによる要素へのアクセスができます。\n"
+"    // （インデックスは0から開始する）\n"
+
+#: src/std/vec.md:37
+msgid "\"Second element: {}\""
+msgstr "\"Second element: {}\""
+
+#: src/std/vec.md:39
+msgid "// `pop` removes the last element from the vector and returns it\n"
+msgstr "// `pop`はベクタの最後の要素を削除すると同時に返します。\n"
+
+#: src/std/vec.md:40
+msgid "\"Pop last element: {:?}\""
+msgstr "\"Pop last element: {:?}\""
+
+#: src/std/vec.md:42
+msgid "// Out of bounds indexing yields a panic\n"
+msgstr "// 不正なインデックスアクセスはpanicを引き起こします。\n"
+
+#: src/std/vec.md:43
+msgid "\"Fourth element: {}\""
+msgstr "\"Fourth element: {}\""
+
+#: src/std/vec.md:46
+msgid "// `Vector`s can be easily iterated over\n"
+msgstr "// `Vector`は簡単にイテレートできます。\n"
+
+#: src/std/vec.md:47
+msgid "\"Contents of xs:\""
+msgstr "\"Contents of xs:\""
+
+#: src/std/vec.md:52
+msgid ""
+"// A `Vector` can also be iterated over while the iteration\n"
+"    // count is enumerated in a separate variable (`i`)\n"
+msgstr ""
+"// `Vector`をイテレートしながら、\n"
+"    // イテレーションの回数を別の変数（`i`）に列挙することもできます。\n"
+
+#: src/std/vec.md:55
+msgid "\"In position {} we have value {}\""
+msgstr "\"In position {} we have value {}\""
+
+#: src/std/vec.md:58
+msgid ""
+"// Thanks to `iter_mut`, mutable `Vector`s can also be iterated\n"
+"    // over in a way that allows modifying each value\n"
+msgstr ""
+"// `iter_mut`を使うと、ミュータブルな`Vector`をイテレートし、\n"
+"    // それぞれの値を修正することができます。\n"
+
+#: src/std/vec.md:63
+msgid "\"Updated vector: {:?}\""
+msgstr "\"Updated vector: {:?}\""
+
+#: src/std/vec.md:67
+msgid ""
+"More `Vec` methods can be found under the [std::vec](https://doc.rust-lang."
+"org/std/vec/) module"
+msgstr ""
+"`Vec`型のメソッドの一覧は[std::vec](https://doc.rust-lang.org/std/vec/)"
+"モジュールを見てください。"
+
+#: src/std/str.md:3
+msgid "There are two types of strings in Rust: `String` and `&str`."
+msgstr "Rustには文字列を扱う型が2つあります。`String`と`&str`です。"
+
+#: src/std/str.md:5
+msgid ""
+"A `String` is stored as a vector of bytes (`Vec<u8>`), but guaranteed to "
+"always be a valid UTF-8 sequence. `String` is heap allocated, growable and "
+"not null terminated."
+msgstr ""
+"`String`は有効なUTF-8の配列であることを保証されたバイトのベクタ(`Vec<u8>`)として保持されます。"
+"ヒープ上に保持され、伸長可能で、末端にnull文字を含みません。"
+
+#: src/std/str.md:9
+msgid ""
+"`&str` is a slice (`&[u8]`) that always points to a valid UTF-8 sequence, "
+"and can be used to view into a `String`, just like `&[T]` is a view into "
+"`Vec<T>`."
+msgstr ""
+"`&str`は有効なUTF-8の配列のスライス（`&[u8]`）で、いつでも`String`に変換することができます。"
+"`&[T]`がいつでも`Vec<T>`に変換できるのと同様です。"
+
+#: src/std/str.md:14
+msgid ""
+"// (all the type annotations are superfluous)\n"
+"    // A reference to a string allocated in read only memory\n"
+msgstr ""
+"// （以下の例では型を明示していますが、これらは必須ではありません。）\n"
+"    // read only memory上に割り当てられた文字列への参照\n"
+
+#: src/std/str.md:16
+msgid "\"the quick brown fox jumps over the lazy dog\""
+msgstr "\"the quick brown fox jumps over the lazy dog\""
+
+#: src/std/str.md:17
+msgid "\"Pangram: {}\""
+msgstr "\"Pangram: {}\""
+
+#: src/std/str.md:19
+msgid "// Iterate over words in reverse, no new string is allocated\n"
+msgstr "// 単語を逆順にイテレートします。新しい文字列の割り当ては起こりません。\n"
+
+#: src/std/str.md:20
+msgid "\"Words in reverse\""
+msgstr "\"Words in reverse\""
+
+#: src/std/str.md:25
+msgid "// Copy chars into a vector, sort and remove duplicates\n"
+msgstr "// 文字をベクタにコピー。ソートして重複を除去。\n"
+
+#: src/std/str.md:30
+msgid "// Create an empty and growable `String`\n"
+msgstr "// 中身が空で、伸長可能な`String`を作成。\n"
+
+#: src/std/str.md:33
+msgid "// Insert a char at the end of string\n"
+msgstr "// 文字を文字列の末端に挿入。\n"
+
+#: src/std/str.md:35
+msgid "// Insert a string at the end of string\n"
+msgstr "// 文字列を文字列の末端に挿入。\n"
+
+#: src/std/str.md:39
+msgid ""
+"// The trimmed string is a slice to the original string, hence no new\n"
+"    // allocation is performed\n"
+msgstr ""
+"// 文字列のトリミング（特定文字種の除去）はオリジナルの文字列のスライスを\n"
+"    // 返すので、新規のメモリ割り当ては発生しません。\n"
+
+#: src/std/str.md:43
+msgid "\"Used characters: {}\""
+msgstr "\"Used characters: {}\""
+
+#: src/std/str.md:45
+msgid "// Heap allocate a string\n"
+msgstr "// 文字列をヒープに割り当てます。\n"
+
+#: src/std/str.md:46
+msgid "\"I like dogs\""
+msgstr "\"I like dogs\""
+
+#: src/std/str.md:47
+msgid "// Allocate new memory and store the modified string there\n"
+msgstr "// 新しくメモリを確保し、変更を加えた文字列をそこに割り当てます。\n"
+
+#: src/std/str.md:48
+msgid "\"dog\""
+msgstr "\"dog\""
+
+#: src/std/str.md:48
+msgid "\"cat\""
+msgstr "\"cat\""
+
+#: src/std/str.md:50
+msgid "\"Alice says: {}\""
+msgstr "\"Alice says: {}\""
+
+#: src/std/str.md:51
+msgid "\"Bob says: {}\""
+msgstr "\"Bob says: {}\""
+
+#: src/std/str.md:55
+msgid ""
+"More `str`/`String` methods can be found under the [std::str](https://doc."
+"rust-lang.org/std/str/) and [std::string](https://doc.rust-lang.org/std/"
+"string/) modules"
+msgstr ""
+"`str`/`String`のメソッドをもっと見たい場合は"
+"[std::str](https://doc.rust-lang.org/std/str/)、"
+"[std::string](https://doc.rust-lang.org/std/string/)モジュールを参照してください。"
+
+#: src/std/str.md:60
+msgid "Literals and escapes"
+msgstr ""
+
+#: src/std/str.md:62
+msgid ""
+"There are multiple ways to write string literals with special characters in "
+"them. All result in a similar `&str` so it's best to use the form that is "
+"the most convenient to write. Similarly there are multiple ways to write "
+"byte string literals, which all result in `&[u8; N]`."
+msgstr ""
+
+#: src/std/str.md:67
+msgid ""
+"Generally special characters are escaped with a backslash character: `\\`. "
+"This way you can add any character to your string, even unprintable ones and "
+"ones that you don't know how to type. If you want a literal backslash, "
+"escape it with another one: `\\\\`"
+msgstr ""
+
+#: src/std/str.md:72
+msgid ""
+"String or character literal delimiters occurring within a literal must be "
+"escaped: `\"\\\"\"`, `'\\''`."
+msgstr ""
+
+#: src/std/str.md:76
+msgid "// You can use escapes to write bytes by their hexadecimal values...\n"
+msgstr ""
+
+#: src/std/str.md:77
+msgid "\"I'm writing \\x52\\x75\\x73\\x74!\""
+msgstr "\"I'm writing \\x52\\x75\\x73\\x74!\""
+
+#: src/std/str.md:78
+msgid "\"What are you doing\\x3F (\\\\x3F means ?) {}\""
+msgstr "\"What are you doing\\x3F (\\\\x3F means ?) {}\""
+
+#: src/std/str.md:80
+msgid "// ...or Unicode code points.\n"
+msgstr ""
+
+#: src/std/str.md:81
+msgid "\"\\u{211D}\""
+msgstr "\"\\u{211D}\""
+
+#: src/std/str.md:82
+msgid "\"\\\"DOUBLE-STRUCK CAPITAL R\\\"\""
+msgstr "\"\\\"DOUBLE-STRUCK CAPITAL R\\\"\""
+
+#: src/std/str.md:84
+msgid "\"Unicode character {} (U+211D) is called {}\""
+msgstr "\"Unicode character {} (U+211D) is called {}\""
+
+#: src/std/str.md:88
+msgid ""
+"\"String literals\n"
+"                        can span multiple lines.\n"
+"                        The linebreak and indentation here ->\\\n"
+"                        <- can be escaped too!\""
+msgstr ""
+"\"String literals\n"
+"                        can span multiple lines.\n"
+"                        The linebreak and indentation here ->\\\n"
+"                        <- can be escaped too!\""
+
+#: src/std/str.md:96
+msgid ""
+"Sometimes there are just too many characters that need to be escaped or it's "
+"just much more convenient to write a string out as-is. This is where raw "
+"string literals come into play."
+msgstr ""
+
+#: src/std/str.md:101
+msgid "r\"Escapes don't work here: \\x3F \\u{211D}\""
+msgstr "r\"Escapes don't work here: \\x3F \\u{211D}\""
+
+#: src/std/str.md:104
+msgid "// If you need quotes in a raw string, add a pair of #s\n"
+msgstr ""
+
+#: src/std/str.md:105
+msgid "r#\"And then I said: \"There is no escape!\"\"#"
+msgstr "r#\"And then I said: \"There is no escape!\"\"#"
+
+#: src/std/str.md:108
+msgid ""
+"// If you need \"# in your string, just use more #s in the delimiter.\n"
+"    // You can use up to 65535 #s.\n"
+msgstr ""
+
+#: src/std/str.md:110
+msgid "r###\"A string with \"# in it. And even \"##!\"###"
+msgstr "r###\"A string with \"# in it. And even \"##!\"###"
+
+#: src/std/str.md:115
+msgid ""
+"Want a string that's not UTF-8? (Remember, `str` and `String` must be valid "
+"UTF-8). Or maybe you want an array of bytes that's mostly text? Byte strings "
+"to the rescue!"
+msgstr ""
+
+#: src/std/str.md:122
+msgid "// Note that this is not actually a `&str`\n"
+msgstr ""
+
+#: src/std/str.md:123
+msgid "b\"this is a byte string\""
+msgstr "b\"this is a byte string\""
+
+#: src/std/str.md:125
+msgid ""
+"// Byte arrays don't have the `Display` trait, so printing them is a bit "
+"limited\n"
+msgstr ""
+
+#: src/std/str.md:126
+msgid "\"A byte string: {:?}\""
+msgstr "\"A byte string: {:?}\""
+
+#: src/std/str.md:128
+msgid "// Byte strings can have byte escapes...\n"
+msgstr ""
+
+#: src/std/str.md:129
+msgid "b\"\\x52\\x75\\x73\\x74 as bytes\""
+msgstr "b\"\\x52\\x75\\x73\\x74 as bytes\""
+
+#: src/std/str.md:130
+msgid ""
+"// ...but no unicode escapes\n"
+"    // let escaped = b\"\\u{211D} is not allowed\";\n"
+msgstr ""
+
+#: src/std/str.md:132
+msgid "\"Some escaped bytes: {:?}\""
+msgstr "\"Some escaped bytes: {:?}\""
+
+#: src/std/str.md:135
+msgid "// Raw byte strings work just like raw strings\n"
+msgstr ""
+
+#: src/std/str.md:136
+msgid "br\"\\u{211D} is not escaped here\""
+msgstr "br\"\\u{211D} is not escaped here\""
+
+#: src/std/str.md:139
+msgid "// Converting a byte array to `str` can fail\n"
+msgstr ""
+
+#: src/std/str.md:141
+msgid "\"And the same as text: '{}'\""
+msgstr "\"And the same as text: '{}'\""
+
+#: src/std/str.md:144
+msgid ""
+"br#\"You can also use \"fancier\" formatting, \\\n"
+"                    like with normal raw strings\"#"
+msgstr ""
+"br#\"You can also use \"fancier\" formatting, \\\n"
+"                    like with normal raw strings\"#"
+
+#: src/std/str.md:147
+msgid "// Byte strings don't have to be UTF-8\n"
+msgstr ""
+
+#: src/std/str.md:148
+msgid "b\"\\x82\\xe6\\x82\\xa8\\x82\\xb1\\x82\\xbb\""
+msgstr "b\"\\x82\\xe6\\x82\\xa8\\x82\\xb1\\x82\\xbb\""
+
+#: src/std/str.md:148
+msgid "// \"ようこそ\" in SHIFT-JIS\n"
+msgstr ""
+
+#: src/std/str.md:150
+msgid "// But then they can't always be converted to `str`\n"
+msgstr ""
+
+#: src/std/str.md:152
+msgid "\"Conversion successful: '{}'\""
+msgstr "\"Conversion successful: '{}'\""
+
+#: src/std/str.md:153
+msgid "\"Conversion failed: {:?}\""
+msgstr "\"Conversion failed: {:?}\""
+
+#: src/std/str.md:158
+msgid ""
+"For conversions between character encodings check out the [encoding](https://"
+"crates.io/crates/encoding) crate."
+msgstr ""
+
+#: src/std/str.md:160
+msgid ""
+"A more detailed listing of the ways to write string literals and escape "
+"characters is given in the ['Tokens' chapter](https://doc.rust-lang.org/"
+"reference/tokens.html) of the Rust Reference."
+msgstr ""
+
+#: src/std/option.md:3
+msgid ""
+"Sometimes it's desirable to catch the failure of some parts of a program "
+"instead of calling `panic!`; this can be accomplished using the `Option` "
+"enum."
+msgstr ""
+"プログラムの一部が失敗した際、`panic!`するよりも、エラーを捕捉する方が望ましい場合があります。"
+"これは`Option`という列挙型を用いることで可能になります。"
+
+#: src/std/option.md:6
+msgid "The `Option<T>` enum has two variants:"
+msgstr "列挙型`Option<T>`には2つの値があります。"
+
+#: src/std/option.md:8
+msgid "`None`, to indicate failure or lack of value, and"
+msgstr "`None`、これは実行の失敗か値の欠如を示します。"
+
+#: src/std/option.md:9
+msgid "`Some(value)`, a tuple struct that wraps a `value` with type `T`."
+msgstr "`Some(value)`、型`T`の`value`をラップするタプルです。"
+
+#: src/std/option.md:12
+msgid "// An integer division that doesn't `panic!`\n"
+msgstr "// `panic!`を起こさない整数の割り算\n"
+
+#: src/std/option.md:15
+msgid "// Failure is represented as the `None` variant\n"
+msgstr "// 失敗は`None`としてあらわされます。\n"
+
+#: src/std/option.md:18
+msgid "// Result is wrapped in a `Some` variant\n"
+msgstr "// 結果は`Some`にラップされます。\n"
+
+#: src/std/option.md:22
+msgid "// This function handles a division that may not succeed\n"
+msgstr "// この関数は失敗する割り算を扱うことができます。\n"
+
+#: src/std/option.md:25
+msgid "// `Option` values can be pattern matched, just like other enums\n"
+msgstr "// `Option` の値は、他のあらゆる列挙型と同様パターンマッチに使用できます。\n"
+
+#: src/std/option.md:27
+msgid "\"{} / {} failed!\""
+msgstr "\"{} / {} failed!\""
+
+#: src/std/option.md:29
+msgid "\"{} / {} = {}\""
+msgstr "\"{} / {} = {}\""
+
+#: src/std/option.md:38
+msgid "// Binding `None` to a variable needs to be type annotated\n"
+msgstr "// `None`を変数に代入する際は、型を明示しなくてはなりません。\n"
+
+#: src/std/option.md:44
+msgid "// Unwrapping a `Some` variant will extract the value wrapped.\n"
+msgstr "// `Some`をアンラップすると中の値を取得できます。\n"
+
+#: src/std/option.md:45 src/std/option.md:48
+msgid "\"{:?} unwraps to {:?}\""
+msgstr "\"{:?} unwraps to {:?}\""
+
+#: src/std/option.md:47
+msgid "// Unwrapping a `None` variant will `panic!`\n"
+msgstr "// `None`をアンラップしようとすると`panic!`します。\n"
+
+#: src/std/result.md:3
+msgid ""
+"We've seen that the `Option` enum can be used as a return value from "
+"functions that may fail, where `None` can be returned to indicate failure. "
+"However, sometimes it is important to express _why_ an operation failed. To "
+"do this we  have the `Result` enum."
+msgstr ""
+"これまでの例で、失敗する可能性のある関数の返り値として、列挙型`Option`が使用でき、"
+"失敗時の返り値には`None`を用いることを見てきました。"
+"しかし、時には **なぜ** そのオペレーションが失敗したのかを明示することが重要な場合があります。"
+"そのためには`Result`列挙型を使用します。"
+
+#: src/std/result.md:8
+msgid "The `Result<T, E>` enum has two variants:"
+msgstr "列挙型`Result<T, E>`は2つの値をとりえます。"
+
+#: src/std/result.md:10
+msgid ""
+"`Ok(value)` which indicates that the operation succeeded, and wraps the "
+"`value` returned by the operation. (`value` has type `T`)"
+msgstr ""
+"`Ok(value)` ... これはオペレーションが成功したことを意味し、返り値`value`をラップします。（`value`は型`T`を持ちます。）"
+
+#: src/std/result.md:12
+msgid ""
+"`Err(why)`, which indicates that the operation failed, and wraps `why`, "
+"which (hopefully) explains the cause of the failure. (`why` has type `E`)"
+msgstr ""
+"`Err(why)` ... これはオペレーションの失敗を意味します。"
+"`why`をラップしており、ここには失敗した理由が（必ずではありませんが）書かれています。（`why`の型は`E`です。）"
+
+#: src/std/result.md:17
+msgid "// Mathematical \"errors\" we want to catch\n"
+msgstr "// 捕捉対象としたい、数学的な「エラー」\n"
+
+#: src/std/result.md:29
+msgid ""
+"// This operation would `fail`, instead let's return the reason of\n"
+"            // the failure wrapped in `Err`\n"
+msgstr ""
+"// 分母が0なので、このオペレーションは普通に行えば失敗します。\n"
+"            // 代わりに`Err`でラップされた失敗の理由を返しましょう。\n"
+
+#: src/std/result.md:33
+msgid "// This operation is valid, return the result wrapped in `Ok`\n"
+msgstr ""
+"// このオペレーションは問題がないので、\n"
+"            // 結果を`Ok`でラップして返しましょう。\n"
+
+#: src/std/result.md:54
+msgid "// `op(x, y)` === `sqrt(ln(x / y))`\n"
+msgstr "// `op(x, y)` === `sqrt(ln(x / y))`\n"
+
+#: src/std/result.md:57
+msgid "// This is a three level match pyramid!\n"
+msgstr "// 3段階の`match`ピラミッド！\n"
+
+#: src/std/result.md:71
+msgid "// Will this fail?\n"
+msgstr "// これは失敗するでしょうか？\n"
+
+#: src/std/result/question_mark.md:3
+msgid ""
+"Chaining results using match can get pretty untidy; luckily, the `?` "
+"operator can be used to make things pretty again. `?` is used at the end of "
+"an expression returning a `Result`, and is equivalent to a match expression, "
+"where the  `Err(err)` branch expands to an early `return Err(From::"
+"from(err))`, and the `Ok(ok)` branch expands to an `ok` expression."
+msgstr ""
+"マッチを利用して結果をチェインするのは中々面倒です。"
+"幸いなことに、`?`マクロを使用すればイケてるコードに戻すことができます。"
+"`?`は`Result`を返す式の末尾で使います。"
+"`Err(err)`の分岐が`return Err(From::from(err))`という早期リターンに展開され、"
+"`Ok(ok)`の分岐が`ok`の式に展開されるようなマッチ式と等価です。"
+
+#: src/std/result/question_mark.md:44
+msgid "// Intermediate function\n"
+msgstr "// 中間関数\n"
+
+#: src/std/result/question_mark.md:46
+msgid "// if `div` \"fails\", then `DivisionByZero` will be `return`ed\n"
+msgstr "// `div`が\"失敗\"したら、`DivisionByZero`が`return`されます。\n"
+
+#: src/std/result/question_mark.md:49
+msgid "// if `ln` \"fails\", then `NonPositiveLogarithm` will be `return`ed\n"
+msgstr "// もし`ln`が\"失敗\"したら、`NonPositiveLogarithm`が`return`されます。\n"
+
+#: src/std/result/question_mark.md:59
+msgid "\"logarithm of non-positive number\""
+msgstr "\"logarithm of non-positive number\""
+
+#: src/std/result/question_mark.md:61 src/std/panic.md:15
+msgid "\"division by zero\""
+msgstr "\"division by zero\""
+
+#: src/std/result/question_mark.md:63
+msgid "\"square root of negative number\""
+msgstr "\"square root of negative number\""
+
+#: src/std/result/question_mark.md:75
+msgid ""
+"Be sure to check the [documentation](https://doc.rust-lang.org/std/result/"
+"index.html), as there are many methods to map/compose `Result`."
+msgstr ""
+"[公式ドキュメント](https://doc.rust-lang.org/std/result/index.html)をチェックすることをオススメします。"
+"`Result`型を扱う関数や`Result`型のメソッドが多く挙げられています。"
+
+#: src/std/panic.md:3
+msgid ""
+"The `panic!` macro can be used to generate a panic and start unwinding its "
+"stack. While unwinding, the runtime will take care of freeing all the "
+"resources _owned_ by the thread by calling the destructor of all its objects."
+msgstr ""
+"`panic!`マクロはパニックを生成し、スタックの巻き戻しを開始するために使用することができます。"
+"巻き戻しの間、ランタイムは、（訳注: panicを起こした）スレッドが **所有権を持つ** 全ての資源のデストラクタを呼び出し、メモリ上から解放します。"
+
+#: src/std/panic.md:7
+msgid ""
+"Since we are dealing with programs with only one thread, `panic!` will cause "
+"the program to report the panic message and exit."
+msgstr ""
+"今回はシングルスレッドのプログラムを実行しているので、`panic!`はプログラムにパニックメッセージを表示させ、exitします。"
+
+#: src/std/panic.md:11
+msgid "// Re-implementation of integer division (/)\n"
+msgstr "// 整数の除法(/)の再実装\n"
+
+#: src/std/panic.md:14
+msgid "// Division by zero triggers a panic\n"
+msgstr "// ゼロによる除算はパニックを引き起こします。\n"
+
+#: src/std/panic.md:20
+msgid "// The `main` task\n"
+msgstr "// `main`のタスク\n"
+
+#: src/std/panic.md:23
+msgid "// Heap allocated integer\n"
+msgstr "// ヒープ上の整数\n"
+
+#: src/std/panic.md:26
+msgid "// This operation will trigger a task failure\n"
+msgstr "// このオペレーションはタスクの失敗を引き起こします。\n"
+
+#: src/std/panic.md:29
+msgid "\"This point won't be reached!\""
+msgstr "\"This point won't be reached!\""
+
+#: src/std/panic.md:31
+msgid "// `_x` should get destroyed at this point\n"
+msgstr "// `_x`はここに到達する前に破棄されます。\n"
+
+#: src/std/panic.md:35
+msgid "Let's check that `panic!` doesn't leak memory."
+msgstr "`panic!`がメモリリークを引き起こさないことを確認しましょう。"
+
+#: src/std/hash.md:3
+msgid ""
+"Where vectors store values by an integer index, `HashMap`s store values by "
+"key.  `HashMap` keys can be booleans, integers, strings,  or any other type "
+"that implements the `Eq` and `Hash` traits.  More on this in the next "
+"section."
+msgstr ""
+"ベクタ型が値を整数のインデックスで保持するのに対し、`HashMap`ではキーで保持します。"
+"`HashMap`のキーはブーリアン、整数、文字列等の`Eq`と`Hash`トレイトを保持する型なら何でもOKです。"
+"次のセクションでより詳しく見ていきます。"
+
+#: src/std/hash.md:8
+msgid ""
+"Like vectors, `HashMap`s are growable, but HashMaps can also shrink "
+"themselves  when they have excess space.  You can create a HashMap with a "
+"certain starting capacity using  `HashMap::with_capacity(uint)`, or use "
+"`HashMap::new()` to get a HashMap  with a default initial capacity "
+"(recommended)."
+msgstr ""
+"ベクタ型と同様、伸長可能ですが、`HashMap`の場合さらに、スペースが余っているときには小さくすることも可能です。"
+"`HashMap`を一定の容量のエリアに作成するときは`HashMap::with_capacity(uint)`を、"
+"デフォルトの容量で作成するときは`HashMap::new()`を用います。後者が推奨されています。"
+
+#: src/std/hash.md:19 src/std/hash.md:30
+msgid "\"798-1364\""
+msgstr "\"798-1364\""
+
+#: src/std/hash.md:19
+msgid ""
+"\"We're sorry, the call cannot be completed as dialed. \n"
+"            Please hang up and try again.\""
+msgstr ""
+"\"We're sorry, the call cannot be completed as dialed. \n"
+"            Please hang up and try again.\""
+
+#: src/std/hash.md:21 src/std/hash.md:31
+msgid "\"645-7689\""
+msgstr "\"645-7689\""
+
+#: src/std/hash.md:21
+msgid ""
+"\"Hello, this is Mr. Awesome's Pizza. My name is Fred.\n"
+"            What can I get for you today?\""
+msgstr ""
+"\"Hello, this is Mr. Awesome's Pizza. My name is Fred.\n"
+"            What can I get for you today?\""
+
+#: src/std/hash.md:23
+msgid "\"Hi! Who is this again?\""
+msgstr "\"Hi! Who is this again?\""
+
+#: src/std/hash.md:30 src/std/hash.md:36 src/std/hash.md:43
+msgid "\"Daniel\""
+msgstr "\"Daniel\""
+
+#: src/std/hash.md:31 src/std/hash.md:45 src/std/hash.md:50
+msgid "\"Ashley\""
+msgstr "\"Ashley\""
+
+#: src/std/hash.md:32
+msgid "\"Katie\""
+msgstr "\"Katie\""
+
+#: src/std/hash.md:32
+msgid "\"435-8291\""
+msgstr "\"435-8291\""
+
+#: src/std/hash.md:33
+msgid "\"Robert\""
+msgstr "\"Robert\""
+
+#: src/std/hash.md:33
+msgid "\"956-1745\""
+msgstr "\"956-1745\""
+
+#: src/std/hash.md:35
+msgid "// Takes a reference and returns Option<&V>\n"
+msgstr "// 参照をとり、Option<&V>を返します。\n"
+
+#: src/std/hash.md:37
+msgid "\"Calling Daniel: {}\""
+msgstr "\"Calling Daniel: {}\""
+
+#: src/std/hash.md:38
+msgid "\"Don't have Daniel's number.\""
+msgstr "\"Don't have Daniel's number.\""
+
+#: src/std/hash.md:41
+msgid ""
+"// `HashMap::insert()` returns `None`\n"
+"    // if the inserted value is new, `Some(value)` otherwise\n"
+msgstr ""
+"// `HashMap::insert()`は\n"
+"    // insertされた値が新しい場合は`None`を\n"
+"    // そうでなければ`Some(value)`を返します。\n"
+
+#: src/std/hash.md:43
+msgid "\"164-6743\""
+msgstr "\"164-6743\""
+
+#: src/std/hash.md:46
+msgid "\"Calling Ashley: {}\""
+msgstr "\"Calling Ashley: {}\""
+
+#: src/std/hash.md:47
+msgid "\"Don't have Ashley's number.\""
+msgstr "\"Don't have Ashley's number.\""
+
+#: src/std/hash.md:52
+msgid ""
+"// `HashMap::iter()` returns an iterator that yields \n"
+"    // (&'a key, &'a value) pairs in arbitrary order.\n"
+msgstr ""
+"// `HashMap::iter()`は(&'a key, &'a value)\n"
+"    // のペアを順不同で産出するイテレータを返します。\n"
+
+#: src/std/hash.md:55
+msgid "\"Calling {}: {}\""
+msgstr "\"Calling {}: {}\""
+
+#: src/std/hash.md:60
+msgid ""
+"For more information on how hashing and hash maps  (sometimes called hash "
+"tables) work, have a look at  [Hash Table Wikipedia](https://en.wikipedia."
+"org/wiki/Hash_table)"
+msgstr ""
+"ハッシングやハッシュマップ（ハッシュテーブルと呼ばれることもあります）の仕組みについて、"
+"より詳しく知りたい場合は[Wikipediaのハッシュテーブルのページ](https://en.wikipedia.org/wiki/Hash_table)を見てください。"
+
+#: src/std/hash/alt_key_types.md:3
+msgid ""
+"Any type that implements the `Eq` and `Hash` traits can be a key in "
+"`HashMap`.  This includes:"
+msgstr ""
+"`Eq`と`Hash`トレイトを実装している型ならば、なんでも`HashMap`のキーになることができます。"
+"例えば以下です。"
+
+#: src/std/hash/alt_key_types.md:6
+msgid "`bool` (though not very useful since there are only two possible keys)"
+msgstr "`bool` （キーになりうる値が2つしかないので実用的ではないですが…）"
+
+#: src/std/hash/alt_key_types.md:7
+msgid "`int`, `uint`, and all variations thereof"
+msgstr "`int`、`uint`、あるいは他の整数型"
+
+#: src/std/hash/alt_key_types.md:8
+msgid ""
+"`String` and `&str` (protip: you can have a `HashMap` keyed by `String` and "
+"call `.get()` with an `&str`)"
+msgstr "`String`と`&str`（Tips：`String`をキーにしたハッシュマップを作製した場合、`.get()`メソッドの引数に`&str`を与えて値を取得することができます。）"
+
+#: src/std/hash/alt_key_types.md:11
+msgid ""
+"Note that `f32` and `f64` do _not_ implement `Hash`, likely because "
+"[floating-point precision errors](https://en.wikipedia.org/wiki/"
+"Floating_point#Accuracy_problems) would make using them as hashmap keys "
+"horribly error-prone."
+msgstr ""
+"`f32`と`f64`は`Hash`を実装して **いない** ことに注意しましょう。"
+"おそらくこれは[浮動小数点演算時に誤差が発生する](https://en.wikipedia.org/wiki/Floating_point#Accuracy_problems)"
+"ため、キーとして使用すると、恐ろしいほどエラーの元となるためです。"
+
+#: src/std/hash/alt_key_types.md:15
+msgid ""
+"All collection classes implement `Eq` and `Hash`  if their contained type "
+"also respectively implements `Eq` and `Hash`.  For example, `Vec<T>` will "
+"implement `Hash` if `T` implements `Hash`."
+msgstr ""
+"集合型は、その要素となっている全ての型が`Eq`を、あるいは`Hash`を実装している場合、"
+"必ず同じトレイトを実装しています。"
+"例えば、`Vec<T>`は`T`が`Hash`を実装している場合、`Hash`を実装します。"
+
+#: src/std/hash/alt_key_types.md:19
+msgid ""
+"You can easily implement `Eq` and `Hash` for a custom type with just one "
+"line:  `#[derive(PartialEq, Eq, Hash)]`"
+msgstr ""
+"独自の型に`Eq`あるいは`Hash`を実装するのは簡単です。以下の一行で済みます。"
+"`#[derive(PartialEq, Eq, Hash)]`"
+
+#: src/std/hash/alt_key_types.md:22
+msgid ""
+"The compiler will do the rest. If you want more control over the details,  "
+"you can implement `Eq` and/or `Hash` yourself.  This guide will not cover "
+"the specifics of implementing `Hash`. "
+msgstr ""
+"後はコンパイラがよしなにしてくれます。"
+"これらのトレイトの詳細をコントロールしたい場合、`Eq`や`Hash`を自分で実装することもできます。"
+"この文書では`Hash`トレイトを実装する方法の詳細については触れません。"
+
+#: src/std/hash/alt_key_types.md:26
+msgid ""
+"To play around with using a `struct` in `HashMap`,  let's try making a very "
+"simple user logon system:"
+msgstr ""
+"`struct`を`HashMap`で扱う際の例として、とてもシンプルなユーザーログインシステムを作成してみましょう。"
+
+#: src/std/hash/alt_key_types.md:31
+msgid "// Eq requires that you derive PartialEq on the type.\n"
+msgstr "// Eqトレイトを使用する時は、PartialEqをderiveする必要があります。\n"
+
+#: src/std/hash/alt_key_types.md:48
+msgid "\"Username: {}\""
+msgstr "\"Username: {}\""
+
+#: src/std/hash/alt_key_types.md:49
+msgid "\"Password: {}\""
+msgstr "\"Password: {}\""
+
+#: src/std/hash/alt_key_types.md:50
+msgid "\"Attempting logon...\""
+msgstr "\"Attempting logon...\""
+
+#: src/std/hash/alt_key_types.md:59
+msgid "\"Successful logon!\""
+msgstr "\"Successful logon!\""
+
+#: src/std/hash/alt_key_types.md:60
+msgid "\"Name: {}\""
+msgstr "\"Name: {}\""
+
+#: src/std/hash/alt_key_types.md:61
+msgid "\"Email: {}\""
+msgstr "\"Email: {}\""
+
+#: src/std/hash/alt_key_types.md:63
+msgid "\"Login failed!\""
+msgstr "\"Login failed!\""
+
+#: src/std/hash/alt_key_types.md:71 src/std/hash/alt_key_types.md:82
+#: src/std/hash/alt_key_types.md:84
+msgid "\"j.everyman\""
+msgstr "\"j.everyman\""
+
+#: src/std/hash/alt_key_types.md:72 src/std/hash/alt_key_types.md:84
+msgid "\"password123\""
+msgstr "\"password123\""
+
+#: src/std/hash/alt_key_types.md:76
+msgid "\"John Everyman\""
+msgstr "\"John Everyman\""
+
+#: src/std/hash/alt_key_types.md:77
+msgid "\"j.everyman@email.com\""
+msgstr "\"j.everyman@email.com\""
+
+#: src/std/hash/alt_key_types.md:82
+msgid "\"psasword123\""
+msgstr "\"psasword123\""
+
+#: src/std/hash/hashset.md:3
+msgid ""
+"Consider a `HashSet` as a `HashMap` where we just care about the keys "
+"( `HashSet<T>` is, in actuality, just a wrapper around `HashMap<T, ()>`)."
+msgstr ""
+"値がなく、キーだけの`HashMap`を想像してみてください。"
+"これはハッシュ集合（`HashSet`）と呼ばれるものです。（`HashSet<T>`は、実際には`HashMap<T, ()>`のラッパーです。）"
+
+#: src/std/hash/hashset.md:6
+msgid ""
+"\"What's the point of that?\" you ask. \"I could just store the keys in a "
+"`Vec`.\""
+msgstr ""
+"「何の意味があるの？フツーにキーを`Vec`に入れればいいじゃん」そう思いましたね？"
+
+#: src/std/hash/hashset.md:8
+msgid ""
+"A `HashSet`'s unique feature is that  it is guaranteed to not have duplicate "
+"elements.  That's the contract that any set collection fulfills.  `HashSet` "
+"is just one implementation. (see also: [`BTreeSet`](https://doc.rust-lang."
+"org/std/collections/struct.BTreeSet.html))"
+msgstr ""
+"それは、`HashSet`独自の機能として、要素に重複がないということが保証されるためです。"
+"これは全ての集合型がもつ機能です。`HashSet`はその実装の1つであり、"
+"他には[`BTreeSet`](https://doc.rust-lang.org/std/collections/struct.BTreeSet.html)等があります。"
+
+#: src/std/hash/hashset.md:13
+msgid ""
+"If you insert a value that is already present in the `HashSet`,  (i.e. the "
+"new value is equal to the existing and they both have the same hash),  then "
+"the new value will replace the old."
+msgstr ""
+"`HashSet`に、すでに存在する値を加えようとすると、"
+"（すなわち、加えようとしている値のハッシュ値と、要素中のいずれかの値のハッシュ値が等しい場合、）"
+"新しい値によって古い値が上書きされます。"
+
+#: src/std/hash/hashset.md:17
+msgid ""
+"This is great for when you never want more than one of something,  or when "
+"you want to know if you've already got something."
+msgstr "これは、同じ値を2つ以上欲しくない場合や、すでにある値を持っているか知りたい場合にとても有効です。"
+
+#: src/std/hash/hashset.md:20
+msgid "But sets can do more than that. "
+msgstr "しかし、集合型の機能はそれだけではありません。"
+
+#: src/std/hash/hashset.md:22
+msgid ""
+"Sets have 4 primary operations (all of the following calls return an "
+"iterator):"
+msgstr "集合型には4つの主要なメソッドがあり、（すべてイテレータを返します。）"
+
+#: src/std/hash/hashset.md:24
+msgid "`union`: get all the unique elements in both sets."
+msgstr "`union`：2つの集合型のどちらか一方にある値を全て取得。"
+
+#: src/std/hash/hashset.md:26
+msgid ""
+"`difference`: get all the elements that are in the first set but not the "
+"second."
+msgstr "`difference`：1つ目の集合にあり、かつ2つ目には存在しない値を全て取得。"
+
+#: src/std/hash/hashset.md:28
+msgid "`intersection`: get all the elements that are only in _both_ sets."
+msgstr "`intersection`：両方の集合にある値のみを取得。"
+
+#: src/std/hash/hashset.md:30
+msgid ""
+"`symmetric_difference`:  get all the elements that are in one set or the "
+"other, but _not_ both."
+msgstr "`symmetric_difference`：どちらか一方の集合には存在するが、両方には **ない** 値を取得。"
+
+#: src/std/hash/hashset.md:33
+msgid "Try all of these in the following example:"
+msgstr "以下の例でこれらをすべて見ていきましょう。"
+
+#: src/std/hash/hashset.md:45
+msgid ""
+"// `HashSet::insert()` returns false if\n"
+"    // there was a value already present.\n"
+msgstr ""
+"// 既に存在する値を追加しようとすると\n"
+"    // `HashSet::insert()`はfalseを返します。\n"
+
+#: src/std/hash/hashset.md:47
+msgid "\"Value 4 is already in set B!\""
+msgstr "\"Value 4 is already in set B!\""
+
+#: src/std/hash/hashset.md:52
+msgid ""
+"// If a collection's element type implements `Debug`,\n"
+"    // then the collection implements `Debug`.\n"
+"    // It usually prints its elements in the format `[elem1, elem2, ...]`\n"
+msgstr ""
+"// 集合の要素が、`Debug`を実装している型の場合、\n"
+"    // 集合そのものも`Debug`を実装します。\n"
+"    // 通常は`[elem1, elem2, ...]`のように要素を出力します。\n"
+
+#: src/std/hash/hashset.md:55
+msgid "\"A: {:?}\""
+msgstr "\"A: {:?}\""
+
+#: src/std/hash/hashset.md:56
+msgid "\"B: {:?}\""
+msgstr "\"B: {:?}\""
+
+#: src/std/hash/hashset.md:58
+msgid "// Print [1, 2, 3, 4, 5] in arbitrary order\n"
+msgstr "// [1, 2, 3, 4, 5]を順不同に出力。\n"
+
+#: src/std/hash/hashset.md:59
+msgid "\"Union: {:?}\""
+msgstr "\"Union: {:?}\""
+
+#: src/std/hash/hashset.md:61
+msgid "// This should print [1]\n"
+msgstr "// これは[1]を出力。\n"
+
+#: src/std/hash/hashset.md:62
+msgid "\"Difference: {:?}\""
+msgstr "\"Difference: {:?}\""
+
+#: src/std/hash/hashset.md:64
+msgid "// Print [2, 3, 4] in arbitrary order.\n"
+msgstr "// [2, 3, 4]を順不同に出力。\n"
+
+#: src/std/hash/hashset.md:65
+msgid "\"Intersection: {:?}\""
+msgstr "\"Intersection: {:?}\""
+
+#: src/std/hash/hashset.md:67
+msgid "// Print [1, 5]\n"
+msgstr "// [1, 5]を出力。\n"
+
+#: src/std/hash/hashset.md:68
+msgid "\"Symmetric Difference: {:?}\""
+msgstr "\"Symmetric Difference: {:?}\""
+
+#: src/std/hash/hashset.md:73
+msgid ""
+"(Examples are adapted from the [documentation.](https://doc.rust-lang.org/"
+"std/collections/struct.HashSet.html#method.difference))"
+msgstr ""
+"例は[公式ドキュメント](https://doc.rust-lang.org/std/collections/struct.HashSet.html#method.difference)"
+"から持ってきています。"
+
+#: src/std/rc.md:3
+msgid ""
+"When multiple ownership is needed, `Rc`(Reference Counting) can be used. "
+"`Rc` keeps track of the number of the references which means the number of "
+"owners of the value wrapped inside an `Rc`. "
+msgstr ""
+
+#: src/std/rc.md:5
+msgid ""
+"Reference count of an `Rc` increases by 1 whenever an `Rc` is cloned, and "
+"decreases by 1 whenever one cloned `Rc` is dropped out of the scope. When an "
+"`Rc`'s reference count becomes zero (which means there are no remaining "
+"owners), both the `Rc` and the value are all dropped. "
+msgstr ""
+
+#: src/std/rc.md:7
+msgid ""
+"Cloning an `Rc` never performs a deep copy. Cloning creates just another "
+"pointer to the wrapped value, and increments the count."
+msgstr ""
+
+#: src/std/rc.md:13
+msgid "\"Rc examples\""
+msgstr "\"Rc examples\""
+
+#: src/std/rc.md:15
+msgid "\"--- rc_a is created ---\""
+msgstr "\"--- rc_a is created ---\""
+
+#: src/std/rc.md:18 src/std/rc.md:25 src/std/rc.md:37
+msgid "\"Reference Count of rc_a: {}\""
+msgstr "\"Reference Count of rc_a: {}\""
+
+#: src/std/rc.md:21
+msgid "\"--- rc_a is cloned to rc_b ---\""
+msgstr "\"--- rc_a is cloned to rc_b ---\""
+
+#: src/std/rc.md:24
+msgid "\"Reference Count of rc_b: {}\""
+msgstr "\"Reference Count of rc_b: {}\""
+
+#: src/std/rc.md:27
+msgid "// Two `Rc`s are equal if their inner values are equal\n"
+msgstr ""
+
+#: src/std/rc.md:28
+msgid "\"rc_a and rc_b are equal: {}\""
+msgstr "\"rc_a and rc_b are equal: {}\""
+
+#: src/std/rc.md:30
+msgid "// We can use methods of a value directly\n"
+msgstr ""
+
+#: src/std/rc.md:31
+msgid "\"Length of the value inside rc_a: {}\""
+msgstr "\"Length of the value inside rc_a: {}\""
+
+#: src/std/rc.md:32
+msgid "\"Value of rc_b: {}\""
+msgstr "\"Value of rc_b: {}\""
+
+#: src/std/rc.md:34
+msgid "\"--- rc_b is dropped out of scope ---\""
+msgstr "\"--- rc_b is dropped out of scope ---\""
+
+#: src/std/rc.md:39
+msgid "\"--- rc_a is dropped out of scope ---\""
+msgstr "\"--- rc_a is dropped out of scope ---\""
+
+#: src/std/rc.md:42
+msgid ""
+"// Error! `rc_examples` already moved into `rc_a`\n"
+"    // And when `rc_a` is dropped, `rc_examples` is dropped together\n"
+"    // println!(\"rc_examples: {}\", rc_examples);\n"
+"    // TODO ^ Try uncommenting this line\n"
+msgstr ""
+
+#: src/std/rc.md:51
+msgid ""
+"[std::rc](https://doc.rust-lang.org/std/rc/index.html) and [std::sync::arc]"
+"(https://doc.rust-lang.org/std/sync/struct.Arc.html)."
+msgstr ""
+
+#: src/std/arc.md:1
+msgid "Arc"
+msgstr ""
+
+#: src/std/arc.md:3
+msgid ""
+"When shared ownership between threads is needed, `Arc`(Atomically Reference "
+"Counted) can be used. This struct, via the `Clone` implementation can create "
+"a reference pointer for the location of a value in the memory heap while "
+"increasing the reference counter. As it shares ownership between threads, "
+"when the last reference pointer to a value is out of scope, the variable is "
+"dropped."
+msgstr ""
+
+#: src/std/arc.md:15
+msgid "// This variable declaration is where its value is specified.\n"
+msgstr ""
+
+#: src/std/arc.md:16
+msgid "\"the same apple\""
+msgstr "\"the same apple\""
+
+#: src/std/arc.md:19
+msgid ""
+"// Here there is no value specification as it is a pointer to a\n"
+"        // reference in the memory heap.\n"
+msgstr ""
+
+#: src/std/arc.md:24
+msgid ""
+"// As Arc was used, threads can be spawned using the value allocated\n"
+"            // in the Arc variable pointer's location.\n"
+msgstr ""
+
+#: src/std/arc.md:30
+msgid "// Make sure all Arc instances are printed from spawned threads.\n"
+msgstr ""
+
+#: src/std_misc.md:3
+msgid ""
+"Many other types are provided by the std library to support things such as:"
+msgstr ""
+"他にも、様々な型がstdライブラリの中で提供されています。例えば以下の機能を果たすための物があります。"
+
+#: src/std_misc.md:10
+msgid "These expand beyond what the [primitives](primitives.md) provide."
+msgstr "これらにより[基本データ型](primitives.md)の提供する機能よりも遥かに豊かなことが実現できます。"
+
+#: src/std_misc/threads.md:3
+msgid ""
+"Rust provides a mechanism for spawning native OS threads via the `spawn` "
+"function, the argument of this function is a moving closure."
+msgstr ""
+"Rustは`spawn`関数を用いてOSのネイティブスレッドを開始することができます。"
+"この関数の引数はmoveクロージャ（訳注: 参照ではなく値を取るクロージャ）です。"
+
+#: src/std_misc/threads.md:10 src/std_misc/threads/testcase_mapreduce.md:28
+msgid "// This is the `main` thread\n"
+msgstr "// この関数は`main`スレッドで実行されます。\n"
+
+#: src/std_misc/threads.md:13
+msgid "// Make a vector to hold the children which are spawned.\n"
+msgstr "// spawnされるクロージャを保持するためのベクタ\n"
+
+#: src/std_misc/threads.md:17
+msgid "// Spin up another thread\n"
+msgstr "// 新しいスレッドを起動。\n"
+
+#: src/std_misc/threads.md:19
+msgid "\"this is thread number {}\""
+msgstr "\"this is thread number {}\""
+
+#: src/std_misc/threads.md:24
+msgid "// Wait for the thread to finish. Returns a result.\n"
+msgstr "// 子スレッドが終了するのを待ち、結果を返します。\n"
+
+#: src/std_misc/threads.md:30
+msgid "These threads will be scheduled by the OS."
+msgstr "これらのスレッドのスケジューリングはOSによって行われます。"
+
+#: src/std_misc/threads/testcase_mapreduce.md:3
+msgid ""
+"Rust makes it very easy to parallelise data processing, without many of the "
+"headaches traditionally associated with such an attempt."
+msgstr ""
+
+#: src/std_misc/threads/testcase_mapreduce.md:5
+msgid ""
+"The standard library provides great threading primitives out of the box. "
+"These, combined with Rust's concept of Ownership and aliasing rules, "
+"automatically prevent data races."
+msgstr ""
+
+#: src/std_misc/threads/testcase_mapreduce.md:9
+msgid ""
+"The aliasing rules (one writable reference XOR many readable references) "
+"automatically prevent you from manipulating state that is visible to other "
+"threads. (Where synchronisation is needed, there are synchronisation "
+"primitives like `Mutex`es or `Channel`s.)"
+msgstr ""
+
+#: src/std_misc/threads/testcase_mapreduce.md:14
+msgid ""
+"In this example, we will calculate the sum of all digits in a block of "
+"numbers. We will do this by parcelling out chunks of the block into "
+"different threads. Each thread will sum its tiny block of digits, and "
+"subsequently we will sum the intermediate sums produced by each thread."
+msgstr ""
+
+#: src/std_misc/threads/testcase_mapreduce.md:19
+msgid ""
+"Note that, although we're passing references across thread boundaries, Rust "
+"understands that we're only passing read-only references, and that thus no "
+"unsafety or data races can occur. Also because the references we're passing "
+"have `'static` lifetimes, Rust understands that our data won't be destroyed "
+"while these threads are still running. (When you need to share non-`static` "
+"data between threads, you can use a smart pointer like `Arc` to keep the "
+"data alive and avoid non-`static` lifetimes.)"
+msgstr ""
+
+#: src/std_misc/threads/testcase_mapreduce.md:32
+msgid ""
+"// This is our data to process.\n"
+"    // We will calculate the sum of all digits via a threaded map-reduce "
+"algorithm.\n"
+"    // Each whitespace separated chunk will be handled in a different "
+"thread.\n"
+"    //\n"
+"    // TODO: see what happens to the output if you insert spaces!\n"
+msgstr ""
+
+#: src/std_misc/threads/testcase_mapreduce.md:37
+msgid ""
+"\"86967897737416471853297327050364959\n"
+"11861322575564723963297542624962850\n"
+"70856234701860851907960690014725639\n"
+"38397966707106094172783238747669219\n"
+"52380795257888236525459303330302837\n"
+"58495327135744041048897885734297812\n"
+"69920216438980873548808413720956532\n"
+"16278424637452589860345374828574668\""
+msgstr ""
+"\"86967897737416471853297327050364959\n"
+"11861322575564723963297542624962850\n"
+"70856234701860851907960690014725639\n"
+"38397966707106094172783238747669219\n"
+"52380795257888236525459303330302837\n"
+"58495327135744041048897885734297812\n"
+"69920216438980873548808413720956532\n"
+"16278424637452589860345374828574668\""
+
+#: src/std_misc/threads/testcase_mapreduce.md:46
+msgid "// Make a vector to hold the child-threads which we will spawn.\n"
+msgstr ""
+
+#: src/std_misc/threads/testcase_mapreduce.md:49
+msgid ""
+"/*************************************************************************\n"
+"     * \"Map\" phase\n"
+"     *\n"
+"     * Divide our data into segments, and apply initial processing\n"
+"     ************************************************************************/"
+msgstr ""
+
+#: src/std_misc/threads/testcase_mapreduce.md:55
+msgid ""
+"// split our data into segments for individual calculation\n"
+"    // each chunk will be a reference (&str) into the actual data\n"
+msgstr ""
+
+#: src/std_misc/threads/testcase_mapreduce.md:59
+msgid ""
+"// Iterate over the data segments.\n"
+"    // .enumerate() adds the current loop index to whatever is iterated\n"
+"    // the resulting tuple \"(index, element)\" is then immediately\n"
+"    // \"destructured\" into two variables, \"i\" and \"data_segment\" with "
+"a\n"
+"    // \"destructuring assignment\"\n"
+msgstr ""
+
+#: src/std_misc/threads/testcase_mapreduce.md:65
+msgid "\"data segment {} is \\\"{}\\\"\""
+msgstr "\"data segment {} is \\\"{}\\\"\""
+
+#: src/std_misc/threads/testcase_mapreduce.md:67
+msgid ""
+"// Process each data segment in a separate thread\n"
+"        //\n"
+"        // spawn() returns a handle to the new thread,\n"
+"        // which we MUST keep to access the returned value\n"
+"        //\n"
+"        // 'move || -> u32' is syntax for a closure that:\n"
+"        // * takes no arguments ('||')\n"
+"        // * takes ownership of its captured variables ('move') and\n"
+"        // * returns an unsigned 32-bit integer ('-> u32')\n"
+"        //\n"
+"        // Rust is smart enough to infer the '-> u32' from\n"
+"        // the closure itself so we could have left that out.\n"
+"        //\n"
+"        // TODO: try removing the 'move' and see what happens\n"
+msgstr ""
+
+#: src/std_misc/threads/testcase_mapreduce.md:82
+msgid "// Calculate the intermediate sum of this segment:\n"
+msgstr ""
+
+#: src/std_misc/threads/testcase_mapreduce.md:84
+msgid "// iterate over the characters of our segment..\n"
+msgstr ""
+
+#: src/std_misc/threads/testcase_mapreduce.md:86
+msgid "// .. convert text-characters to their number value..\n"
+msgstr ""
+
+#: src/std_misc/threads/testcase_mapreduce.md:87
+msgid "\"should be a digit\""
+msgstr "\"should be a digit\""
+
+#: src/std_misc/threads/testcase_mapreduce.md:88
+msgid "// .. and sum the resulting iterator of numbers\n"
+msgstr ""
+
+#: src/std_misc/threads/testcase_mapreduce.md:91
+msgid "// println! locks stdout, so no text-interleaving occurs\n"
+msgstr ""
+
+#: src/std_misc/threads/testcase_mapreduce.md:92
+msgid "\"processed segment {}, result={}\""
+msgstr "\"processed segment {}, result={}\""
+
+#: src/std_misc/threads/testcase_mapreduce.md:94
+msgid ""
+"// \"return\" not needed, because Rust is an \"expression language\", the\n"
+"            // last evaluated expression in each block is automatically its "
+"value.\n"
+msgstr ""
+
+#: src/std_misc/threads/testcase_mapreduce.md:102
+msgid ""
+"/*************************************************************************\n"
+"     * \"Reduce\" phase\n"
+"     *\n"
+"     * Collect our intermediate results, and combine them into a final "
+"result\n"
+"     ************************************************************************/"
+msgstr ""
+
+#: src/std_misc/threads/testcase_mapreduce.md:108
+msgid ""
+"// combine each thread's intermediate results into a single final sum.\n"
+"    //\n"
+"    // we use the \"turbofish\" ::<> to provide sum() with a type hint.\n"
+"    //\n"
+"    // TODO: try without the turbofish, by instead explicitly\n"
+"    // specifying the type of final_result\n"
+msgstr ""
+
+#: src/std_misc/threads/testcase_mapreduce.md:116
+msgid "\"Final sum result: {}\""
+msgstr "\"Final sum result: {}\""
+
+#: src/std_misc/threads/testcase_mapreduce.md:122
+msgid "Assignments"
+msgstr ""
+
+#: src/std_misc/threads/testcase_mapreduce.md:123
+msgid ""
+"It is not wise to let our number of threads depend on user inputted data. "
+"What if the user decides to insert a lot of spaces? Do we _really_ want to "
+"spawn 2,000 threads? Modify the program so that the data is always chunked "
+"into a limited number of chunks, defined by a static constant at the "
+"beginning of the program."
+msgstr ""
+
+#: src/std_misc/threads/testcase_mapreduce.md:129
+msgid "[Threads](../threads.md)"
+msgstr "[スレッド](../threads.md)"
+
+#: src/std_misc/threads/testcase_mapreduce.md:130
+msgid "[vectors](../../std/vec.md) and [iterators](../../trait/iter.md)"
+msgstr "[ベクタ型](../../std/vec.md), [イテレータ](../../trait/iter.md)"
+
+#: src/std_misc/threads/testcase_mapreduce.md:131
+msgid ""
+"[closures](../../fn/closures.md), [move](../../scope/move.md) semantics and "
+"[`move` closures](https://doc.rust-lang.org/book/ch13-01-closures."
+"html#closures-can-capture-their-environment)"
+msgstr ""
+"[クロージャ](../../fn/closures.md), [move](../../scope/move.md) semantics and "
+"[`move` クロージャ](https://doc.rust-lang.org/book/ch13-01-closures."
+"html#closures-can-capture-their-environment)"
+
+#: src/std_misc/threads/testcase_mapreduce.md:132
+msgid ""
+"[destructuring](https://doc.rust-lang.org/book/ch18-03-pattern-syntax."
+"html#destructuring-to-break-apart-values) assignments"
+msgstr ""
+"[デストラクト](https://doc.rust-lang.org/book/ch18-03-pattern-syntax."
+"html#destructuring-to-break-apart-values) 代入"
+
+#: src/std_misc/threads/testcase_mapreduce.md:133
+msgid ""
+"[turbofish notation](https://doc.rust-lang.org/book/appendix-02-operators."
+"html?highlight=turbofish) to help type inference"
+msgstr ""
+"型推論を補助する [ターボフィッシュ記法](https://doc.rust-lang.org/book/appendix-02-operators."
+"html?highlight=turbofish)"
+
+#: src/std_misc/threads/testcase_mapreduce.md:134
+msgid "[unwrap vs. expect](../../error/option_unwrap.md)"
+msgstr "[unwrap と expect](../../error/option_unwrap.md)"
+
+#: src/std_misc/threads/testcase_mapreduce.md:135
+msgid "[enumerate](https://doc.rust-lang.org/book/loops.html#enumerate)"
+msgstr "[enumerate](https://doc.rust-lang.org/book/loops.html#enumerate)"
+
+#: src/std_misc/channels.md:3
+msgid ""
+"Rust provides asynchronous `channels` for communication between threads. "
+"Channels allow a unidirectional flow of information between two end-points: "
+"the `Sender` and the `Receiver`."
+msgstr ""
+"Rustは、スレッド間のコミュニケーションのために、非同期のチャネルを提供しています。"
+"チャネルは2つのエンドポイント、すなわち送信者と受信者を介して、情報の一方向への流れを作り出すことを可能にしています。"
+
+#: src/std_misc/channels.md:15
+msgid ""
+"// Channels have two endpoints: the `Sender<T>` and the `Receiver<T>`,\n"
+"    // where `T` is the type of the message to be transferred\n"
+"    // (type annotation is superfluous)\n"
+msgstr ""
+"// チャネルには`Sender<T>`と`Receiver<T>`という2つのエンドポイントがあります。\n"
+"    // ここで、`T`は送信されるメッセージの型です。\n"
+"    // （型アノテーションは必須ではありません。）\n"
+
+#: src/std_misc/channels.md:22
+msgid "// The sender endpoint can be copied\n"
+msgstr "// 送信者エンドポイントはコピーすることができます。\n"
+
+#: src/std_misc/channels.md:25
+msgid "// Each thread will send its id via the channel\n"
+msgstr "// ここでは、それぞれのスレッドが自身のIDを送信しています。\n"
+
+#: src/std_misc/channels.md:27
+msgid ""
+"// The thread takes ownership over `thread_tx`\n"
+"            // Each thread queues a message in the channel\n"
+msgstr ""
+"// スレッドは`thread_tx`の所有権をとり、それぞれのスレッドは\n"
+"            // メッセージをチャネルにキューイングします。\n"
+
+#: src/std_misc/channels.md:31
+msgid ""
+"// Sending is a non-blocking operation, the thread will continue\n"
+"            // immediately after sending its message\n"
+msgstr ""
+"// 送信はノンブロッキングなオペレーションなので、\n"
+"            // メッセージを送信した後もすぐに実行を継続します。\n"
+
+#: src/std_misc/channels.md:33
+msgid "\"thread {} finished\""
+msgstr "\"thread {} finished\""
+
+#: src/std_misc/channels.md:39
+msgid "// Here, all the messages are collected\n"
+msgstr "// ここで、全てのメッセージが収集されます。\n"
+
+#: src/std_misc/channels.md:42
+msgid ""
+"// The `recv` method picks a message from the channel\n"
+"        // `recv` will block the current thread if there are no messages "
+"available\n"
+msgstr ""
+"// `recv`メソッドはチャネルからメッセージを取り出します。\n"
+"        // もし取り出せるメッセージが存在しない場合、`recv`は\n"
+"        // 現在のスレッドをブロックします。\n"
+
+#: src/std_misc/channels.md:47
+msgid "// Wait for the threads to complete any remaining work\n"
+msgstr ""
+
+#: src/std_misc/channels.md:49
+msgid "\"oops! the child thread panicked\""
+msgstr "\"oops! the child thread panicked\""
+
+#: src/std_misc/channels.md:52
+msgid "// Show the order in which the messages were sent\n"
+msgstr "// メッセージが送信された順番を表示。\n"
+
+#: src/std_misc/path.md:3
+msgid ""
+"The `Path` struct represents file paths in the underlying filesystem. There "
+"are two flavors of `Path`: `posix::Path`, for UNIX-like systems, and "
+"`windows::Path`, for Windows. The prelude exports the appropriate platform-"
+"specific `Path` variant."
+msgstr ""
+"構造体`Path`は、ファイルシステム中のパスを表します。`Path`には2つの変種があります。"
+"UNIXライクなファイルシステムのための`posix::Path`と、Windows用の`windows::Path`です。"
+"それぞれプラットフォームに対応した`Path`をエクスポートします。"
+
+#: src/std_misc/path.md:8
+msgid ""
+"A `Path` can be created from an `OsStr`, and provides several methods to get "
+"information from the file/directory the path points to."
+msgstr ""
+"`Path`は`OsStr`から作ることができます。"
+"そうすればそのパスが指すファイル・ディレクトリの情報を取得するためのメソッドがいくつか使えるようになります。"
+
+#: src/std_misc/path.md:11
+msgid ""
+"A `Path` is immutable. The owned version of `Path` is `PathBuf`. The "
+"relation  between `Path` and `PathBuf` is similar to that of `str` and "
+"`String`:  a `PathBuf` can be mutated in-place, and can be dereferenced to a "
+"`Path`."
+msgstr ""
+"`Path`はイミュータブルです。`Path`の所有権ありのバージョンが`PathBuf`です。"
+"`Path`と`PathBuf`の関係は、`str`と`String`の関係に似ています。"
+"`PathBuf`はそのまま変更でき、`Path`にデリファレンスすることができます。"
+
+#: src/std_misc/path.md:15
+msgid ""
+"Note that a `Path` is _not_ internally represented as an UTF-8 string, but "
+"instead is stored as an `OsString`. Therefore, converting a `Path` to a "
+"`&str` is _not_ free and may fail (an `Option` is returned). However, a "
+"`Path` can be  freely converted to an `OsString` or `&OsStr` using "
+"`into_os_string` and `as_os_str`, respectively."
+msgstr ""
+"`Path`の実態はUTF-8の文字列 **ではなく** 、`OsString`であることに注意しましょう。"
+"したがって、`Path`を`&str`に変換するのは無条件 **ではなく** 、失敗する可能性があります。それゆえ`Option`型が返されます。"
+"しかし`Path`から`OsString`あるいは`&OsStr`への変換はそれぞれ`into_os_string`と`as_os_str`によって無条件でできます。"
+
+#: src/std_misc/path.md:25
+msgid "// Create a `Path` from an `&'static str`\n"
+msgstr "// `&'static str`から`Path`を作成。\n"
+
+#: src/std_misc/path.md:26
+msgid "\".\""
+msgstr "\".\""
+
+#: src/std_misc/path.md:28
+msgid "// The `display` method returns a `Display`able structure\n"
+msgstr "// `display`メソッドは`Display`可能な構造体を返します。\n"
+
+#: src/std_misc/path.md:31
+msgid ""
+"// `join` merges a path with a byte container using the OS specific\n"
+"    // separator, and returns a `PathBuf`\n"
+msgstr ""
+"// `join`はOS固有のセパレータによってバイトのコンテナ型であるパス\n"
+"    // を結合し、`PathBuf`を返します。\n"
+
+#: src/std_misc/path.md:35
+msgid "// `push` extends the `PathBuf` with a `&Path`\n"
+msgstr "// `push`は`PathBuf`を`&Path`で拡張します。\n"
+
+#: src/std_misc/path.md:37
+msgid "\"myfile.tar.gz\""
+msgstr "\"myfile.tar.gz\""
+
+#: src/std_misc/path.md:39
+msgid "// `set_file_name` updates the file name of the `PathBuf`\n"
+msgstr "// `set_file_name`は`PathBuf`のファイル名を更新します。\n"
+
+#: src/std_misc/path.md:40
+msgid "\"package.tgz\""
+msgstr "\"package.tgz\""
+
+#: src/std_misc/path.md:42
+msgid "// Convert the `PathBuf` into a string slice\n"
+msgstr "// `PathBuf`を文字列のスライスに変換します。\n"
+
+#: src/std_misc/path.md:44
+msgid "\"new path is not a valid UTF-8 sequence\""
+msgstr "\"new path is not a valid UTF-8 sequence\""
+
+#: src/std_misc/path.md:45
+msgid "\"new path is {}\""
+msgstr "\"new path is {}\""
+
+#: src/std_misc/path.md:51
+msgid ""
+"Be sure to check at other `Path` methods (`posix::Path` or `windows::Path`) "
+"and the `Metadata` struct."
+msgstr ""
+"他の`Path`メソッド（`posix::Path`と`windows::Path`）をチェックするのを忘れずに！"
+"それと`Metadata`構造体も見ておくことをオススメします。"
+
+#: src/std_misc/path.md:56
+msgid ""
+"[OsStr](https://doc.rust-lang.org/std/ffi/struct.OsStr.html) and [Metadata]"
+"(https://doc.rust-lang.org/std/fs/struct.Metadata.html)."
+msgstr ""
+"[OsStr](https://doc.rust-lang.org/std/ffi/struct.OsStr.html), [Metadata]"
+"(https://doc.rust-lang.org/std/fs/struct.Metadata.html)."
+
+#: src/std_misc/file.md:3
+msgid ""
+"The `File` struct represents a file that has been opened (it wraps a file "
+"descriptor), and gives read and/or write access to the underlying file."
+msgstr ""
+"`File`構造体は開かれたファイルを表し（実際にはファイルディスクリプタのラッパーです）、"
+"読み込み・書き込み権限のどちらか一方、あるいは両方を提供します。"
+
+#: src/std_misc/file.md:6
+msgid ""
+"Since many things can go wrong when doing file I/O, all the `File` methods "
+"return the `io::Result<T>` type, which is an alias for `Result<T, io::"
+"Error>`."
+msgstr ""
+
+#: src/std_misc/file.md:9
+msgid ""
+"This makes the failure of all I/O operations _explicit_. Thanks to this, the "
+"programmer can see all the failure paths, and is encouraged to handle them "
+"in a proactive manner."
+msgstr ""
+"これはI/Oに関するオペレーションの失敗をより明瞭にします。"
+"このおかげでプログラマは直面した失敗を全て見ることができ、より生産的な方法でそれらを扱うことが可能になります。"
+
+#: src/std_misc/file/open.md:3
+msgid "The `open` function can be used to open a file in read-only mode."
+msgstr "`open`関数を用いることで読み込み専用モードでファイルを開くことが可能です。"
+
+#: src/std_misc/file/open.md:5
+msgid ""
+"A `File` owns a resource, the file descriptor and takes care of closing the "
+"file when it is `drop`ed."
+msgstr ""
+"`File`はファイルディスクリプタという資源を保持しており、"
+"`drop`時にはファイルを閉じるところまで面倒を見てくれます。"
+
+#: src/std_misc/file/open.md:14
+msgid "// Create a path to the desired file\n"
+msgstr "// 目的ファイルに対する`Path`を作成\n"
+
+#: src/std_misc/file/open.md:15
+msgid "\"hello.txt\""
+msgstr "\"hello.txt\""
+
+#: src/std_misc/file/open.md:18
+msgid "// Open the path in read-only mode, returns `io::Result<File>`\n"
+msgstr "// pathを読み込み専用モードで開きます。これは`io::Result<File>`を返します。\n"
+
+#: src/std_misc/file/open.md:20
+msgid "\"couldn't open {}: {}\""
+msgstr "\"couldn't open {}: {}\""
+
+#: src/std_misc/file/open.md:24
+msgid "// Read the file contents into a string, returns `io::Result<usize>`\n"
+msgstr "// ファイルの中身を文字列に読み込みます。`io::Result<usize>`を返します。\n"
+
+#: src/std_misc/file/open.md:27
+msgid "\"couldn't read {}: {}\""
+msgstr "\"couldn't read {}: {}\""
+
+#: src/std_misc/file/open.md:28
+msgid "\"{} contains:\\n{}\""
+msgstr "\"{} contains:\\n{}\""
+
+#: src/std_misc/file/open.md:31
+msgid "// `file` goes out of scope, and the \"hello.txt\" file gets closed\n"
+msgstr "// `file`がスコープから抜け、\"hello.txt\"が閉じられます。\n"
+
+#: src/std_misc/file/open.md:35 src/std_misc/file/create.md:39
+#: src/std_misc/fs.md:109
+msgid "Here's the expected successful output:"
+msgstr "以下が成功時に期待されるアウトプットです。"
+
+#: src/std_misc/file/open.md:37
+msgid ""
+"```shell\n"
+"$ echo \"Hello World!\" > hello.txt\n"
+"$ rustc open.rs && ./open\n"
+"hello.txt contains:\n"
+"Hello World!\n"
+"```"
+msgstr ""
+"```shell\n"
+"$ echo \"Hello World!\" > hello.txt\n"
+"$ rustc open.rs && ./open\n"
+"hello.txt contains:\n"
+"Hello World!\n"
+"```"
+
+#: src/std_misc/file/open.md:44
+msgid ""
+"(You are encouraged to test the previous example under different failure "
+"conditions: `hello.txt` doesn't exist, or `hello.txt` is not readable, etc.)"
+msgstr ""
+"（気が向いたなら、上記の例を様々な形で失敗させてみましょう。"
+"例えば`hello.txt`が存在しないとか、読み込み権限がないとか、そういった状況で実行してみてください。）"
+
+#: src/std_misc/file/create.md:3
+msgid ""
+"The `create` function opens a file in write-only mode. If the file already "
+"existed, the old content is destroyed. Otherwise, a new file is created."
+msgstr ""
+"`create`関数はファイルを書き込み専用モードで開きます。"
+"すでにファイルが存在している場合、破棄して新しい物を作成します。"
+
+#: src/std_misc/file/create.md:9
+msgid ""
+"\"Lorem ipsum dolor sit amet, consectetur adipisicing elit, sed do eiusmod\n"
+"tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim "
+"veniam,\n"
+"quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo\n"
+"consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse\n"
+"cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat "
+"non\n"
+"proident, sunt in culpa qui officia deserunt mollit anim id est laborum.\n"
+"\""
+msgstr ""
+"\"Lorem ipsum dolor sit amet, consectetur adipisicing elit, sed do eiusmod\n"
+"tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim "
+"veniam,\n"
+"quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo\n"
+"consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse\n"
+"cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat "
+"non\n"
+"proident, sunt in culpa qui officia deserunt mollit anim id est laborum.\n"
+"\""
+
+#: src/std_misc/file/create.md:22
+msgid "\"lorem_ipsum.txt\""
+msgstr "\"lorem_ipsum.txt\""
+
+#: src/std_misc/file/create.md:25
+msgid "// Open a file in write-only mode, returns `io::Result<File>`\n"
+msgstr "// ファイルを書き込み専用モードで開きます。返り値は`io::Result<File>`。\n"
+
+#: src/std_misc/file/create.md:27
+msgid "\"couldn't create {}: {}\""
+msgstr "\"couldn't create {}: {}\""
+
+#: src/std_misc/file/create.md:31
+msgid "// Write the `LOREM_IPSUM` string to `file`, returns `io::Result<()>`\n"
+msgstr "// `LOREM_IPSUM`の文字列を`file`に書き込みます。返り値は`io::Result<()>`。\n"
+
+#: src/std_misc/file/create.md:33
+msgid "\"couldn't write to {}: {}\""
+msgstr "\"couldn't write to {}: {}\""
+
+#: src/std_misc/file/create.md:34
+msgid "\"successfully wrote to {}\""
+msgstr "\"successfully wrote to {}\""
+
+#: src/std_misc/file/create.md:53
+msgid ""
+"(As in the previous example, you are encouraged to test this example under "
+"failure conditions.)"
+msgstr "前項の例と同じように、様々な失敗パターンをためしてみることをオススメします。"
+
+#: src/std_misc/file/create.md:56
+msgid ""
+"The [`OpenOptions`](https://doc.rust-lang.org/std/fs/struct.OpenOptions."
+"html) struct can be used to configure how a file is opened."
+msgstr ""
+"[`OpenOptions`](https://doc.rust-lang.org/std/fs/struct.OpenOptions.html)"
+"構造体を利用して、ファイルの開き方を設定できます。"
+
+#: src/std_misc/file/read_lines.md:3
+msgid "A naive approach"
+msgstr "単純なやり方"
+
+#: src/std_misc/file/read_lines.md:5
+msgid ""
+"This might be a reasonable first attempt for a beginner's first "
+"implementation for reading lines from a file."
+msgstr ""
+"テキストファイルの行を読み込むのを、初心者が初めて実装した場合、"
+"以下のようになるでしょう。"
+
+#: src/std_misc/file/read_lines.md:22
+msgid ""
+"Since the method `lines()` returns an iterator over the lines in the file, "
+"we can also perform a map inline and collect the results, yielding a more "
+"concise and fluent expression."
+msgstr ""
+"`lines()`メソッドはファイルの各行のイテレータを返すので、"
+"インラインでマップを実行し結果を収集することもできます。"
+"そうすると、より簡潔で読みやすい表現となります。"
+
+#: src/std_misc/file/read_lines.md:31
+msgid "// panic on possible file-reading errors\n"
+msgstr "// ファイル読み込みエラーの場合はパニックします。\n"
+
+#: src/std_misc/file/read_lines.md:32
+msgid "// split the string into an iterator of string slices\n"
+msgstr "// 文字列のスライスのイテレータに分割します。\n"
+
+#: src/std_misc/file/read_lines.md:33
+msgid "// make each slice into a string\n"
+msgstr "// スライスを文字列に変換します。\n"
+
+#: src/std_misc/file/read_lines.md:34
+msgid "// gather them together into a vector\n"
+msgstr "// ベクタにまとめます。\n"
+
+#: src/std_misc/file/read_lines.md:38
+msgid ""
+"Note that in both examples above, we must convert the `&str` reference "
+"returned from `lines()` to the owned type `String`, using `.to_string()` and "
+"`String::from` respectively."
+msgstr ""
+"上の例では、`lines()`から返された`&str`を"
+"それぞれ`to_string()`と`String::from`を使って、"
+"所有権のある`String`型に変換しなければならない点に注意してください。"
+
+#: src/std_misc/file/read_lines.md:42
+msgid "A more efficient approach"
+msgstr "より効率的なやり方"
+
+#: src/std_misc/file/read_lines.md:44
+msgid ""
+"Here we pass ownership of the open `File` to a `BufReader` struct. "
+"`BufReader` uses an internal buffer to reduce intermediate allocations."
+msgstr ""
+"ここでは、開いた`File`の所有権を`BufReader`構造体に渡します。"
+"`BufReader`は内部的なバッファを使い、中間のメモリ割り当てを削減します。"
+
+#: src/std_misc/file/read_lines.md:47
+msgid ""
+"We also update `read_lines` to return an iterator instead of allocating new "
+"`String` objects in memory for each line."
+msgstr ""
+"`read_lines`を更新して、それぞれの行に対してメモリ上に新しい`String`オブジェクトを割り当てるのではなく、"
+"イテレータを返すようにします。"
+
+#: src/std_misc/file/read_lines.md:56
+msgid "// File hosts.txt must exist in the current path\n"
+msgstr "// hosts.txtファイルは現在のパスに存在しなければなりません。\n"
+
+#: src/std_misc/file/read_lines.md:57
+msgid "\"./hosts.txt\""
+msgstr "\"./hosts.txt\""
+
+#: src/std_misc/file/read_lines.md:58
+msgid "// Consumes the iterator, returns an (Optional) String\n"
+msgstr "// イテレータを消費し、Option型のStringを返します。\n"
+
+#: src/std_misc/file/read_lines.md:64
+msgid ""
+"// The output is wrapped in a Result to allow matching on errors.\n"
+"// Returns an Iterator to the Reader of the lines of the file.\n"
+msgstr ""
+"// 出力はResult型にラップされ、エラーをマッチできるようになります。\n"
+"// ファイルの各行のReaderへのイテレータを返します。\n"
+
+#: src/std_misc/file/read_lines.md:74
+msgid "Running this program simply prints the lines individually."
+msgstr "このプログラムを実行すると、単に各行を出力します。"
+
+#: src/std_misc/file/read_lines.md:75
+msgid ""
+"```shell\n"
+"$ echo -e \"127.0.0.1\\n192.168.0.1\\n\" > hosts.txt\n"
+"$ rustc read_lines.rs && ./read_lines\n"
+"127.0.0.1\n"
+"192.168.0.1\n"
+"```"
+msgstr ""
+"```shell\n"
+"$ echo -e \"127.0.0.1\\n192.168.0.1\\n\" > hosts.txt\n"
+"$ rustc read_lines.rs && ./read_lines\n"
+"127.0.0.1\n"
+"192.168.0.1\n"
+"```"
+
+#: src/std_misc/file/read_lines.md:82
+msgid ""
+"(Note that since `File::open` expects a generic `AsRef<Path>` as argument, "
+"we define our generic `read_lines()` method with the same generic "
+"constraint, using the `where` keyword.)"
+msgstr ""
+"`File::open`はジェネリックな`AsRef<Path>`を引数にとるので、"
+"ジェネリックな`read_lines`メソッドも、`where`キーワードを使って、同じジェネリックな制約を持たせています。"
+
+#: src/std_misc/file/read_lines.md:85
+msgid ""
+"This process is more efficient than creating a `String` in memory with all "
+"of the file's contents. This can especially cause performance issues when "
+"working with larger files."
+msgstr ""
+"この処理は、ファイルの中身全てをメモリ上の`String`にするよりも効率的です。"
+"メモリ上に`String`を作ると、より大きなファイルを取り扱う際に、パフォーマンスの問題につながります。"
+
+#: src/std_misc/process.md:3
+msgid ""
+"The `process::Output` struct represents the output of a finished child "
+"process, and the `process::Command` struct is a process builder."
+msgstr ""
+"`process::Output`構造体は終了したプロセスのアウトプットを表し、"
+"`process::Command`構造体はプロセスの作成を行います。"
+
+#: src/std_misc/process.md:10
+msgid "\"rustc\""
+msgstr "\"rustc\""
+
+#: src/std_misc/process.md:11
+msgid "\"--version\""
+msgstr "\"--version\""
+
+#: src/std_misc/process.md:13
+msgid "\"failed to execute process: {}\""
+msgstr "\"failed to execute process: {}\""
+
+#: src/std_misc/process.md:19
+msgid "\"rustc succeeded and stdout was:\\n{}\""
+msgstr "\"rustc succeeded and stdout was:\\n{}\""
+
+#: src/std_misc/process.md:23
+msgid "\"rustc failed and stderr was:\\n{}\""
+msgstr "\"rustc failed and stderr was:\\n{}\""
+
+#: src/std_misc/process.md:28
+msgid ""
+"(You are encouraged to try the previous example with an incorrect flag "
+"passed to `rustc`)"
+msgstr "（余裕があれば、上の例で`rustc`に不正なフラグを渡し、どうなるか見てみましょう）"
+
+#: src/std_misc/process/pipe.md:3
+msgid ""
+"The `std::Child` struct represents a running child process, and exposes the "
+"`stdin`, `stdout` and `stderr` handles for interaction with the underlying "
+"process via pipes."
+msgstr ""
+"`std::Child`構造体は実行中の子プロセスを表します。"
+"`stdin`、`stdout`、`stderr`を介して表面化のプロセスとのやり取りを仲介します。"
+
+#: src/std_misc/process/pipe.md:11
+msgid "\"the quick brown fox jumped over the lazy dog\\n\""
+msgstr "\"the quick brown fox jumped over the lazy dog\\n\""
+
+#: src/std_misc/process/pipe.md:15
+msgid "// Spawn the `wc` command\n"
+msgstr "// `wc`コマンドを起動します。\n"
+
+#: src/std_misc/process/pipe.md:16 src/std_misc/fs.md:12 src/std_misc/fs.md:73
+#: src/std_misc/ffi.md:11
+msgid "\"windows\""
+msgstr "\"windows\""
+
+#: src/std_misc/process/pipe.md:17
+msgid "\"powershell\""
+msgstr "\"powershell\""
+
+#: src/std_misc/process/pipe.md:18
+msgid "\"-Command\""
+msgstr "\"-Command\""
+
+#: src/std_misc/process/pipe.md:18
+msgid "\"$input | Measure-Object -Line -Word -Character\""
+msgstr "\"$input | Measure-Object -Line -Word -Character\""
+
+#: src/std_misc/process/pipe.md:21
+msgid "\"wc\""
+msgstr "\"wc\""
+
+#: src/std_misc/process/pipe.md:27
+msgid "\"couldn't spawn wc: {}\""
+msgstr "\"couldn't spawn wc: {}\""
+
+#: src/std_misc/process/pipe.md:31
+msgid ""
+"// Write a string to the `stdin` of `wc`.\n"
+"    //\n"
+"    // `stdin` has type `Option<ChildStdin>`, but since we know this "
+"instance\n"
+"    // must have one, we can directly `unwrap` it.\n"
+msgstr ""
+"// `wc`の`stdin`に文字列を書き込みます。\n"
+"    //\n"
+"    // `stdin`は`Option<ChildStdin>`型を持ちますが、今回は値を持っていることが\n"
+"    // 確かなので、いきなり`unwrap`してしまって構いません。\n"
+
+#: src/std_misc/process/pipe.md:36
+msgid "\"couldn't write to wc stdin: {}\""
+msgstr "\"couldn't write to wc stdin: {}\""
+
+#: src/std_misc/process/pipe.md:37
+msgid "\"sent pangram to wc\""
+msgstr "\"sent pangram to wc\""
+
+#: src/std_misc/process/pipe.md:40
+msgid ""
+"// Because `stdin` does not live after the above calls, it is `drop`ed,\n"
+"    // and the pipe is closed.\n"
+"    //\n"
+"    // This is very important, otherwise `wc` wouldn't start processing the\n"
+"    // input we just sent.\n"
+msgstr ""
+"// `stdin`は上のプロセスコールのあとには有効でないので、`drop`され、\n"
+"    // パイプはcloseされます。\n"
+"    //\n"
+"    // これは非常に重要です。というのもcloseしないと`wc`は\n"
+"    // 送った値の処理を開始しないからです。\n"
+
+#: src/std_misc/process/pipe.md:46
+msgid ""
+"// The `stdout` field also has type `Option<ChildStdout>` so must be "
+"unwrapped.\n"
+msgstr "// `stdout`フィールドも`Option<ChildStdout>`型なのでアンラップする必要があります\n"
+
+#: src/std_misc/process/pipe.md:49
+msgid "\"couldn't read wc stdout: {}\""
+msgstr "\"couldn't read wc stdout: {}\""
+
+#: src/std_misc/process/pipe.md:50
+msgid "\"wc responded with:\\n{}\""
+msgstr "\"wc responded with:\\n{}\""
+
+#: src/std_misc/process/wait.md:3
+msgid ""
+"If you'd like to wait for a `process::Child` to finish, you must call "
+"`Child::wait`, which will return a `process::ExitStatus`."
+msgstr ""
+"`process::Child`が終了するのを待ちたい場合は、"
+"`process::ExitStatus`を返す`Child::wait`を呼び出さなくてはなりません。"
+
+#: src/std_misc/process/wait.md:10
+msgid "\"sleep\""
+msgstr "\"sleep\""
+
+#: src/std_misc/process/wait.md:13
+msgid "\"reached end of main\""
+msgstr "\"reached end of main\""
+
+#: src/std_misc/process/wait.md:18
+msgid ""
+"# `wait` keeps running for 5 seconds until the `sleep 5` command finishes\n"
+msgstr "# `wait`は`sleep 5`コマンドが終了するまで5秒間実行され続けます。\n"
+
+#: src/std_misc/fs.md:3
+msgid ""
+"The `std::fs` module contains several functions that deal with the "
+"filesystem."
+msgstr ""
+"`std::fs`モジュールはファイルシステムとやり取りするための関数をいくつか持っています。"
+
+#: src/std_misc/fs.md:10 src/std_misc/fs.md:68 src/std_misc/ffi.md:20
+msgid "\"unix\""
+msgstr "\"unix\""
+
+#: src/std_misc/fs.md:15
+msgid "// A simple implementation of `% cat path`\n"
+msgstr "// `% cat path`のシンプルな実装\n"
+
+#: src/std_misc/fs.md:25
+msgid "// A simple implementation of `% echo s > path`\n"
+msgstr "// `% echo s > path`の簡単な実装\n"
+
+#: src/std_misc/fs.md:32
+msgid "// A simple implementation of `% touch path` (ignores existing files)\n"
+msgstr "// `% touch path`の簡単な実装（すでにファイルが存在しても無視します。）\n"
+
+#: src/std_misc/fs.md:42
+msgid "\"`mkdir a`\""
+msgstr "\"`mkdir a`\""
+
+#: src/std_misc/fs.md:43
+msgid "// Create a directory, returns `io::Result<()>`\n"
+msgstr "// ディレクトリを作成します。返り値は`io::Result<()>`。\n"
+
+#: src/std_misc/fs.md:45 src/std_misc/fs.md:52 src/std_misc/fs.md:58
+#: src/std_misc/fs.md:63 src/std_misc/fs.md:70 src/std_misc/fs.md:75
+#: src/std_misc/fs.md:81 src/std_misc/fs.md:88 src/std_misc/fs.md:97
+#: src/std_misc/fs.md:103
+msgid "\"! {:?}\""
+msgstr "\"! {:?}\""
+
+#: src/std_misc/fs.md:49
+msgid "\"`echo hello > a/b.txt`\""
+msgstr "\"`echo hello > a/b.txt`\""
+
+#: src/std_misc/fs.md:50
+msgid ""
+"// The previous match can be simplified using the `unwrap_or_else` method\n"
+msgstr "// 上のmatchは`unwrap_or_else`をメソッドを用いて簡略化できます。\n"
+
+#: src/std_misc/fs.md:51
+msgid "\"a/b.txt\""
+msgstr "\"a/b.txt\""
+
+#: src/std_misc/fs.md:55
+msgid "\"`mkdir -p a/c/d`\""
+msgstr "\"`mkdir -p a/c/d`\""
+
+#: src/std_misc/fs.md:56
+msgid "// Recursively create a directory, returns `io::Result<()>`\n"
+msgstr "// 再帰的にディレクトリを作成します。返り値は`io::Result<()>`。\n"
+
+#: src/std_misc/fs.md:57 src/std_misc/fs.md:102
+msgid "\"a/c/d\""
+msgstr "\"a/c/d\""
+
+#: src/std_misc/fs.md:61
+msgid "\"`touch a/c/e.txt`\""
+msgstr "\"`touch a/c/e.txt`\""
+
+#: src/std_misc/fs.md:62 src/std_misc/fs.md:96
+msgid "\"a/c/e.txt\""
+msgstr "\"a/c/e.txt\""
+
+#: src/std_misc/fs.md:66
+msgid "\"`ln -s ../b.txt a/c/b.txt`\""
+msgstr "\"`ln -s ../b.txt a/c/b.txt`\""
+
+#: src/std_misc/fs.md:67
+msgid "// Create a symbolic link, returns `io::Result<()>`\n"
+msgstr "// シンボリックリンクを作成、返り値は`io::Result<()>`。\n"
+
+#: src/std_misc/fs.md:69 src/std_misc/fs.md:74
+msgid "\"../b.txt\""
+msgstr "\"../b.txt\""
+
+#: src/std_misc/fs.md:69 src/std_misc/fs.md:74 src/std_misc/fs.md:80
+msgid "\"a/c/b.txt\""
+msgstr "\"a/c/b.txt\""
+
+#: src/std_misc/fs.md:79
+msgid "\"`cat a/c/b.txt`\""
+msgstr "\"`cat a/c/b.txt`\""
+
+#: src/std_misc/fs.md:85
+msgid "\"`ls a`\""
+msgstr "\"`ls a`\""
+
+#: src/std_misc/fs.md:86
+msgid "// Read the contents of a directory, returns `io::Result<Vec<Path>>`\n"
+msgstr "// ディレクトリの内容を読み込みます。返り値は`io::Result<Vec<Path>>`。\n"
+
+#: src/std_misc/fs.md:94
+msgid "\"`rm a/c/e.txt`\""
+msgstr "\"`rm a/c/e.txt`\""
+
+#: src/std_misc/fs.md:95
+msgid "// Remove a file, returns `io::Result<()>`\n"
+msgstr "// ファイルを削除。返り値は`io::Result<()>`。\n"
+
+#: src/std_misc/fs.md:100
+msgid "\"`rmdir a/c/d`\""
+msgstr "\"`rmdir a/c/d`\""
+
+#: src/std_misc/fs.md:101
+msgid "// Remove an empty directory, returns `io::Result<()>`\n"
+msgstr "// 空のディレクトリを削除。返り値は`io::Result<()>`。\n"
+
+#: src/std_misc/fs.md:111
+msgid ""
+"```shell\n"
+"$ rustc fs.rs && ./fs\n"
+"`mkdir a`\n"
+"`echo hello > a/b.txt`\n"
+"`mkdir -p a/c/d`\n"
+"`touch a/c/e.txt`\n"
+"`ln -s ../b.txt a/c/b.txt`\n"
+"`cat a/c/b.txt`\n"
+"> hello\n"
+"`ls a`\n"
+"> \"a/b.txt\"\n"
+"> \"a/c\"\n"
+"`rm a/c/e.txt`\n"
+"`rmdir a/c/d`\n"
+"```"
+msgstr ""
+"```shell\n"
+"$ rustc fs.rs && ./fs\n"
+"`mkdir a`\n"
+"`echo hello > a/b.txt`\n"
+"`mkdir -p a/c/d`\n"
+"`touch a/c/e.txt`\n"
+"`ln -s ../b.txt a/c/b.txt`\n"
+"`cat a/c/b.txt`\n"
+"> hello\n"
+"`ls a`\n"
+"> \"a/b.txt\"\n"
+"> \"a/c\"\n"
+"`rm a/c/e.txt`\n"
+"`rmdir a/c/d`\n"
+"```"
+
+#: src/std_misc/fs.md:127
+msgid "And the final state of the `a` directory is:"
+msgstr "最終的な`a`ディレクトリの状態は以下です。"
+
+#: src/std_misc/fs.md:139
+msgid "An alternative way to define the function `cat` is with `?` notation:"
+msgstr ""
+
+#: src/std_misc/fs.md:152
+msgid "[`cfg!`](../attribute/cfg.md)"
+msgstr "[`cfg!`](../attribute/cfg.md)"
+
+#: src/std_misc/arg.md:3
+msgid "Standard Library"
+msgstr "標準ライブラリ"
+
+#: src/std_misc/arg.md:5
+msgid ""
+"The command line arguments can be accessed using `std::env::args`, which "
+"returns an iterator that yields a `String` for each argument:"
+msgstr ""
+"コマンドライン引数は`std::env::args`を介して取得できます。"
+"これはそれぞれの引数を文字列として生成するイテレータを返します。"
+
+#: src/std_misc/arg.md:14
+msgid "// The first argument is the path that was used to call the program.\n"
+msgstr "// ひとつ目の引数はプログラムを呼び出す際に使用したパス。\n"
+
+#: src/std_misc/arg.md:15
+msgid "\"My path is {}.\""
+msgstr "\"My path is {}.\""
+
+#: src/std_misc/arg.md:17
+msgid ""
+"// The rest of the arguments are the passed command line parameters.\n"
+"    // Call the program like this:\n"
+"    //   $ ./args arg1 arg2\n"
+msgstr ""
+"// 残りはプログラムに渡されたコマンドラインパラメータ。\n"
+"    // プログラムはこんなふうに呼び出します。\n"
+"    //   $ ./args arg1 arg2\n"
+
+#: src/std_misc/arg.md:20
+msgid "\"I got {:?} arguments: {:?}.\""
+msgstr "\"I got {:?} arguments: {:?}.\""
+
+#: src/std_misc/arg.md:24
+msgid ""
+"```shell\n"
+"$ ./args 1 2 3\n"
+"My path is ./args.\n"
+"I got 3 arguments: [\"1\", \"2\", \"3\"].\n"
+"```"
+msgstr ""
+"```shell\n"
+"$ ./args 1 2 3\n"
+"My path is ./args.\n"
+"I got 3 arguments: [\"1\", \"2\", \"3\"].\n"
+"```"
+
+#: src/std_misc/arg.md:32
+msgid ""
+"Alternatively, there are numerous crates that can provide extra "
+"functionality when creating command-line applications. One of the more "
+"popular command line argument crates being [`clap`](https://rust-cli.github."
+"io/book/tutorial/cli-args.html#parsing-cli-arguments-with-clap)."
+msgstr ""
+
+#: src/std_misc/arg/matching.md:3
+msgid "Matching can be used to parse simple arguments:"
+msgstr "matchを用いて簡単な引数をパースできます。"
+
+#: src/std_misc/arg/matching.md:17
+msgid ""
+"\"usage:\n"
+"match_args <string>\n"
+"    Check whether given string is the answer.\n"
+"match_args {{increase|decrease}} <integer>\n"
+"    Increase or decrease given integer by one.\""
+msgstr ""
+"\"usage:\n"
+"match_args <string>\n"
+"    Check whether given string is the answer.\n"
+"match_args {{increase|decrease}} <integer>\n"
+"    Increase or decrease given integer by one.\""
+
+#: src/std_misc/arg/matching.md:28
+msgid "// no arguments passed\n"
+msgstr "// 引数がない場合\n"
+
+#: src/std_misc/arg/matching.md:30
+msgid "\"My name is 'match_args'. Try passing some arguments!\""
+msgstr "\"My name is 'match_args'. Try passing some arguments!\""
+
+#: src/std_misc/arg/matching.md:32
+msgid "// one argument passed\n"
+msgstr "// 引数が1つの場合\n"
+
+#: src/std_misc/arg/matching.md:35
+msgid "\"This is the answer!\""
+msgstr "\"This is the answer!\""
+
+#: src/std_misc/arg/matching.md:36
+msgid "\"This is not the answer.\""
+msgstr "\"This is not the answer.\""
+
+#: src/std_misc/arg/matching.md:39
+msgid "// one command and one argument passed\n"
+msgstr "// コマンドが一つと引数が一つの場合\n"
+
+#: src/std_misc/arg/matching.md:43
+msgid "// parse the number\n"
+msgstr "// 数字をパース。\n"
+
+#: src/std_misc/arg/matching.md:49
+msgid "\"error: second argument not an integer\""
+msgstr "\"error: second argument not an integer\""
+
+#: src/std_misc/arg/matching.md:54
+msgid "// parse the command\n"
+msgstr "// コマンドをパース。\n"
+
+#: src/std_misc/arg/matching.md:56
+msgid "\"increase\""
+msgstr "\"increase\""
+
+#: src/std_misc/arg/matching.md:57
+msgid "\"decrease\""
+msgstr "\"decrease\""
+
+#: src/std_misc/arg/matching.md:59
+msgid "\"error: invalid command\""
+msgstr "\"error: invalid command\""
+
+#: src/std_misc/arg/matching.md:64
+msgid "// all the other cases\n"
+msgstr "// その他の場合\n"
+
+#: src/std_misc/arg/matching.md:66
+msgid "// show a help message\n"
+msgstr "// ヘルプメッセージを表示。\n"
+
+#: src/std_misc/arg/matching.md:73
+msgid ""
+"If you named your program `match_args.rs` and compile it like this `rustc "
+"match_args.rs`, you can execute it as follows:"
+msgstr ""
+
+#: src/std_misc/ffi.md:3
+msgid ""
+"Rust provides a Foreign Function Interface (FFI) to C libraries. Foreign "
+"functions must be declared inside an `extern` block annotated with a "
+"`#[link]` attribute containing the name of the foreign library."
+msgstr ""
+"RustはCのライブラリを呼び出すために他言語関数インターフェイス（Foreign Function Interface, FFI）を持っています。"
+"他言語の関数を使用する際には、そのライブラリ名を`#[link]`アトリビュートに渡し、"
+"更にそれでアノテーションされた`extern`ブロック内で宣言する必要があります。"
+
+#: src/std_misc/ffi.md:9
+msgid "// this extern block links to the libm library\n"
+msgstr "// このexternブロックはlibmライブラリをリンクします。\n"
+
+#: src/std_misc/ffi.md:12
+msgid "\"msvcrt\""
+msgstr "\"msvcrt\""
+
+#: src/std_misc/ffi.md:14 src/std_misc/ffi.md:23
+msgid ""
+"// this is a foreign function\n"
+"    // that computes the square root of a single precision complex number\n"
+msgstr ""
+"// 他言語の関数宣言。\n"
+"    // この関数は単精度浮動小数の複素数型の平方根を計算するためのものです。\n"
+
+#: src/std_misc/ffi.md:21
+msgid "\"m\""
+msgstr "\"m\""
+
+#: src/std_misc/ffi.md:29
+msgid ""
+"// Since calling foreign functions is considered unsafe,\n"
+"// it's common to write safe wrappers around them.\n"
+msgstr "// 型安全にするためのラッパ\n"
+
+#: src/std_misc/ffi.md:37
+msgid "// z = -1 + 0i\n"
+msgstr "// z = -1 + 0i\n"
+
+#: src/std_misc/ffi.md:40
+msgid "// calling a foreign function is an unsafe operation\n"
+msgstr ""
+
+#: src/std_misc/ffi.md:43
+msgid "\"the square root of {:?} is {:?}\""
+msgstr "\"the square root of {:?} is {:?}\""
+
+#: src/std_misc/ffi.md:45
+msgid "// calling safe API wrapped around unsafe operation\n"
+msgstr ""
+
+#: src/std_misc/ffi.md:46
+msgid "\"cos({:?}) = {:?}\""
+msgstr "\"cos({:?}) = {:?}\""
+
+#: src/std_misc/ffi.md:48
+msgid "// Minimal implementation of single precision complex numbers\n"
+msgstr "// 単精度浮動小数の複素数型の最小限の実装\n"
+
+#: src/std_misc/ffi.md:60
+msgid "\"{}-{}i\""
+msgstr "\"{}-{}i\""
+
+#: src/std_misc/ffi.md:62
+msgid "\"{}+{}i\""
+msgstr "\"{}+{}i\""
+
+#: src/testing.md:3
+msgid ""
+"Rust is a programming language that cares a lot about correctness and it "
+"includes support for writing software tests within the language itself."
+msgstr ""
+"Rustはとても正確性を配慮したプログラミング言語であり、"
+"ソフトウェアテストを書くためのサポートを言語自身が含んでいます。"
+
+#: src/testing.md:6
+msgid "Testing comes in three styles:"
+msgstr "テストには3つの種類があります。"
+
+#: src/testing.md:8
+msgid "[Unit](testing/unit_testing.md) testing."
+msgstr "[単体テスト](testing/unit_testing.md)"
+
+#: src/testing.md:9
+msgid "[Doc](testing/doc_testing.md) testing."
+msgstr "[ドキュメンテーションテスト](testing/doc_testing.md)"
+
+#: src/testing.md:10
+msgid "[Integration](testing/integration_testing.md) testing."
+msgstr "[結合テスト](testing/integration_testing.md)"
+
+#: src/testing.md:12
+msgid "Also Rust has support for specifying additional dependencies for tests:"
+msgstr "またRustではテストのために追加の依存パッケージを指定することもできます。"
+
+#: src/testing.md:14
+msgid "[Dev-dependencies](testing/dev_dependencies.md)"
+msgstr ""
+
+#: src/testing.md:18
+msgid ""
+"[The Book](https://doc.rust-lang.org/book/ch11-00-testing.html) chapter on "
+"testing"
+msgstr "[The Book](https://doc.rust-lang.org/book/ch11-00-testing.html) のテストの章"
+
+#: src/testing.md:19
+msgid ""
+"[API Guidelines](https://rust-lang-nursery.github.io/api-guidelines/"
+"documentation.html) on doc-testing"
+msgstr ""
+
+#: src/testing/unit_testing.md:3
+msgid ""
+"Tests are Rust functions that verify that the non-test code is functioning "
+"in the expected manner. The bodies of test functions typically perform some "
+"setup, run the code we want to test, then assert whether the results are "
+"what we expect."
+msgstr ""
+"テストは、テスト以外のコードが想定通りに動いているかを確かめるRustの関数です。"
+"一般にテスト関数は、準備をしてからテストしたいコードを実行し、そしてその結果が期待したものであるか確認します。"
+
+#: src/testing/unit_testing.md:8
+msgid ""
+"Most unit tests go into a `tests` [mod](../mod.md) with the `#[cfg(test)]` "
+"[attribute](../attribute.md). Test functions are marked with the `#[test]` "
+"attribute."
+msgstr ""
+"大抵の場合ユニットテストは`#[cfg(test)]`[アトリビュート](../attribute.md)"
+"を付けた`tests`[モジュール](../mod.md)に配置されます。"
+"テスト関数には`#[test]`アトリビュートを付与します。"
+
+#: src/testing/unit_testing.md:11
+msgid ""
+"Tests fail when something in the test function [panics](../std/panic.md). "
+"There are some helper [macros](../macros.md):"
+msgstr ""
+"テスト関数内部で[パニック](../std/panic.md)するとテストは失敗となります。"
+"次のような[マクロ](../macros.md)が用意されています。"
+
+#: src/testing/unit_testing.md:14
+msgid "`assert!(expression)` - panics if expression evaluates to `false`."
+msgstr "`assert!(expression)` - 式を評価した結果が`false`であればパニックします。"
+
+#: src/testing/unit_testing.md:15
+msgid ""
+"`assert_eq!(left, right)` and `assert_ne!(left, right)` - testing left and "
+"right expressions for equality and inequality respectively."
+msgstr "`assert_eq!(left, right)`と`assert_ne!(left, right)` - 左右の式を評価した結果が、それぞれ等しくなること、ならないことをテストします。"
+
+#: src/testing/unit_testing.md:22
+msgid ""
+"// This is a really bad adding function, its purpose is to fail in this\n"
+"// example.\n"
+msgstr "// 誤った加算をする関数がテストに通らないことを示します。\n"
+
+#: src/testing/unit_testing.md:32
+msgid ""
+"// Note this useful idiom: importing names from outer (for mod tests) "
+"scope.\n"
+msgstr "// 外部のスコープから（mod testsに）名前をインポートする便利なイディオム。\n"
+
+#: src/testing/unit_testing.md:42
+msgid ""
+"// This assert would fire and test will fail.\n"
+"        // Please note, that private functions can be tested too!\n"
+msgstr ""
+"// このアサーションはパニックして、テストは失敗します。\n"
+"        // プライベートな関数もテストすることができます。\n"
+
+#: src/testing/unit_testing.md:49
+msgid "Tests can be run with `cargo test`."
+msgstr "`cargo test`でテストを実行できます。"
+
+#: src/testing/unit_testing.md:73
+msgid "Tests and `?`"
+msgstr "テストと`?`"
+
+#: src/testing/unit_testing.md:74
+msgid ""
+"None of the previous unit test examples had a return type. But in Rust 2018, "
+"your unit tests can return `Result<()>`, which lets you use `?` in them! "
+"This can make them much more concise."
+msgstr ""
+"ここまでに例示したユニットテストは返り値の型を持っていませんでしたが、"
+"Rust 2018ではユニットテストが`Result<()>`を返し、内部で`?`を使えるようになりました！"
+"これにより、ユニットテストをさらに簡潔に記述できます。"
+
+#: src/testing/unit_testing.md:83
+msgid "\"negative floats don't have square roots\""
+msgstr "\"negative floats don't have square roots\""
+
+#: src/testing/unit_testing.md:100
+msgid ""
+"See [\"The Edition Guide\"](https://doc.rust-lang.org/edition-guide/"
+"rust-2018/error-handling-and-panics/question-mark-in-main-and-tests.html) "
+"for more details."
+msgstr ""
+"詳細は[エディションガイド](https://doc.rust-lang.org/edition-guide/rust-2018/error-handling-and-panics/question-mark-in-main-and-tests.html)"
+"を参照してください。"
+
+#: src/testing/unit_testing.md:102
+msgid "Testing panics"
+msgstr "パニックをテストする"
+
+#: src/testing/unit_testing.md:104
+msgid ""
+"To check functions that should panic under certain circumstances, use "
+"attribute `#[should_panic]`. This attribute accepts optional parameter "
+"`expected = ` with the text of the panic message. If your function can panic "
+"in multiple ways, it helps make sure your test is testing the correct panic."
+msgstr ""
+"ある条件下でパニックすべき関数をテストするには、`#[should_panic]`アトリビュートを使います。"
+"このアトリビュートはパニックメッセージをオプションの引数`expected =`で受け取れます。"
+"パニックの原因が複数あるときに、想定した原因でパニックが発生したことを確認できます。"
+
+#: src/testing/unit_testing.md:112 src/testing/doc_testing.md:45
+msgid "\"Divide-by-zero error\""
+msgstr "\"Divide-by-zero error\""
+
+#: src/testing/unit_testing.md:114 src/testing/unit_testing.md:135
+msgid "\"Divide result is zero\""
+msgstr "\"Divide result is zero\""
+
+#: src/testing/unit_testing.md:142
+msgid "Running these tests gives us:"
+msgstr "テストを実行すると、次の結果を得られます。"
+
+#: src/testing/unit_testing.md:161
+msgid "Running specific tests"
+msgstr "実行するテストを指定する"
+
+#: src/testing/unit_testing.md:163
+msgid ""
+"To run specific tests one may specify the test name to `cargo test` command."
+msgstr "`cargo test`にテストの名前を与えると、そのテストだけが実行されます。"
+
+#: src/testing/unit_testing.md:179
+msgid ""
+"To run multiple tests one may specify part of a test name that matches all "
+"the tests that should be run."
+msgstr "テスト名の一部を指定すると、それにマッチするすべてのテストが実行されます。"
+
+#: src/testing/unit_testing.md:197
+msgid "Ignoring tests"
+msgstr "テストを除外する"
+
+#: src/testing/unit_testing.md:199
+msgid ""
+"Tests can be marked with the `#[ignore]` attribute to exclude some tests. Or "
+"to run them with command `cargo test -- --ignored`"
+msgstr ""
+"テストを実行から除外するには、`#[ignore]`アトリビュートを使います。"
+"また、`cargo test -- --ignored`で、除外したテストのみを実行できます。"
+
+#: src/testing/doc_testing.md:3
+msgid ""
+"The primary way of documenting a Rust project is through annotating the "
+"source code. Documentation comments are written in  [CommonMark Markdown "
+"specification](https://commonmark.org/) and support code blocks in them. "
+"Rust takes care about correctness, so these code blocks are compiled and "
+"used  as documentation tests."
+msgstr ""
+"Rustのプロジェクトでは、ソースコードに注釈する形でドキュメントを書くのが主流です。"
+"ドキュメンテーションコメントの記述は[CommonMark Markdown specification](https://commonmark.org/)"
+"で行い、コードブロックも使えます。"
+"Rustは正確性を重視しているので、コードブロックもコンパイルされ、テストとして使われます。"
+
+#: src/testing/doc_testing.md:10
+msgid ""
+"/// First line is a short summary describing function.\n"
+"///\n"
+"/// The next lines present detailed documentation. Code blocks start with\n"
+"/// triple backquotes and have implicit `fn main()` inside\n"
+"/// and `extern crate <cratename>`. Assume we're testing `doccomments` "
+"crate:\n"
+"///\n"
+"/// ```\n"
+"/// let result = doccomments::add(2, 3);\n"
+"/// assert_eq!(result, 5);\n"
+"/// ```\n"
+msgstr ""
+"/// 最初の行には関数の機能の短い要約を書きます。\n"
+"///\n"
+"/// 以降で詳細なドキュメンテーションを記述します。コードブロックは三重のバッククォートで始まり、\n"
+"/// 暗黙的に`fn main()`と`extern crate <クレート名>`で囲われます。\n"
+"/// `doccomments`クレートをテストしたいときには、次のように記述します。\n"
+"///\n"
+"/// ```\n"
+"/// let result = doccomments::add(2, 3);\n"
+"/// assert_eq!(result, 5);\n"
+"/// ```\n"
+
+#: src/testing/doc_testing.md:23
+msgid ""
+"/// Usually doc comments may include sections \"Examples\", \"Panics\" and "
+"\"Failures\".\n"
+"///\n"
+"/// The next function divides two numbers.\n"
+"///\n"
+"/// # Examples\n"
+"///\n"
+"/// ```\n"
+"/// let result = doccomments::div(10, 2);\n"
+"/// assert_eq!(result, 5);\n"
+"/// ```\n"
+"///\n"
+"/// # Panics\n"
+"///\n"
+"/// The function panics if the second argument is zero.\n"
+"///\n"
+"/// ```rust,should_panic\n"
+"/// // panics on division by zero\n"
+"/// doccomments::div(10, 0);\n"
+"/// ```\n"
+msgstr ""
+"/// 一般的に、ドキュメンテーションコメントは\n"
+"/// \"Examples\", \"Panics\", \"Failures\" という章から成ります。\n"
+"///\n"
+"/// 次の関数は除算を実行します。\n"
+"///\n"
+"/// # Examples\n"
+"///\n"
+"/// ```\n"
+"/// let result = doccomments::div(10, 2);\n"
+"/// assert_eq!(result, 5);\n"
+"/// ```\n"
+"///\n"
+"/// # Panics\n"
+"///\n"
+"/// 第2引数がゼロであればパニックします。\n"
+"///\n"
+"/// ```rust,should_panic\n"
+"/// // ゼロで除算するとパニックします\n"
+"/// doccomments::div(10, 0);\n"
+"/// ```\n"
+
+#: src/testing/doc_testing.md:52
+msgid ""
+"Code blocks in documentation are automatically tested when running the "
+"regular `cargo test` command:"
+msgstr ""
+"ドキュメンテーションコメント中のコードブロックは、`cargo test`コマンドで自動的にテストされます。"
+
+#: src/testing/doc_testing.md:71
+msgid "Motivation behind documentation tests"
+msgstr "ドキュメンテーションテストの目的"
+
+#: src/testing/doc_testing.md:73
+msgid ""
+"The main purpose of documentation tests is to serve as examples that "
+"exercise the functionality, which is one of the most important [guidelines]"
+"(https://rust-lang-nursery.github.io/api-guidelines/documentation."
+"html#examples-use--not-try-not-unwrap-c-question-mark). It allows using "
+"examples from docs as complete code snippets. But using `?` makes "
+"compilation fail since `main` returns `unit`. The ability to hide some "
+"source lines from documentation comes to the rescue: one may write `fn "
+"try_main() -> Result<(), ErrorType>`, hide it and `unwrap` it in hidden "
+"`main`. Sounds complicated? Here's an example:"
+msgstr ""
+"ドキュメンテーションテストの主な目的は、実行例を示すことであり、"
+"これは最も大切な[ガイドライン](https://rust-lang-nursery.github.io/api-guidelines/documentation.html#examples-use--not-try-not-unwrap-c-question-mark)"
+"の一つにもなっています。これにより、ドキュメントの例を実際に動くコードとして使うことができます。"
+"しかしながら、`main`が`()`を返すために、`?`を使うとコンパイルに失敗してしまいます。"
+"ドキュメンテーションでコードブロックの一部を隠す機能で、この問題に対処できます。"
+"つまり、`fn try_main() -> Result<(), ErrorType>`を定義しておきながらそれを隠し、"
+"暗黙の`main`の内部で`unwrap`するのです。複雑なので、例を見てみましょう。"
+
+#: src/testing/doc_testing.md:82
+msgid ""
+"/// Using hidden `try_main` in doc tests.\n"
+"///\n"
+"/// ```\n"
+"/// # // hidden lines start with `#` symbol, but they're still compilable!\n"
+"/// # fn try_main() -> Result<(), String> { // line that wraps the body "
+"shown in doc\n"
+"/// let res = doccomments::try_div(10, 2)?;\n"
+"/// # Ok(()) // returning from try_main\n"
+"/// # }\n"
+"/// # fn main() { // starting main that'll unwrap()\n"
+"/// #    try_main().unwrap(); // calling try_main and unwrapping\n"
+"/// #                         // so that test will panic in case of error\n"
+"/// # }\n"
+"/// ```\n"
+msgstr ""
+"/// ドキュメンテーションテストで、`try_main`を隠して使います。\n"
+"///\n"
+"/// ```\n"
+"/// # // 行頭に `#` を置くと行が隠されるが、コンパイルには成功します。\n"
+"/// # fn try_main() -> Result<(), String> { // ドキュメントの本体を囲う行\n"
+"/// let res = doccomments::try_div(10, 2)?;\n"
+"/// # Ok(()) // try_mainから値を返します\n"
+"/// # }\n"
+"/// # fn main() { // unwrap()を実行します。\n"
+"/// #    try_main().unwrap(); // try_mainを呼びunwrapすると、エラーの場合にパニックします。\n"
+"/// # }\n"
+"/// ```\n"
+
+#: src/testing/doc_testing.md:97
+msgid "\"Divide-by-zero\""
+msgstr "\"Divide-by-zero\""
+
+#: src/testing/doc_testing.md:106
+msgid ""
+"[RFC505](https://github.com/rust-lang/rfcs/blob/master/text/0505-api-comment-"
+"conventions.md) on documentation style"
+msgstr ""
+"[RFC505](https://github.com/rust-lang/rfcs/blob/master/text/0505-api-comment-"
+"conventions.md) ドキュメンテーションのスタイルについて"
+
+#: src/testing/doc_testing.md:107
+msgid ""
+"[API Guidelines](https://rust-lang-nursery.github.io/api-guidelines/"
+"documentation.html) on documentation guidelines"
+msgstr ""
+"[API Guidelines](https://rust-lang-nursery.github.io/api-guidelines/"
+"documentation.html) ドキュメンテーションのガイドラインについて"
+
+#: src/testing/integration_testing.md:3
+msgid ""
+"[Unit tests](unit_testing.md) are testing one module in isolation at a time: "
+"they're small and can test private code. Integration tests are external to "
+"your crate and use only its public interface in the same way any other code "
+"would. Their purpose is to test that many parts of your library work "
+"correctly together."
+msgstr ""
+"[ユニットテスト](unit_testing.md)は、独立したモジュールを一つずつテストするものであり、"
+"テストは小さく、プライベートなコードについてもテストすることができます。"
+"統合テストはクレートの外側にあるもので、他の外部のコードと同様に、"
+"パブリックなインタフェースだけを使います。"
+"統合テストの目的は、ライブラリのそれぞれのモジュールが連携して正しく動作するかどうかテストすることです。"
+
+#: src/testing/integration_testing.md:8
+msgid "Cargo looks for integration tests in `tests` directory next to `src`."
+msgstr "Cargoは、`src`ディレクトリと並んで配置された`tests`ディレクトリを統合テストとして扱います。"
+
+#: src/testing/integration_testing.md:10 src/testing/dev_dependencies.md:17
+msgid "File `src/lib.rs`:"
+msgstr "ファイル`src/lib.rs`："
+
+#: src/testing/integration_testing.md:13
+msgid "// Define this in a crate called `adder`.\n"
+msgstr "// `adder`という名前のクレートの内部で、次の関数を定義します。\n"
+
+#: src/testing/integration_testing.md:19
+msgid "File with test: `tests/integration_test.rs`:"
+msgstr "テストを含むファイル`tests/integration_test.rs`："
+
+#: src/testing/integration_testing.md:28
+msgid "Running tests with `cargo test` command:"
+msgstr "`cargo test`コマンドでテストを実行します。"
+
+#: src/testing/integration_testing.md:50
+msgid ""
+"Each Rust source file in the `tests` directory is compiled as a separate "
+"crate. In order to share some code between integration tests we can make a "
+"module with public functions, importing and using it within tests."
+msgstr ""
+"`tests`ディレクトリにあるRustのソースファイルは別のクレートとしてコンパイルされます。"
+"統合テストの間でコードを共有するには、パブリックな関数をモジュールに入れて、"
+"それぞれのテストでインポートして利用する方法があります。"
+
+#: src/testing/integration_testing.md:54
+msgid "File `tests/common/mod.rs`:"
+msgstr "ファイル`tests/common.rs`："
+
+#: src/testing/integration_testing.md:58
+msgid ""
+"// some setup code, like creating required files/directories, starting\n"
+"    // servers, etc.\n"
+msgstr "// 必要なファイル・ディレクトリの作成やサーバの起動といった準備を行うコードを記述します。\n"
+
+#: src/testing/integration_testing.md:63
+msgid "File with test: `tests/integration_test.rs`"
+msgstr "テストを含むファイル`tests/integration_test.rs`："
+
+#: src/testing/integration_testing.md:66
+msgid "// importing common module.\n"
+msgstr "// 共通のモジュールをインポートします。\n"
+
+#: src/testing/integration_testing.md:71
+msgid "// using common code.\n"
+msgstr "// 共通のコードを利用します。\n"
+
+#: src/testing/integration_testing.md:77
+msgid ""
+"Creating the module as `tests/common.rs` also works, but is not recommended "
+"because the test runner will treat the file as a test crate and try to run "
+"tests inside it."
+msgstr ""
+"モジュールを`tests/common.rs`に記述することも可能ですが、"
+"`tests/common.rs`中のテストも自動的に実行されてしまうため非推奨です。"
+
+#: src/testing/dev_dependencies.md:1
+msgid "Development dependencies"
+msgstr "開発中の依存関係"
+
+#: src/testing/dev_dependencies.md:3
+msgid ""
+"Sometimes there is a need to have dependencies for tests (or examples, or "
+"benchmarks) only. Such dependencies are added to `Cargo.toml` in the `[dev-"
+"dependencies]` section. These dependencies are not propagated to other "
+"packages which depend on this package."
+msgstr ""
+"テスト（あるいは例やベンチマーク）のためだけに、あるクレートに依存しなければならないことがあります。"
+"このような依存関係は、`Cargo.toml`の`[dev-dependencies]`セクションに追加します。"
+"このセクションに追加した依存関係は、このパッケージに依存するパッケージには適用されません。"
+
+#: src/testing/dev_dependencies.md:8
+msgid ""
+"One such example is [`pretty_assertions`](https://docs.rs/"
+"pretty_assertions/1.0.0/pretty_assertions/index.html), which extends "
+"standard `assert_eq!` and `assert_ne!` macros, to provide colorful diff.  \n"
+"File `Cargo.toml`:"
+msgstr ""
+"そのようなクレートの例として、[`pretty_assertions`](https://docs.rs/pretty_assertions/1.0.0/pretty_assertions/index.html)"
+"クレートが挙げられます。"
+"これは、標準の`assert_eq!`と`assert_ne!`マクロを拡張して、差分をカラフルに表示するものです。  \n"
+"ファイル`Cargo.toml`："
+
+#: src/testing/dev_dependencies.md:11
+msgid ""
+"```toml\n"
+"# standard crate data is left out\n"
+"[dev-dependencies]\n"
+"pretty_assertions = \"1\"\n"
+"```"
+msgstr ""
+"```toml\n"
+"# 本節の内容に関係のない行は省略しています。\n"
+"[dev-dependencies]\n"
+"pretty_assertions = \"1\"\n"
+"```"
+
+#: src/testing/dev_dependencies.md:27
+msgid "// crate for test-only use. Cannot be used in non-test code.\n"
+msgstr ""
+"// テストのためのクレートであり、\n"
+"                                      // テスト以外のコードには使えません。\n"
+
+#: src/testing/dev_dependencies.md:37
+msgid ""
+"[Cargo](http://doc.crates.io/specifying-dependencies.html) docs on "
+"specifying dependencies."
+msgstr ""
+"[Cargo](http://doc.crates.io/specifying-dependencies.html) 依存関係の指定について"
+
+#: src/unsafe.md:3
+msgid ""
+"As an introduction to this section, to borrow from [the official docs]"
+"(https://doc.rust-lang.org/book/ch19-01-unsafe-rust.html), \"one should try "
+"to minimize the amount of unsafe code in a code base.\" With that in mind, "
+"let's get started! Unsafe annotations in Rust are used to bypass protections "
+"put in place by the compiler; specifically, there are four primary things "
+"that unsafe is used for:"
+msgstr ""
+"この章の内容を見る前に、[公式ドキュメント](https://doc.rust-lang.org/book/ch19-01-unsafe-rust.html)"
+"から引用した次の文章をお読みください。"
+"「コードベース中の、アンセーフな操作をするコードの量は、可能な限り小さく無くてはならない。」"
+"この戒めを頭に叩き込んだ上で、さあはじめましょう！"
+"Rustにおいて、アンセーフなブロックはコンパイラのチェックをスルーするために使われます。"
+"具体的には以下の4つの主要なユースケースがあります。"
+
+#: src/unsafe.md:9
+msgid "dereferencing raw pointers"
+msgstr "生ポインタのデリファレンス"
+
+#: src/unsafe.md:10
+msgid ""
+"calling functions or methods which are `unsafe` (including calling a "
+"function over FFI, see [a previous chapter](std_misc/ffi.md) of the book) "
+msgstr "安全でない関数やメソッドの呼び出し(FFI経由の関数の呼び出しを含む (詳細は [本書のFFIに関する説明](std_misc/ffi.md) を参照ください))"
+
+#: src/unsafe.md:12
+msgid "accessing or modifying static mutable variables"
+msgstr "静的なミュータブル変数へのアクセスや変更"
+
+#: src/unsafe.md:13
+msgid "implementing unsafe traits"
+msgstr "安全でないトレイトの実装"
+
+#: src/unsafe.md:15
+msgid "Raw Pointers"
+msgstr "生ポインタ"
+
+#: src/unsafe.md:16
+msgid ""
+"Raw pointers `*` and references `&T` function similarly, but references are "
+"always safe because they are guaranteed to point to valid data due to the "
+"borrow checker. Dereferencing a raw pointer can only be done through an "
+"unsafe block."
+msgstr ""
+"生ポインタ`*`と参照`&T`はよく似た機能を持ちますが、"
+"後者は必ず有効なデータを指していることが借用チェッカーによって保証されているので、常に安全です。"
+"生ポインタのデリファレンスはアンセーフなブロックでしか実行できません。"
+
+#: src/unsafe.md:31
+msgid "Calling Unsafe Functions"
+msgstr "安全でない関数呼び出し"
+
+#: src/unsafe.md:32
+msgid ""
+"Some functions can be declared as `unsafe`, meaning it is the programmer's "
+"responsibility to ensure correctness instead of the compiler's. One example "
+"of this is [`std::slice::from_raw_parts`](https://doc.rust-lang.org/std/"
+"slice/fn.from_raw_parts.html) which will create a slice given a pointer to "
+"the first element and a length."
+msgstr ""
+"関数は `unsafe` として宣言できます。"
+"これはコンパイラの代わりにプログラマの責任で正しさを保証することを意味します。"
+"例として [`std::slice::from_raw_parts`](https://doc.rust-lang.org/std/slice/fn.from_raw_parts.html)"
+"があります。この関数は最初の要素へのポインタと長さを指定してスライスを作成します。"
+
+#: src/unsafe.md:54
+msgid ""
+"For `slice::from_raw_parts`, one of the assumptions which _must_ be upheld "
+"is  that the pointer passed in points to valid memory and that the memory "
+"pointed to is of the correct type. If these invariants aren't upheld then "
+"the program's  behaviour is undefined and there is no knowing what will "
+"happen."
+msgstr ""
+"`slice::from_raw_parts` は、次のふたつの仮定に基づいて処理します。"
+"ひとつは渡されたポインタが有効なメモリ位置を指していること、もうひとつはそのメモリに格納された値が正しい型であることです。"
+"この仮定を満たさない場合、プログラムの動作は不定となり、何が起こるかわかりません。"
+
+#: src/unsafe/asm.md:3
+msgid ""
+"Rust provides support for inline assembly via the `asm!` macro. It can be "
+"used to embed handwritten assembly in the assembly output generated by the "
+"compiler. Generally this should not be necessary, but might be where the "
+"required performance or timing cannot be otherwise achieved. Accessing low "
+"level hardware primitives, e.g. in kernel code, may also demand this "
+"functionality."
+msgstr ""
+"Rustは`asm!`マクロによってインラインアセンブリをサポートしています。"
+"コンパイラが生成するアセンブリに、手書きのアセンブリを埋め込むことができます。"
+"一般的には必要ありませんが、要求されるパフォーマンスやタイミングを達成するために必要な場合があります。"
+"カーネルコードのような、低レベルなハードウェアの基本要素にアクセスする場合にも、この機能が必要でしょう。"
+
+#: src/unsafe/asm.md:8
+msgid ""
+"**Note**: the examples here are given in x86/x86-64 assembly, but other "
+"architectures are also supported."
+msgstr "**注意**: 以下の例はx86/x86-64アセンブリで書かれていますが、他のアーキテクチャもサポートされています。"
+
+#: src/unsafe/asm.md:10
+msgid "Inline assembly is currently supported on the following architectures:"
+msgstr "インラインアセンブリは現在以下のアーキテクチャでサポートされています。"
+
+#: src/unsafe/asm.md:11
+msgid "x86 and x86-64"
+msgstr "x86とx86-64"
+
+#: src/unsafe/asm.md:12
+msgid "ARM"
+msgstr "ARM"
+
+#: src/unsafe/asm.md:13
+msgid "AArch64"
+msgstr "AArch64"
+
+#: src/unsafe/asm.md:14
+msgid "RISC-V"
+msgstr "RISC-V"
+
+#: src/unsafe/asm.md:16
+msgid "Basic usage"
+msgstr "基本的な使い方"
+
+#: src/unsafe/asm.md:18
+msgid "Let us start with the simplest possible example:"
+msgstr "最も単純な例から始めましょう。"
+
+#: src/unsafe/asm.md:21 src/unsafe/asm.md:41 src/unsafe/asm.md:68
+#: src/unsafe/asm.md:106 src/unsafe/asm.md:123 src/unsafe/asm.md:148
+#: src/unsafe/asm.md:174 src/unsafe/asm.md:195 src/unsafe/asm.md:212
+#: src/unsafe/asm.md:251 src/unsafe/asm.md:287 src/unsafe/asm.md:303
+#: src/unsafe/asm.md:329 src/unsafe/asm.md:367 src/unsafe/asm.md:394
+#: src/unsafe/asm.md:418 src/unsafe/asm.md:456
+msgid "\"x86_64\""
+msgstr "\"x86_64\""
+
+#: src/unsafe/asm.md:25
+msgid "\"nop\""
+msgstr "\"nop\""
+
+#: src/unsafe/asm.md:30
+msgid ""
+"This will insert a NOP (no operation) instruction into the assembly "
+"generated by the compiler. Note that all `asm!` invocations have to be "
+"inside an `unsafe` block, as they could insert arbitrary instructions and "
+"break various invariants. The instructions to be inserted are listed in the "
+"first argument of the `asm!` macro as a string literal."
+msgstr ""
+"これは、コンパイラが生成したアセンブリに、NOP（no operation）命令を挿入します。"
+"すべての`asm!`呼び出しは、`unsafe`ブロックの中になければいけません。"
+"インラインアセンブリは任意の命令を挿入でき、不変条件を壊してしまうからです。"
+"挿入される命令は、文字列リテラルとして`asm!`マクロの第一引数に列挙されます。"
+
+#: src/unsafe/asm.md:35
+msgid "Inputs and outputs"
+msgstr "入力と出力"
+
+#: src/unsafe/asm.md:37
+msgid ""
+"Now inserting an instruction that does nothing is rather boring. Let us do "
+"something that actually acts on data:"
+msgstr ""
+"何もしない命令を挿入しても面白くありません。"
+"実際にデータを操作してみましょう。"
+
+#: src/unsafe/asm.md:46
+msgid "\"mov {}, 5\""
+msgstr "\"mov {}, 5\""
+
+#: src/unsafe/asm.md:52
+msgid ""
+"This will write the value `5` into the `u64` variable `x`. You can see that "
+"the string literal we use to specify instructions is actually a template "
+"string. It is governed by the same rules as Rust [format strings](https://"
+"doc.rust-lang.org/std/fmt/#syntax). The arguments that are inserted into the "
+"template however look a bit different than you may be familiar with. First "
+"we need to specify if the variable is an input or an output of the inline "
+"assembly. In this case it is an output. We declared this by writing `out`. "
+"We also need to specify in what kind of register the assembly expects the "
+"variable. In this case we put it in an arbitrary general purpose register by "
+"specifying `reg`. The compiler will choose an appropriate register to insert "
+"into the template and will read the variable from there after the inline "
+"assembly finishes executing."
+msgstr ""
+"これは`u64`型の変数`x`に`5`の値を書き込んでいます。"
+"命令を指定するために利用している文字列リテラルが、実はテンプレート文字列になっています。"
+"これはRustの[フォーマット文字列](https://doc.rust-lang.org/std/fmt/#syntax)と同じルールに従います。"
+"ですが、テンプレートに挿入される引数は、みなさんがよく知っているものとは少し違っています。"
+"まず、変数がインラインアセンブリの入力なのか出力なのかを指定する必要があります。"
+"上記の例では出力となっています。"
+"`out`と書くことで出力であると宣言しています。"
+"また、アセンブリが変数をどの種類のレジスタに格納するかについても指定する必要があります。"
+"上の例では、`reg`を指定して任意の汎用レジスタに格納しています。"
+"コンパイラはテンプレートに挿入する適切なレジスタを選び、インラインアセンブリの実行終了後、そのレジスタから変数を読みこみます。"
+
+#: src/unsafe/asm.md:65
+msgid "Let us see another example that also uses an input:"
+msgstr "入力を利用する別の例を見てみましょう。"
+
+#: src/unsafe/asm.md:75
+msgid "\"mov {0}, {1}\""
+msgstr "\"mov {0}, {1}\""
+
+#: src/unsafe/asm.md:76 src/unsafe/asm.md:111 src/unsafe/asm.md:129
+msgid "\"add {0}, 5\""
+msgstr "\"add {0}, 5\""
+
+#: src/unsafe/asm.md:85
+msgid ""
+"This will add `5` to the input in variable `i` and write the result to "
+"variable `o`. The particular way this assembly does this is first copying "
+"the value from `i` to the output, and then adding `5` to it."
+msgstr ""
+"この例では、変数`i`の入力に`5`を加え、その結果を変数`o`に書き込んでいます。"
+"このアセンブリ特有のやり方として、はじめに`i`の値を出力にコピーし、それから`5`を加えています。"
+
+#: src/unsafe/asm.md:89
+msgid "The example shows a few things:"
+msgstr "この例はいくつかのことを示します。"
+
+#: src/unsafe/asm.md:91
+msgid ""
+"First, we can see that `asm!` allows multiple template string arguments; "
+"each one is treated as a separate line of assembly code, as if they were all "
+"joined together with newlines between them. This makes it easy to format "
+"assembly code."
+msgstr ""
+"まず、`asm!`では複数のテンプレート文字列を引数として利用できます。"
+"それぞれの文字列は、改行を挟んで結合されたのと同じように、独立したアセンブリコードとして扱われます。"
+"このおかげで、アセンブリコードを容易にフォーマットできます。"
+
+#: src/unsafe/asm.md:96
+msgid ""
+"Second, we can see that inputs are declared by writing `in` instead of `out`."
+msgstr "つぎに、入力は`out`ではなく`in`と書くことで宣言されています。"
+
+#: src/unsafe/asm.md:98
+msgid ""
+"Third, we can see that we can specify an argument number, or name as in any "
+"format string. For inline assembly templates this is particularly useful as "
+"arguments are often used more than once. For more complex inline assembly "
+"using this facility is generally recommended, as it improves readability, "
+"and allows reordering instructions without changing the argument order."
+msgstr ""
+"そして、他のフォーマット文字列と同じように引数を番号や名前で指定できます。"
+"インラインアセンブリのテンプレートでは、引数が2回以上利用されることが多いため、これは特に便利です。"
+"より複雑なインラインアセンブリを書く場合、この機能を使うのが推奨されます。"
+"可読性が向上し、引数の順序を変えることなく命令を並べ替えることができるからです。"
+
+#: src/unsafe/asm.md:103
+msgid "We can further refine the above example to avoid the `mov` instruction:"
+msgstr "上記の例をさらに改善して、`mov`命令をやめることもできます。"
+
+#: src/unsafe/asm.md:117
+msgid ""
+"We can see that `inout` is used to specify an argument that is both input "
+"and output. This is different from specifying an input and output separately "
+"in that it is guaranteed to assign both to the same register."
+msgstr ""
+"`inout`で入力でもあり出力でもある引数を指定しています。"
+"こうすることで、入力と出力を個別に指定する場合と違って、入出力が同じレジスタに割り当てられることが保証されます。"
+
+#: src/unsafe/asm.md:120
+msgid ""
+"It is also possible to specify different variables for the input and output "
+"parts of an `inout` operand:"
+msgstr "`inout`のオペランドとして、入力と出力それぞれに異なる変数を指定することも可能です。"
+
+#: src/unsafe/asm.md:135
+msgid "Late output operands"
+msgstr "遅延出力オペランド"
+
+#: src/unsafe/asm.md:137
+msgid ""
+"The Rust compiler is conservative with its allocation of operands. It is "
+"assumed that an `out` can be written at any time, and can therefore not "
+"share its location with any other argument. However, to guarantee optimal "
+"performance it is important to use as few registers as possible, so they "
+"won't have to be saved and reloaded around the inline assembly block. To "
+"achieve this Rust provides a `lateout` specifier. This can be used on any "
+"output that is written only after all inputs have been consumed. There is "
+"also an `inlateout` variant of this  specifier."
+msgstr ""
+"Rustコンパイラはオペランドの割り当てに保守的です。"
+"`out`はいつでも書き込めるので、他の引数とは場所を共有できません。"
+"しかし、最適なパフォーマンスを保証するためには、できるだけ少ないレジスタを使うことが重要です。"
+"そうすることで、インラインアセンブリブロックの前後でレジスタを保存したり再読み込みしたりする必要がありません。"
+"これを達成するために、Rustは`lateout`指定子を提供します。"
+"全ての入力が消費された後でのみ書き込まれる出力に利用できます。"
+"この指定子には`inlateout`という変化形もあります。"
+
+#: src/unsafe/asm.md:145
+msgid ""
+"Here is an example where `inlateout` _cannot_ be used in `release` mode or "
+"other optimized cases:"
+msgstr "以下は、`release`モードやその他の最適化された場合に、`inlateout`を利用 *できない* 例です。"
+
+#: src/unsafe/asm.md:156 src/unsafe/asm.md:180 src/unsafe/asm.md:463
+msgid "\"add {0}, {1}\""
+msgstr "\"add {0}, {1}\""
+
+#: src/unsafe/asm.md:157
+msgid "\"add {0}, {2}\""
+msgstr "\"add {0}, {2}\""
+
+#: src/unsafe/asm.md:167
+msgid ""
+"In unoptimized cases (e.g. `Debug` mode), replacing `inout(reg) a` with "
+"`inlateout(reg) a` in the above example can continue to give the expected "
+"result. However, with `release` mode or other optimized cases, using "
+"`inlateout(reg) a` can instead lead to the final value `a = 16`, causing the "
+"assertion to fail. "
+msgstr ""
+
+#: src/unsafe/asm.md:169
+msgid ""
+"This is because in optimized cases, the compiler is free to allocate the "
+"same register for inputs `b` and `c` since it knows that they have the same "
+"value. Furthermore, when `inlateout` is used, `a` and `c` could be allocated "
+"to the same register, in which case the first `add` instruction would "
+"overwrite the initial load from variable `c`. This is in contrast to how "
+"using `inout(reg) a` ensures a separate register is allocated for `a`. "
+msgstr ""
+"というのも、最適化されている場合、コンパイラは`b`と`c`が同じ値だと知っているので、"
+"`b`と`c`の入力に同じレジスタを割り当てる場合があります。"
+"もし`inlateout`が使われていたら、`a`と`c`に同じレジスタが割り当てられ、最初の`add`命令によって`c`の値が上書きされるでしょう。"
+"`inout(reg) a`の使用により`a`に対する独立したレジスタ割り当てが保証されるのとは対照的です。"
+
+#: src/unsafe/asm.md:171
+msgid ""
+"However, the following example can use `inlateout` since the output is only "
+"modified after all input registers have been read:"
+msgstr "しかし、次の例では、全ての入力レジスタが読み込まれた後でのみ出力が変更されるので、`inlateout`を利用できます。"
+
+#: src/unsafe/asm.md:186
+msgid ""
+"As you can see, this assembly fragment will still work correctly if `a` and "
+"`b` are assigned to the same register."
+msgstr "このアセンブリコードは、`a`と`b`が同じレジスタに割り当てられても、正しく動作します。"
+
+#: src/unsafe/asm.md:188
+msgid "Explicit register operands"
+msgstr "明示的なレジスタオペランド"
+
+#: src/unsafe/asm.md:190
+msgid ""
+"Some instructions require that the operands be in a specific register. "
+"Therefore, Rust inline assembly provides some more specific constraint "
+"specifiers. While `reg` is generally available on any architecture, explicit "
+"registers are highly architecture specific. E.g. for x86 the general purpose "
+"registers `eax`, `ebx`, `ecx`, `edx`, `ebp`, `esi`, and `edi` among others "
+"can be addressed by their name."
+msgstr ""
+"いくつかの命令では、オペランドが特定のレジスタにある必要があります。"
+"したがって、Rustのインラインアセンブリでは、より具体的な制約指定子を提供しています。"
+"`reg`は一般的にどのアーキテクチャでも利用可能ですが、明示的レジスタはアーキテクチャに強く依存しています。"
+"たとえば、x86の汎用レジスタである`eax`、`ebx`、`ecx`、`edx`、`ebp`、`esi`、`edi`などは、その名前で指定できます。"
+
+#: src/unsafe/asm.md:200
+msgid "\"out 0x64, eax\""
+msgstr "\"out 0x64, eax\""
+
+#: src/unsafe/asm.md:200 src/unsafe/asm.md:276
+msgid "\"eax\""
+msgstr "\"eax\""
+
+#: src/unsafe/asm.md:205
+msgid ""
+"In this example we call the `out` instruction to output the content of the "
+"`cmd` variable to port `0x64`. Since the `out` instruction only accepts "
+"`eax` (and its sub registers) as operand we had to use the `eax` constraint "
+"specifier."
+msgstr ""
+"この例では、`out`命令を呼び出して、`cmd`変数の中身を`0x64`ポートに出力しています。"
+"`out`命令は`eax`とそのサブレジスタのみをオペランドとして受け取るため、"
+"`eax`の制約指定子を使わなければなりません。"
+
+#: src/unsafe/asm.md:207
+msgid ""
+"**Note**: unlike other operand types, explicit register operands cannot be "
+"used in the template string: you can't use `{}` and should write the "
+"register name directly instead. Also, they must appear at the end of the "
+"operand list after all other operand types."
+msgstr ""
+"**注意**: 他のオペランドタイプと異なり、明示的なレジスタオペランドはテンプレート文字列中で利用できません。"
+"`{}`を使えないので、レジスタの名前を直接書く必要があります。"
+"また、オペランドのリストの中で他のオペランドタイプの一番最後に置かれなくてはなりません。"
+
+#: src/unsafe/asm.md:209
+msgid "Consider this example which uses the x86 `mul` instruction:"
+msgstr "x86の`mul`命令を使った次の例を考えてみましょう。"
+
+#: src/unsafe/asm.md:221
+msgid ""
+"// The x86 mul instruction takes rax as an implicit input and writes\n"
+"            // the 128-bit result of the multiplication to rax:rdx.\n"
+"            \"mul {}\""
+msgstr ""
+"// x86のmul命令はraxを暗黙的な入力に取り、\n"
+"            // 128ビットの乗算結果をrax:rdxに書き込みます。\n"
+"            \"mul {}\""
+
+#: src/unsafe/asm.md:225 src/unsafe/asm.md:347
+msgid "\"rax\""
+msgstr "\"rax\""
+
+#: src/unsafe/asm.md:226
+msgid "\"rdx\""
+msgstr "\"rdx\""
+
+#: src/unsafe/asm.md:235
+msgid ""
+"This uses the `mul` instruction to multiply two 64-bit inputs with a 128-bit "
+"result. The only explicit operand is a register, that we fill from the "
+"variable `a`. The second operand is implicit, and must be the `rax` "
+"register, which we fill from the variable `b`. The lower 64 bits of the "
+"result are stored in `rax` from which we fill the variable `lo`. The higher "
+"64 bits are stored in `rdx` from which we fill the variable `hi`."
+msgstr ""
+"`mul`命令を使って2つの64ビットの入力を128ビットの結果に出力しています。"
+"唯一の明示的なオペランドはレジスタで、変数`a`から入力します。"
+"2つ目のオペランドは暗黙的であり、`rax`レジスタである必要があります。変数`b`から`rax`レジスタに入力します。"
+"計算結果の下位64ビットは`rax`レジスタに保存され、そこから変数`lo`に出力されます。"
+"上位64ビットは`rdx`レジスタに保存され、そこから変数`hi`に出力されます。"
+
+#: src/unsafe/asm.md:241
+msgid "Clobbered registers"
+msgstr "クロバーレジスタ"
+
+#: src/unsafe/asm.md:243
+msgid ""
+"In many cases inline assembly will modify state that is not needed as an "
+"output. Usually this is either because we have to use a scratch register in "
+"the assembly or because instructions modify state that we don't need to "
+"further examine. This state is generally referred to as being \"clobbered\". "
+"We need to tell the compiler about this since it may need to save and "
+"restore this state around the inline assembly block."
+msgstr ""
+"多くの場合、インラインアセンブリは出力として必要のない状態を変更することがあります。"
+"これは普通、アセンブリでスクラッチレジスタを利用する必要があったり、"
+"私たちがこれ以上必要としていない状態を命令が変更したりするためです。"
+"この状態を一般的に\"クロバー\"（訳注：上書き）と呼びます。"
+"私たちはコンパイラにこのことを伝える必要があります。"
+"なぜならコンパイラは、インラインアセンブリブロックの前後で、"
+"この状態を保存して復元しなくてはならない可能性があるからです。"
+
+#: src/unsafe/asm.md:253
+msgid "// three entries of four bytes each\n"
+msgstr "// 4バイトのエントリー3つ\n"
+
+#: src/unsafe/asm.md:255
+msgid ""
+"// String is stored as ascii in ebx, edx, ecx in order\n"
+"    // Because ebx is reserved, the asm needs to preserve the value of it.\n"
+"    // So we push and pop it around the main asm.\n"
+"    // 64 bit mode on 64 bit processors does not allow pushing/popping of\n"
+"    // 32 bit registers (like ebx), so we have to use the extended rbx "
+"register instead.\n"
+msgstr ""
+"// 文字列はasciiとしてebx, edx, ecxの順に保存されています。\n"
+"    // ebxは予約されているので、アセンブリはebxの値を維持する必要があります。\n"
+"    // 従ってメインのアセンブリの前後でプッシュおよびポップを行います。\n"
+"    // （以下は64ビットプロセッサの64ビットモードの場合。32ビットプロセッサはebxを利用します。）\n"
+
+#: src/unsafe/asm.md:263
+msgid "\"push rbx\""
+msgstr "\"push rbx\""
+
+#: src/unsafe/asm.md:264
+msgid "\"cpuid\""
+msgstr "\"cpuid\""
+
+#: src/unsafe/asm.md:265
+msgid "\"mov [rdi], ebx\""
+msgstr "\"mov [rdi], ebx\""
+
+#: src/unsafe/asm.md:266
+msgid "\"mov [rdi + 4], edx\""
+msgstr "\"mov [rdi + 4], edx\""
+
+#: src/unsafe/asm.md:267
+msgid "\"mov [rdi + 8], ecx\""
+msgstr "\"mov [rdi + 8], ecx\""
+
+#: src/unsafe/asm.md:268
+msgid "\"pop rbx\""
+msgstr "\"pop rbx\""
+
+#: src/unsafe/asm.md:269
+msgid ""
+"// We use a pointer to an array for storing the values to simplify\n"
+"            // the Rust code at the cost of a couple more asm instructions\n"
+"            // This is more explicit with how the asm works however, as "
+"opposed\n"
+"            // to explicit register outputs such as `out(\"ecx\") val`\n"
+"            // The *pointer itself* is only an input even though it's "
+"written behind\n"
+msgstr ""
+"// いくつかのアセンブリ命令を追加してRustのコードを単純化するために\n"
+"            // 値を格納する配列へのポインタを利用します。\n"
+"            // しかし、`out(\"ecx\") val`のような明示的なレジスタの出力とは違い、\n"
+"            // アセンブリの動作をより明示的にします。\n"
+"            // *ポインタそのもの* は後ろに書かれていても入力にすぎません。\n"
+
+#: src/unsafe/asm.md:274 src/unsafe/asm.md:345
+msgid "\"rdi\""
+msgstr "\"rdi\""
+
+#: src/unsafe/asm.md:275
+msgid "// select cpuid 0, also specify eax as clobbered\n"
+msgstr "// cpuid 0を選択し、eaxをクロバーに指定します。\n"
+
+#: src/unsafe/asm.md:277
+msgid "// cpuid clobbers these registers too\n"
+msgstr "// cpuidは以下のレジスタもクロバーします。\n"
+
+#: src/unsafe/asm.md:278
+msgid "\"ecx\""
+msgstr "\"ecx\""
+
+#: src/unsafe/asm.md:279
+msgid "\"edx\""
+msgstr "\"edx\""
+
+#: src/unsafe/asm.md:284
+msgid "\"CPU Manufacturer ID: {}\""
+msgstr "\"CPU Manufacturer ID: {}\""
+
+#: src/unsafe/asm.md:291
+msgid ""
+"In the example above we use the `cpuid` instruction to read the CPU "
+"manufacturer ID. This instruction writes to `eax` with the maximum supported "
+"`cpuid` argument and `ebx`, `edx`, and `ecx` with the CPU manufacturer ID as "
+"ASCII bytes in that order."
+msgstr ""
+"上の例では、`cpuid`命令を使い、CPUベンタIDを読み込んでいます。"
+"この命令は`eax`にサポートされている最大の`cpuid`引数を書き込み、"
+"`ebx`、`edx`、`ecx`の順にCPUベンダIDをASCIIコードとして書き込みます。"
+
+#: src/unsafe/asm.md:294
+msgid ""
+"Even though `eax` is never read we still need to tell the compiler that the "
+"register has been modified so that the compiler can save any values that "
+"were in these registers before the asm. This is done by declaring it as an "
+"output but with `_` instead of a variable name, which indicates that the "
+"output value is to be discarded."
+msgstr ""
+"`eax`は読み込まれることはありません。"
+"しかし、コンパイラがアセンブリ以前にこれらのレジスタにあった値を保存できるように、"
+"レジスタが変更されたことをコンパイラに伝える必要があります。"
+"そのために、変数名の代わりに`_`を用いて出力を宣言し、出力の値が破棄されるということを示しています。"
+
+#: src/unsafe/asm.md:296
+msgid ""
+"This code also works around the limitation that `ebx` is a reserved register "
+"by LLVM. That means that LLVM assumes that it has full control over the "
+"register and it must be restored to its original state before exiting the "
+"asm block, so it cannot be used as an input or output **except** if the "
+"compiler uses it to fulfill a general register class (e.g. `in(reg)`). This "
+"makes `reg` operands dangerous when using reserved registers as we could "
+"unknowingly corrupt our input or output because they share the same register."
+msgstr ""
+"このコードは`ebx`がLLVMによって予約されたレジスタであるという制約を回避しています。"
+"LLVMは、自身がレジスタを完全にコントロールし、"
+"アセンブリブロックを抜ける前に元の状態を復元しなくてはならないと考えています。"
+"そのため、コンパイラが`in(reg)`のような汎用レジスタクラスを満たすために使用する場合 **を除いて** `ebx`を入力や出力として利用できません。"
+"つまり、予約されたレジスタを利用する場合に、`reg`オペランドは危険なのです。"
+"入力と出力が同じレジスタを共有しているので、知らないうちに入力や出力を破壊してしまうかもしれません。"
+
+#: src/unsafe/asm.md:298
+msgid ""
+"To work around this we use `rdi` to store the pointer to the output array, "
+"save `ebx` via `push`, read from `ebx` inside the asm block into the array "
+"and then restore `ebx` to its original state via `pop`. The `push` and `pop` "
+"use the full 64-bit `rbx` version of the register to ensure that the entire "
+"register is saved. On 32 bit targets the code would instead use `ebx` in the "
+"`push`/`pop`."
+msgstr ""
+"これを回避するために、`rdi`を用いて出力の配列へのポインタを保管し、`push`で`ebx`を保存し、"
+"アセンブリブロック内で`ebx`から読み込んで配列に書き込み、`pop`で`ebx`を元の状態に戻しています。"
+"`push`と`pop`は完全な64ビットの`rbx`レジスタを使って、レジスタ全体を確実に保存しています。"
+"32ビットの場合、`push`と`pop`において`ebx`がかわりに利用されるでしょう。"
+
+#: src/unsafe/asm.md:300
+msgid ""
+"This can also be used with a general register class to obtain a scratch "
+"register for use inside the asm code:"
+msgstr ""
+"アセンブリコード内部で利用するスクラッチレジスタを獲得するために、"
+"汎用レジスタクラスとともに使用することもできます。"
+
+#: src/unsafe/asm.md:305
+msgid "// Multiply x by 6 using shifts and adds\n"
+msgstr "// シフト演算と加算を利用してxに6をかけます。\n"
+
+#: src/unsafe/asm.md:310
+msgid "\"mov {tmp}, {x}\""
+msgstr "\"mov {tmp}, {x}\""
+
+#: src/unsafe/asm.md:311
+msgid "\"shl {tmp}, 1\""
+msgstr "\"shl {tmp}, 1\""
+
+#: src/unsafe/asm.md:312
+msgid "\"shl {x}, 2\""
+msgstr "\"shl {x}, 2\""
+
+#: src/unsafe/asm.md:313
+msgid "\"add {x}, {tmp}\""
+msgstr "\"add {x}, {tmp}\""
+
+#: src/unsafe/asm.md:322
+msgid "Symbol operands and ABI clobbers"
+msgstr "シンボル・オペランドとABIクロバー"
+
+#: src/unsafe/asm.md:324
+msgid ""
+"By default, `asm!` assumes that any register not specified as an output will "
+"have its contents preserved by the assembly code. The [`clobber_abi`](../../"
+"reference/inline-assembly.html#abi-clobbers) argument to `asm!` tells the "
+"compiler to automatically insert the necessary clobber operands according to "
+"the given calling convention ABI: any register which is not fully preserved "
+"in that ABI will be treated as clobbered.  Multiple `clobber_abi` arguments "
+"may be provided and all clobbers from all specified ABIs will be inserted."
+msgstr ""
+"デフォルトでは、`asm!`は、出力として指定されていないレジスタはアセンブリコードによって中身が維持される、と考えます。"
+"`asm!`に渡される[`clobber_abi`](../../reference/inline-assembly.html#abi-clobbers)"
+"引数は、与えられた呼び出し規約のABIに従って、"
+"必要なクロバーオペランドを自動的に挿入するようコンパイラに伝えます。"
+"そのABIで完全に保存されていないレジスタは、クロバーとして扱われます。"
+"複数の `clobber_abi` 引数を指定すると、指定されたすべてのABIのクロバーが挿入されます。"
+
+#: src/unsafe/asm.md:332 src/unsafe/asm.md:350
+msgid "\"C\""
+msgstr "\"C\""
+
+#: src/unsafe/asm.md:333
+msgid "\"arg = {}\""
+msgstr "\"arg = {}\""
+
+#: src/unsafe/asm.md:341
+msgid "\"call {}\""
+msgstr "\"call {}\""
+
+#: src/unsafe/asm.md:342
+msgid "// Function pointer to call\n"
+msgstr "// 呼び出す関数ポインタ\n"
+
+#: src/unsafe/asm.md:344
+msgid "// 1st argument in rdi\n"
+msgstr "// 最初の引数はrdiにあります。\n"
+
+#: src/unsafe/asm.md:346
+msgid "// Return value in rax\n"
+msgstr "// 戻り値はraxにあります。\n"
+
+#: src/unsafe/asm.md:348
+msgid ""
+"// Mark all registers which are not preserved by the \"C\" calling\n"
+"            // convention as clobbered.\n"
+msgstr "// \"C\"の呼び出し規約で保存されていないすべてのレジスタをクロバーに指定。\n"
+
+#: src/unsafe/asm.md:358
+msgid "Register template modifiers"
+msgstr "レジスタテンプレート修飾子"
+
+#: src/unsafe/asm.md:360
+msgid ""
+"In some cases, fine control is needed over the way a register name is "
+"formatted when inserted into the template string. This is needed when an "
+"architecture's assembly language has several names for the same register, "
+"each typically being a \"view\" over a subset of the register (e.g. the low "
+"32 bits of a 64-bit register)."
+msgstr ""
+"テンプレート文字列に挿入されるレジスタの名前のフォーマット方法について、細かい制御が必要な場合があります。"
+"アーキテクチャのアセンブリ言語が、同じレジスタに別名を持っている場合です。"
+"典型的な例としては、レジスタの部分集合に対する\"ビュー\"があります（例：64ビットレジスタの下位32ビット）。"
+
+#: src/unsafe/asm.md:362
+msgid ""
+"By default the compiler will always choose the name that refers to the full "
+"register size (e.g. `rax` on x86-64, `eax` on x86, etc)."
+msgstr ""
+"デフォルトでは、コンパイラは常に完全なレジスタサイズの名前を選択します"
+"（例：x86-64では`rax`、x86では`eax`、など）。"
+
+#: src/unsafe/asm.md:364
+msgid ""
+"This default can be overridden by using modifiers on the template string "
+"operands, just like you would with format strings:"
+msgstr "この挙動は、フォーマット文字列と同じように、テンプレート文字列のオペランドに修飾子を利用することで上書きできます。"
+
+#: src/unsafe/asm.md:373
+msgid "\"mov {0:h}, {0:l}\""
+msgstr "\"mov {0:h}, {0:l}\""
+
+#: src/unsafe/asm.md:380
+msgid ""
+"In this example, we use the `reg_abcd` register class to restrict the "
+"register allocator to the 4 legacy x86 registers (`ax`, `bx`, `cx`, `dx`) of "
+"which the first two bytes can be addressed independently."
+msgstr ""
+"この例では、`reg_abcd`レジスタクラスを用いて、レジスタアロケータを4つのレガシーなx86レジスタ"
+"（`ax`, `bx`, `cx`, `dx`）に制限しています。このうち最初の2バイトは独立して指定できます。"
+
+#: src/unsafe/asm.md:382
+msgid ""
+"Let us assume that the register allocator has chosen to allocate `x` in the "
+"`ax` register. The `h` modifier will emit the register name for the high "
+"byte of that register and the `l` modifier will emit the register name for "
+"the low byte. The asm code will therefore be expanded as `mov ah, al` which "
+"copies the low byte of the value into the high byte."
+msgstr ""
+"レジスタアロケータが`x`を`ax`レジスタに割り当てることにしたと仮定しましょう。"
+"`h`修飾子はそのレジスタの上位バイトのレジスタ名を出力し、`l`修飾子は下位バイトのレジスタ名を出力します。"
+"したがって、このアセンブリコードは`mov ah, al`に展開され、値の下位バイトを上位バイトにコピーします。"
+
+#: src/unsafe/asm.md:385
+msgid ""
+"If you use a smaller data type (e.g. `u16`) with an operand and forget to "
+"use template modifiers, the compiler will emit a warning and suggest the "
+"correct modifier to use."
+msgstr ""
+"より小さなデータ型（例：`u16`）をオペランドに利用し、テンプレート修飾子を使い忘れた場合、"
+"コンパイラは警告を出力し、正しい修飾子を提案してくれます。"
+
+#: src/unsafe/asm.md:387
+msgid "Memory address operands"
+msgstr "メモリアドレスオペランド"
+
+#: src/unsafe/asm.md:389
+msgid ""
+"Sometimes assembly instructions require operands passed via memory addresses/"
+"memory locations. You have to manually use the memory address syntax "
+"specified by the target architecture. For example, on x86/x86_64 using Intel "
+"assembly syntax, you should wrap inputs/outputs in `[]` to indicate they are "
+"memory operands:"
+msgstr ""
+"アセンブリ命令はオペランドがメモリアドレスやメモリロケーション経由で渡される必要なこともあります。"
+"そのときは手動で、ターゲットのアーキテクチャによって指定されたメモリアドレスのシンタックスを利用しなくてはなりません。"
+"例えば、Intelのアセンブリシンタックスを使うx86/x86_64の場合、入出力を`[]`で囲んで、"
+"メモリオペランドであることを示さなくてはなりません。"
+
+#: src/unsafe/asm.md:399
+msgid "\"fldcw [{}]\""
+msgstr "\"fldcw [{}]\""
+
+#: src/unsafe/asm.md:405
+msgid "Labels"
+msgstr "ラベル"
+
+#: src/unsafe/asm.md:407
+msgid ""
+"Any reuse of a named label, local or otherwise, can result in an assembler "
+"or linker error or may cause other strange behavior. Reuse of a named label "
+"can happen in a variety of ways including:"
+msgstr ""
+"名前つきラベルの再利用は、ローカルかそうでないかに関わらず、"
+"アセンブラやリンカのエラーを引き起こしたり、変な挙動の原因となります。"
+"名前つきラベルの再利用は以下のようなケースがあります。"
+
+#: src/unsafe/asm.md:409
+msgid ""
+"explicitly: using a label more than once in one `asm!` block, or multiple "
+"times across blocks."
+msgstr "明示的再利用：同じラベルを1つの`asm!`ブロック中で、または複数のブロック中で2回以上利用する場合です。"
+
+#: src/unsafe/asm.md:410
+msgid ""
+"implicitly via inlining: the compiler is allowed to instantiate multiple "
+"copies of an `asm!` block, for example when the function containing it is "
+"inlined in multiple places."
+msgstr ""
+"インライン化による暗黙の再利用：コンパイラは`asm!`ブロックの複数のコピーをインスタンス化する場合があります。"
+"例えば、`asm!`ブロックを含む関数が複数箇所でインライン化される場合です。"
+
+#: src/unsafe/asm.md:411
+msgid ""
+"implicitly via LTO: LTO can cause code from _other crates_ to be placed in "
+"the same codegen unit, and so could bring in arbitrary labels."
+msgstr ""
+"LTO（訳注：Link Time Optimizationの略）による暗黙の再利用："
+"LTOは *他のクレート* のコードを同じコード生成単位に配置するため、同じ名前のラベルを持ち込む場合があります。"
+
+#: src/unsafe/asm.md:413
+msgid ""
+"As a consequence, you should only use GNU assembler **numeric** [local "
+"labels](https://sourceware.org/binutils/docs/as/Symbol-Names.html#Local-"
+"Labels) inside inline assembly code. Defining symbols in assembly code may "
+"lead to assembler and/or linker errors due to duplicate symbol definitions."
+msgstr ""
+"そのため、インラインアセンブリコードの中では、GNUアセンブラの **数値型**"
+"[ローカルラベル](https://sourceware.org/binutils/docs/as/Symbol-Names.html#Local-Labels)のみ使用してください。"
+"アセンブリコード内でシンボルを定義すると、シンボル定義の重複により、アセンブラやリンカのエラーが発生する可能性があります。"
+
+#: src/unsafe/asm.md:415
+msgid ""
+"Moreover, on x86 when using the default Intel syntax, due to [an LLVM bug]"
+"(https://bugs.llvm.org/show_bug.cgi?id=36144), you shouldn't use labels "
+"exclusively made of `0` and `1` digits, e.g. `0`, `11` or `101010`, as they "
+"may end up being interpreted as binary values. Using `options(att_syntax)` "
+"will avoid any ambiguity, but that affects the syntax of the _entire_ `asm!` "
+"block. (See [Options](#options), below, for more on `options`.)"
+msgstr ""
+"さらに、x86でデフォルトのIntel構文を使用する場合、[LLVMのバグ](https://bugs.llvm.org/show_bug.cgi?id=36144)によって、"
+"`0`、`11`、`101010`といった`0`と`1`だけで構成されたラベルは、"
+"バイナリ値として解釈されてしまうため、使用してはいけません。"
+"`options(att_syntax)`を使うと曖昧さを避けられますが、`asm!`ブロック _全体_ の構文に影響します。"
+"（`options`については、後述の[オプション](#options)を参照してください。）"
+
+#: src/unsafe/asm.md:424
+msgid "\"mov {0}, 10\""
+msgstr "\"mov {0}, 10\""
+
+#: src/unsafe/asm.md:425 src/unsafe/asm.md:430
+msgid "\"2:\""
+msgstr "\"2:\""
+
+#: src/unsafe/asm.md:426
+msgid "\"sub {0}, 1\""
+msgstr "\"sub {0}, 1\""
+
+#: src/unsafe/asm.md:427
+msgid "\"cmp {0}, 3\""
+msgstr "\"cmp {0}, 3\""
+
+#: src/unsafe/asm.md:428
+msgid "\"jle 2f\""
+msgstr "\"jle 2f\""
+
+#: src/unsafe/asm.md:429
+msgid "\"jmp 2b\""
+msgstr "\"jmp 2b\""
+
+#: src/unsafe/asm.md:431
+msgid "\"add {0}, 2\""
+msgstr "\"add {0}, 2\""
+
+#: src/unsafe/asm.md:439
+msgid ""
+"This will decrement the `{0}` register value from 10 to 3, then add 2 and "
+"store it in `a`."
+msgstr "このコードは、`{0}`のレジスタの値を10から3にデクリメントし、2を加え、`a`にその値を保存します。"
+
+#: src/unsafe/asm.md:441
+msgid "This example shows a few things:"
+msgstr "この例は、以下のことを示しています。"
+
+#: src/unsafe/asm.md:443
+msgid ""
+"First, that the same number can be used as a label multiple times in the "
+"same inline block."
+msgstr "まず、ラベルとして同じ数字を複数回、同じインラインブロックで利用できます。"
+
+#: src/unsafe/asm.md:444
+msgid ""
+"Second, that when a numeric label is used as a reference (as an instruction "
+"operand, for example), the suffixes “b” (“backward”) or ”f” (“forward”) "
+"should be added to the numeric label. It will then refer to the nearest "
+"label defined by this number in this direction."
+msgstr ""
+"つぎに、数字のラベルが参照として(例えば、命令のオペランドに)利用された場合、"
+"\"b\"（\"後方\"）や\"f\"（\"前方\"）の接尾辞が数字のラベルに追加されなくてはなりません。"
+"そうすることで、この数字の指定された方向の最も近いラベルを参照できます。"
+
+#: src/unsafe/asm.md:449
+msgid "Options"
+msgstr "オプション"
+
+#: src/unsafe/asm.md:451
+msgid ""
+"By default, an inline assembly block is treated the same way as an external "
+"FFI function call with a custom calling convention: it may read/write "
+"memory, have observable side effects, etc. However, in many cases it is "
+"desirable to give the compiler more information about what the assembly code "
+"is actually doing so that it can optimize better."
+msgstr ""
+"デフォルトでは、インラインアセンブリブロックは、カスタム呼び出し規約をもつ外部のFFI関数呼び出しと同じように扱われます:"
+"メモリを読み込んだり書き込んだり、観測可能な副作用を持っていたりするかもしれません。"
+"しかし、多くの場合、アセンブリコードが実際に何をするかという情報を多く与えて、より最適化できる方が望ましいでしょう。"
+
+#: src/unsafe/asm.md:453
+msgid "Let's take our previous example of an `add` instruction:"
+msgstr "先ほどの`add`命令の例を見てみましょう。"
+
+#: src/unsafe/asm.md:472
+msgid ""
+"Options can be provided as an optional final argument to the `asm!` macro. "
+"We specified three options here:"
+msgstr ""
+"オプションは`asm!`マクロの最後の任意引数として渡されます。"
+"ここでは3つのオプションを利用しました："
+
+#: src/unsafe/asm.md:473
+msgid ""
+"`pure` means that the asm code has no observable side effects and that its "
+"output depends only on its inputs. This allows the compiler optimizer to "
+"call the inline asm fewer times or even eliminate it entirely."
+msgstr ""
+"`pure`は、アセンブリコードが観測可能な副作用を持っておらず、出力は入力のみに依存することを意味します。"
+"これにより、コンパイラオプティマイザはインラインアセンブリの呼び出し回数を減らしたり、"
+"インラインアセンブリを完全に削除したりできます。"
+
+#: src/unsafe/asm.md:474
+msgid ""
+"`nomem` means that the asm code does not read or write to memory. By default "
+"the compiler will assume that inline assembly can read or write any memory "
+"address that is accessible to it (e.g. through a pointer passed as an "
+"operand, or a global)."
+msgstr ""
+"`nomem`は、アセンブリコードがメモリの読み書きをしないことを意味します。"
+"デフォルトでは、インラインアセンブリはアクセス可能なメモリアドレス"
+"（例えばオペランドとして渡されたポインタや、グローバルなど）の読み書きを行うとコンパイラは仮定しています。"
+
+#: src/unsafe/asm.md:475
+msgid ""
+"`nostack` means that the asm code does not push any data onto the stack. "
+"This allows the compiler to use optimizations such as the stack red zone on "
+"x86-64 to avoid stack pointer adjustments."
+msgstr ""
+"`nostack`は、アセンブリコードがスタックにデータをプッシュしないことを意味します。"
+"これにより、コンパイラはx86-64のスタックレッドゾーンなどの最適化を利用し、"
+"スタックポインタの調整を避けることができます。"
+
+#: src/unsafe/asm.md:477
+msgid ""
+"These allow the compiler to better optimize code using `asm!`, for example "
+"by eliminating pure `asm!` blocks whose outputs are not needed."
+msgstr ""
+"これにより、コンパイラは、出力が全く必要とされていない純粋な`asm!`ブロックを削除するなどして、"
+"`asm!`を使ったコードをより最適化できます。"
+
+#: src/unsafe/asm.md:479
+msgid ""
+"See the [reference](https://doc.rust-lang.org/stable/reference/inline-"
+"assembly.html) for the full list of available options and their effects."
+msgstr ""
+"利用可能なオプションとその効果の一覧は[リファレンス](https://doc.rust-lang.org/stable/reference/inline-assembly.html)"
+"を参照してください。"
+
+#: src/compatibility.md:3
+msgid ""
+"The Rust language is fastly evolving, and because of this certain "
+"compatibility issues can arise, despite efforts to ensure forwards-"
+"compatibility wherever possible."
+msgstr ""
+"Rust言語は急速に進化しており、可能な限り前方互換性を確保する努力にも関わらず、"
+"特定の互換性の問題が生じることがあります。"
+
+#: src/compatibility.md:7
+msgid "[Raw identifiers](compatibility/raw_identifiers.md)"
+msgstr "[生識別子](compatibility/raw_identifiers.md)"
+
+#: src/compatibility/raw_identifiers.md:3
+msgid ""
+"Rust, like many programming languages, has the concept of \"keywords\". "
+"These identifiers mean something to the language, and so you cannot use them "
+"in places like variable names, function names, and other places. Raw "
+"identifiers let you use keywords where they would not normally be allowed. "
+"This is particularly useful when Rust introduces new keywords, and a library "
+"using an older edition of Rust has a variable or function with the same name "
+"as a keyword introduced in a newer edition."
+msgstr ""
+"Rustは多くのプログラミング言語と同様に、「キーワード」の概念を持っています。"
+"これらの識別子は言語にとって何かしらの意味を持ちますので、変数名や関数名、その他の場所で使用することはできません。"
+"生識別子は、通常は許されない状況でキーワードを使用することを可能にします。"
+"これは、新しいキーワードを導入したRustと、古いエディションのRustを使用したライブラリが同じ名前の変数や関数を持つ場合に特に便利です。"
+
+#: src/compatibility/raw_identifiers.md:11
+msgid ""
+"For example, consider a crate `foo` compiled with the 2015 edition of Rust "
+"that exports a function named `try`. This keyword is reserved for a new "
+"feature in the 2018 edition, so without raw identifiers, we would have no "
+"way to name the function."
+msgstr ""
+"例えば、2015年エディションのRustでコンパイルされたクレート`foo`が`try`という名前の関数をエクスポートしているとします。"
+"このキーワードは2018年エディションで新機能として予約されていますので、生識別子がなければ、この関数を名付ける方法がありません。"
+
+#: src/compatibility/raw_identifiers.md:24
+msgid "You'll get this error:"
+msgstr "このエラーが出ます："
+
+#: src/compatibility/raw_identifiers.md:34
+msgid "You can write this with a raw identifier:"
+msgstr "これは生識別子を使って書くことができます："
+
+#: src/meta.md:3
+msgid ""
+"Some topics aren't exactly relevant to how you program but provide you "
+"tooling or infrastructure support which just makes things better for "
+"everyone. These topics include:"
+msgstr ""
+"この章では、プログラミングそれ自体に関係はないけれども、"
+"色々と人々の役に立つ機能やインフラについて説明していきます。例えば："
+
+#: src/meta.md:7
+msgid ""
+"[Documentation](meta/doc.md): Generate library documentation for users via "
+"the included `rustdoc`."
+msgstr "[ドキュメンテーション](meta/doc.md): Rust付属コマンド`rustdoc`を用いて、ライブラリのドキュメントを生成します。"
+
+#: src/meta.md:9
+msgid ""
+"[Playground](meta/playground.md): Integrate the Rust Playground in your "
+"documentation."
+msgstr "[プレイグラウンド](meta/playground.md): あなたのドキュメンテーションにRust Playgroundを組み込めます。"
+
+#: src/meta/doc.md:3
+msgid "Use `cargo doc` to build documentation in `target/doc`."
+msgstr ""
+
+#: src/meta/doc.md:5
+msgid ""
+"Use `cargo test` to run all tests (including documentation tests), and "
+"`cargo test --doc` to only run documentation tests."
+msgstr ""
+
+#: src/meta/doc.md:8
+msgid ""
+"These commands will appropriately invoke `rustdoc` (and `rustc`) as required."
+msgstr ""
+
+#: src/meta/doc.md:10
+msgid "Doc comments"
+msgstr "ドキュメンテーションコメント"
+
+#: src/meta/doc.md:12
+msgid ""
+"Doc comments are very useful for big projects that require documentation. "
+"When running `rustdoc`, these are the comments that get compiled into "
+"documentation. They are denoted by a `///`, and support [Markdown](https://"
+"en.wikipedia.org/wiki/Markdown)."
+msgstr ""
+"ドキュメンテーションコメントとは`rustdoc`を使用した際にドキュメントにコンパイルされるコメントのことです。"
+"`///`によって普通のコメントと区別され、ここでは[Markdown](https://en.wikipedia.org/wiki/Markdown)を使用することができます。"
+"ドキュメンテーションコメントは大規模なプロジェクトの際に非常に有用です。"
+
+#: src/meta/doc.md:17
+msgid "\"doc\""
+msgstr "\"doc\""
+
+#: src/meta/doc.md:18
+msgid "/// A human being is represented here\n"
+msgstr "/// あらゆる人物はここに代表されます。\n"
+
+#: src/meta/doc.md:21
+msgid "/// A person must have a name, no matter how much Juliet may hate it\n"
+msgstr ""
+"/// ジュリエットがどんなに名前というものを嫌っていようと、\n"
+"    /// 人物には名前が必要です。\n"
+
+#: src/meta/doc.md:26
+msgid ""
+"/// Returns a person with the name given them\n"
+"    ///\n"
+"    /// # Arguments\n"
+"    ///\n"
+"    /// * `name` - A string slice that holds the name of the person\n"
+"    ///\n"
+"    /// # Examples\n"
+"    ///\n"
+"    /// ```\n"
+"    /// // You can have rust code between fences inside the comments\n"
+"    /// // If you pass --test to `rustdoc`, it will even test it for you!\n"
+"    /// use doc::Person;\n"
+"    /// let person = Person::new(\"name\");\n"
+"    /// ```\n"
+msgstr ""
+"/// 与えられた名前を持つpersonを返します。\n"
+"    ///\n"
+"    /// # Arguments\n"
+"    ///\n"
+"    /// * `name` - `person`の名前を表す文字列のスライス\n"
+"    ///\n"
+"    /// # Examples\n"
+"    ///\n"
+"    /// ```\n"
+"    /// // バッククォートによってRustのコードをコメント中に挟むこと\n"
+"    /// // もできます。`rustdoc`に--testを渡せば、テストも行えます！\n"
+"    /// // （訳注: pythonのdoctestと同じです。）\n"
+"    /// use doc::Person;\n"
+"    /// let person = Person::new(\"name\");\n"
+"    /// ```\n"
+
+#: src/meta/doc.md:46
+msgid ""
+"/// Gives a friendly hello!\n"
+"    ///\n"
+"    /// Says \"Hello, [name](Person::name)\" to the `Person` it is called "
+"on.\n"
+msgstr ""
+"/// フレンドリーに挨拶しましょう！\n"
+"    ///\n"
+"    /// このメソッドを呼び出した`Person`に対して\n"
+"    /// \"Hello, [name](Person::name)\"と話しかけます。\n"
+
+#: src/meta/doc.md:50
+msgid "\"Hello, {}!\""
+msgstr "\"Hello, {}!\""
+
+#: src/meta/doc.md:55
+msgid "\"John\""
+msgstr "\"John\""
+
+#: src/meta/doc.md:61
+msgid ""
+"To run the tests, first build the code as a library, then tell `rustdoc` "
+"where to find the library so it can link it into each doctest program:"
+msgstr ""
+
+#: src/meta/doc.md:64
+msgid ""
+"```shell\n"
+"$ rustc doc.rs --crate-type lib\n"
+"$ rustdoc --test --extern doc=\"libdoc.rlib\" doc.rs\n"
+"```"
+msgstr ""
+"```shell\n"
+"$ rustc doc.rs --crate-type lib\n"
+"$ rustdoc --test --extern doc=\"libdoc.rlib\" doc.rs\n"
+"```"
+
+#: src/meta/doc.md:69
+msgid "Doc attributes"
+msgstr ""
+
+#: src/meta/doc.md:71
+msgid ""
+"Below are a few examples of the most common `#[doc]` attributes used with "
+"`rustdoc`."
+msgstr ""
+
+#: src/meta/doc.md:74
+msgid "`inline`"
+msgstr "`inline`"
+
+#: src/meta/doc.md:76
+msgid "Used to inline docs, instead of linking out to separate page."
+msgstr ""
+
+#: src/meta/doc.md:81
+msgid "/// bar docs\n"
+msgstr ""
+
+#: src/meta/doc.md:84
+msgid "/// the docs for Bar\n"
+msgstr ""
+
+#: src/meta/doc.md:89
+msgid "`no_inline`"
+msgstr "`no_inline`"
+
+#: src/meta/doc.md:91
+msgid "Used to prevent linking out to separate page or anywhere."
+msgstr ""
+
+#: src/meta/doc.md:94
+msgid "// Example from libcore/prelude\n"
+msgstr ""
+
+#: src/meta/doc.md:99
+msgid "`hidden`"
+msgstr "`hidden`"
+
+#: src/meta/doc.md:101
+msgid "Using this tells `rustdoc` not to include this in documentation:"
+msgstr ""
+
+#: src/meta/doc.md:104
+msgid "// Example from the futures-rs library\n"
+msgstr ""
+
+#: src/meta/doc.md:109
+msgid ""
+"For documentation, `rustdoc` is widely used by the community. It's what is "
+"used to generate the [std library docs](https://doc.rust-lang.org/std/)."
+msgstr ""
+
+#: src/meta/doc.md:114
+msgid ""
+"[The Rust Book: Making Useful Documentation Comments](https://doc.rust-lang."
+"org/book/ch14-02-publishing-to-crates-io.html#making-useful-documentation-"
+"comments)"
+msgstr ""
+
+#: src/meta/doc.md:115
+msgid "[The rustdoc Book](https://doc.rust-lang.org/rustdoc/index.html)"
+msgstr ""
+
+#: src/meta/doc.md:116
+msgid ""
+"[The Reference: Doc comments](https://doc.rust-lang.org/stable/reference/"
+"comments.html#doc-comments)"
+msgstr ""
+
+#: src/meta/doc.md:117
+msgid ""
+"[RFC 1574: API Documentation Conventions](https://rust-lang.github.io/"
+"rfcs/1574-more-api-documentation-conventions.html#appendix-a-full-"
+"conventions-text)"
+msgstr ""
+
+#: src/meta/doc.md:118
+msgid ""
+"[RFC 1946: Relative links to other items from doc comments (intra-rustdoc "
+"links)](https://rust-lang.github.io/rfcs/1946-intra-rustdoc-links.html)"
+msgstr ""
+
+#: src/meta/doc.md:119
+msgid ""
+"[Is there any documentation style guide for comments? (reddit)](https://www."
+"reddit.com/r/rust/comments/ahb50s/"
+"is_there_any_documentation_style_guide_for/)"
+msgstr ""
+
+#: src/meta/playground.md:3
+msgid ""
+"The [Rust Playground](https://play.rust-lang.org/) is a way to experiment "
+"with Rust code through a web interface."
+msgstr ""
+"[Rust Playground](https://play.rust-lang.org/)では、RustのコードをWebのインターフェースを通じて実験できます。"
+
+#: src/meta/playground.md:6
+msgid "Using it with `mdbook`"
+msgstr "`mdbook`と組み合わせる"
+
+#: src/meta/playground.md:8
+msgid ""
+"In [`mdbook`](https://github.com/rust-lang/mdBook), you can make code "
+"examples playable and editable."
+msgstr ""
+"[`mdbook`](https://github.com/rust-lang/mdBook)では、コード例を実行・編集可能にできます。"
+
+#: src/meta/playground.md:16
+msgid ""
+"This allows the reader to both run your code sample, but also modify and "
+"tweak it. The key here is the adding of the word `editable` to your "
+"codefence block separated by a comma."
+msgstr ""
+"これにより、読者はあなたのコード例を実行するだけでなく、変更することもできます。"
+"`editable`という単語をカンマで区切って、あなたのコードブロックに追加するのがキーです。"
+
+#: src/meta/playground.md:26
+msgid ""
+"Additionally, you can add `ignore` if you want `mdbook` to skip your code "
+"when it builds and tests."
+msgstr ""
+"加えて、`mdbook`がビルドやテストを実行するときに、あなたのコードをスキップさせたい場合は、`ignore`を追加できます。"
+
+#: src/meta/playground.md:35
+msgid "Using it with docs"
+msgstr "ドキュメントと組み合わせる"
+
+#: src/meta/playground.md:37
+msgid ""
+"You may have noticed in some of the [official Rust docs](https://doc.rust-"
+"lang.org/core/) a button that says \"Run\", which opens the code sample up "
+"in a new tab in Rust Playground. This feature is enabled if you use the "
+"`#[doc]` attribute called [`html_playground_url`](https://doc.rust-lang.org/"
+"rustdoc/write-documentation/the-doc-attribute.html#html_playground_url)."
+msgstr ""
+"[Rustの公式ドキュメント](https://doc.rust-lang.org/core/)には、「実行(Run)」ボタンがある場合があります。"
+"クリックすると、新しいタブでRust Playgroundが開き、コード例が表示されます。"
+"この機能は、#[doc]アトリビュートの[`html_playground_url`](https://doc.rust-lang.org/rustdoc/write-documentation/the-doc-attribute.html#html_playground_url)"
+"の値で有効化できます。"
+
+#: src/meta/playground.md:42
+msgid ""
+"````\n"
+"#![doc(html_playground_url = \"https://play.rust-lang.org/\")]\n"
+"//! ```\n"
+"//! println!(\"Hello Wolrd\");\n"
+"//! ```\n"
+"````"
+msgstr ""
+"````\n"
+"#![doc(html_playground_url = \"https://play.rust-lang.org/\")]\n"
+"//! ```\n"
+"//! println!(\"Hello Wolrd\");\n"
+"//! ```\n"
+"````"
+
+#: src/meta/playground.md:51
+msgid "[The Rust Playground](https://play.rust-lang.org/)"
+msgstr ""
+
+#: src/meta/playground.md:52
+msgid ""
+"[The Rust Playground On Github](https://github.com/integer32llc/rust-"
+"playground/)"
+msgstr ""
+
+#: src/meta/playground.md:53
+msgid ""
+"[The rustdoc Book](https://doc.rust-lang.org/rustdoc/what-is-rustdoc.html)"
+msgstr ""

--- a/theme/index.hbs
+++ b/theme/index.hbs
@@ -177,6 +177,9 @@
                           <li role="none"><button role="menuitem" class="theme">
                               <a id="en">English</a>
                           </button></li>
+                          <li role="none"><button role="menuitem" class="theme">
+                              <a id="ja">日本語</a>
+                          </button></li>
                         </ul>
 
                         <script>


### PR DESCRIPTION
This PR adds

* Japanese translation resource
  + This is based on https://github.com/rust-lang-ja/rust-by-example-ja/commit/baf7bf07780af48842e27e55ff9218ba43ec3512.
  + The original translators are below.

* Additional translation guide for Japanese
  + To avoid review about Japanese at this repo, rust-lang-ja members will review it at our organization's repo.
  + After the review, we open PR to this repo, so you can merge without Japanese review.
  + This guide describes the step for the review.

* Update mdbook-i18n-helpers to v0.3.1
  + This repo is affected by the issue: https://github.com/google/mdbook-i18n-helpers/pull/129.

The original translators list:

@joemphilips @kdnakt @tatsuya6502 @dalance @a2not @h1g0 @swnakamura @etoal83 @TAKOYAKING8 @sei0o @todays-mitsui @furon-kuina @KANIYONIKA @baseballyama @eldesh @kotet @ohno418 @hnakai0909 @4geru @botamochi0x12 @sadnessOjisan @kakubin @takahiro-itazuri @isudzumi @naoty @kishiguro @KisaragiEffective @kazu728 @tomoyuki-nakabayashi @yoichi @H1Gdev @akiradeveloper @akiomik @uenojp @KeenS @stny @shiomiyan @r6eve @tos-kamiya