### PR TITLE
Raw string literal can contain up to 255 #s according to Rust Reference

### DIFF
--- a/src/std/str.md
+++ b/src/std/str.md
@@ -106,7 +106,7 @@ fn main() {
     println!("{}", quotes);
 
     // If you need "# in your string, just use more #s in the delimiter.
-    // You can use up to 65535 #s.
+    // You can use up to 255 #s.
     let longer_delimiter = r###"A string with "# in it. And even "##!"###;
     println!("{}", longer_delimiter);
 }


### PR DESCRIPTION
According to [rustc lexer](https://github.com/rust-lang/rust/blob/0ac1195ee0f8cd6d87e654a2312b899883272ec2/compiler/rustc_lexer/src/lib.rs#L211) and [Rust Reference ](https://doc.rust-lang.org/reference/tokens.html#raw-string-literals)raw string literals can contain only up to 255 `#`s.