### PR TITLE
Update primitives.md

### DIFF
--- a/src/primitives.md
+++ b/src/primitives.md
@@ -18,7 +18,7 @@ type because it does not contain multiple values.
 ### Compound Types
 
 * Arrays like `[1, 2, 3]`
-* Tuples like `(1, true)`
+* Tuples like `(2, true)`
 
 Variables can always be *type annotated*. Numbers may additionally be annotated
 via a *suffix* or *by default*. Integers default to `i32` and floats to `f64`.


### PR DESCRIPTION
Since tuples can hold values of different types, I think it would be important to make it obvious they can do so.

Right now, the book is saying "Tuples like `(1, true)`.". This might make the impression that tuples are limited to holding values of the same type, so that's why I'm proposing to change `1` to a `2`, making it "Tuples like `(2, true)`.".