### PR TITLE
Add expected error behavior into docs

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -53,6 +53,13 @@ $ cargo install mdbook
 $ mdbook build
 ```
 
+**The following warnings can be ignored safely.**
+
+```
+[WARN] (mdbook::preprocess::cmd): The command wasn't found, is the "gettext" preprocessor installed?
+[WARN] (mdbook::preprocess::cmd):   Command: mdbook-gettext
+```
+
 [install Rust]: http://rust-lang.org/install.html
 
 The files will be in the `book` directory at the top-level; `mdbook serve` will

--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ mdbook serve
 To be able to run the examples, you must be connected to the internet; you can
 read all content offline, however!
 
-The following warnings can be ignored safely.
+**The following warnings can be ignored safely.**
 
 ```
 [WARN] (mdbook::preprocess::cmd): The command wasn't found, is the "gettext" preprocessor installed?


### PR DESCRIPTION
Add expected error behavior into docs **README.md** and **CONTRIBUTING.md**

Tests successful:

```
❯ mdbook build
2024-01-31 15:58:01 [INFO] (mdbook::book): Book building has started
2024-01-31 15:58:01 [WARN] (mdbook::preprocess::cmd): The command wasn't found, is the "gettext" preprocessor installed?
2024-01-31 15:58:01 [WARN] (mdbook::preprocess::cmd):   Command: mdbook-gettext
2024-01-31 15:58:01 [INFO] (mdbook::book): Running the html backend
❯  mdbook test
2024-01-31 15:59:15 [WARN] (mdbook::preprocess::cmd): The command wasn't found, is the "gettext" preprocessor installed?
2024-01-31 15:59:15 [WARN] (mdbook::preprocess::cmd):   Command: mdbook-gettext
2024-01-31 15:59:15 [INFO] (mdbook::book): Testing chapter 'Introduction': "index.md"
2024-01-31 15:59:15 [INFO] (mdbook::book): Testing chapter 'Hello World': "hello.md"

...
...

2024-01-31 15:59:58 [INFO] (mdbook::book): Testing chapter 'Documentation': "meta/doc.md"
2024-01-31 15:59:58 [INFO] (mdbook::book): Testing chapter 'Playground': "meta/playground.md"




```