### PR TITLE
fix(str.md): avoid misunderstanding that there were only two string types

### DIFF
--- a/src/std/str.md
+++ b/src/std/str.md
@@ -1,6 +1,6 @@
 # Strings
 
-There are two types of strings in Rust: `String` and `&str`.
+The two most used string types in Rust are `String` and `&str`.
 
 A `String` is stored as a vector of bytes (`Vec<u8>`), but guaranteed to
 always be a valid UTF-8 sequence. `String` is heap allocated, growable and not


### PR DESCRIPTION
With the previous wording, some might think there are exactly two string types in Rust. Even in the standard library you find more string types than `String` and `&str`, like CStr, OsStr or Path. It is also possible to define your own string types, so theoretically there is an infinite amount of string types in Rust.