### PR TITLE
Update the rustdoc example to match best practice

### DIFF
--- a/src/meta/doc.md
+++ b/src/meta/doc.md
@@ -1,6 +1,7 @@
 # Documentation
 
-Use `cargo doc` to build documentation in `target/doc`.
+Use `cargo doc` to build documentation in `target/doc`, `cargo doc --open`
+will automatically open it in your web browser.
 
 Use `cargo test` to run all tests (including documentation tests), and `cargo
 test --doc` to only run documentation tests.
@@ -23,11 +24,7 @@ pub struct Person {
 }
 
 impl Person {
-    /// Returns a person with the name given them
-    ///
-    /// # Arguments
-    ///
-    /// * `name` - A string slice that holds the name of the person
+    /// Creates a person with the given name.
     ///
     /// # Examples
     ///


### PR DESCRIPTION
 #1457 was closed with prejudice ;) so I've made a PR instead!

This change updates the meta/doc example to match the best practices outlined in RFC 1574 (already referenced by the doc). Specifically, it removes the "Arguments" section from the `Person` doc example.

I've also added a mention of `cargo doc --open` as it's pretty useful and people may not think to see if it exists.

I'm also suspicious about all the mentions of invoking `rustdoc` directly as I suspect ~everyone uses `cargo doc` but I haven't touched them in this change.