### PR TITLE
Adjust translation build on CI

### DIFF
--- a/.github/workflows/rbe.yml
+++ b/.github/workflows/rbe.yml
@@ -55,23 +55,20 @@ jobs:
     - name: Build all translations
       run: |
         for po_lang in ${{ env.LANGUAGES }}; do
-          POT_CREATION_DATE=$(grep --max-count 1 '^"POT-Creation-Date:' po/$po_lang.po | sed -E 's/".*: (.*)\\n"/\1/')
-          if [[ $POT_CREATION_DATE == "" ]]; then
-              POT_CREATION_DATE=now
-          fi
-
-          echo "::group::Building $po_lang translation as of $POT_CREATION_DATE"
-          rm -r src/
-          git restore --source "$(git rev-list -n 1 --before "$POT_CREATION_DATE" @)" src/
-
+          echo "::group::Building $po_lang translation"
           # Set language and adjust site URL. Clear the redirects
           # since they are in sync with the source files, not the
           # translation.
           MDBOOK_BOOK__LANGUAGE=$po_lang \
-          MDBOOK_OUTPUT__HTML__SITE_URL=/rust-by-example/$po_lang/ \
-          MDBOOK_OUTPUT__HTML__REDIRECT='{}' \
           mdbook build -d book/$po_lang
           echo "::endgroup::"
+        done
+
+    - name: Check all translations for broken links
+      run: |
+        for po_lang in ${{ env.LANGUAGES }}; do
+          MDBOOK_BOOK__LANGUAGE=$po_lang \
+          sh linkcheck.sh --all rust-by-example
         done
 
     - name: Upload Artifact


### PR DESCRIPTION
This PR adjusts translation build on CI:

* Remove `git restore`
The `git restore` causes differences between CI of this repo and the release build of rust-lang/rust.
* Add link check for all translations
* Remove unused envs: `MDBOOK_OUTPUT__HTML__SITE_URL`, `MDBOOK_OUTPUT__HTML__REDIRECTS`
This is because `site_url` and `redirects` is not specified in `book.toml`.