### PR TITLE
Add precision on From/Into asymmetry to from_into.md

### DIFF
--- a/src/conversion/from_into.md
+++ b/src/conversion/from_into.md
@@ -74,7 +74,7 @@ fn main() {
 `From` and `Into` are designed to be complementary.
 We do not need to provide an implementation for both traits.
 If you have implemented the `From` trait for your type, `Into` will call it 
-when necessary.  
+when necessary. Note, however, that the converse is not true: implementing `Into` for your type will not automatically provide it with an implementation of `From`. 
 
 ```rust,editable
 use std::convert::From;


### PR DESCRIPTION
Adding a cautionary note to the effect that whilst implementing `From` for a type will provide it w/ `Into`, it doesn't work the other way around: implementing `Into` will not give you `From`. 