### PR TITLE
Update new_types.md wording

### DIFF
--- a/src/generics/new_types.md
+++ b/src/generics/new_types.md
@@ -25,16 +25,16 @@ impl Days {
     }
 }
 
-fn old_enough(age: &Years) -> bool {
+fn is_adult(age: &Years) -> bool {
     age.0 >= 18
 }
 
 fn main() {
-    let age = Years(5);
+    let age = Years(25);
     let age_days = age.to_days();
-    println!("Old enough {}", old_enough(&age));
-    println!("Old enough {}", old_enough(&age_days.to_years()));
-    // println!("Old enough {}", old_enough(&age_days));
+    println!("Is an adult? {}", is_adult(&age));
+    println!("Is an adult? {}", is_adult(&age_days.to_years()));
+    // println!("Is an adult? {}", is_adult(&age_days));
 }
 ```
 


### PR DESCRIPTION
It's a bit odd to have an example checking if a 5 year old is 18 years old using the wording "old enough".

Updates from this:

```rust
fn old_enough(age: &Years) -> bool {
    age.0 >= 18
}

fn main() {
    let age = Years(5);
    let age_days = age.to_days();
    println!("Old enough {}", old_enough(&age));
    println!("Old enough {}", old_enough(&age_days.to_years()));
    // println!("Old enough {}", old_enough(&age_days));
}
```


to this:

```rust
fn is_adult(age: &Years) -> bool {
    age.0 >= 18
}

fn main() {
    let age = Years(25);
    let age_days = age.to_days();
    println!("Is an adult? {}", is_adult(&age));
    println!("Is an adult? {}", is_adult(&age_days.to_years()));
    // println!("Is an adult? {}", is_adult(&age_days));
}
```