### PR TITLE
Add an example of implementing the FromStr trait for Circles.

### DIFF
--- a/src/conversion/string.md
+++ b/src/conversion/string.md
@@ -36,8 +36,7 @@ shown in the following example.
 
 This will convert the string into the type specified as long as the [`FromStr`]
 trait is implemented for that type. This is implemented for numerous types
-within the standard library. To obtain this functionality on a user defined type
-simply implement the [`FromStr`] trait for that type.
+within the standard library.
 
 ```rust,editable
 fn main() {
@@ -46,6 +45,35 @@ fn main() {
 
     let sum = parsed + turbo_parsed;
     println!("Sum: {:?}", sum);
+}
+```
+
+To obtain this functionality on a user defined type simply implement the
+[`FromStr`] trait for that type.
+
+```rust,editable
+use std::num::ParseIntError;
+use std::str::FromStr;
+
+#[derive(Debug)]
+struct Circle {
+    radius: i32,
+}
+
+impl FromStr for Circle {
+    type Err = ParseIntError;
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        match s.trim().parse() {
+            Ok(num) => Ok(Circle{ radius: num }),
+            Err(e) => Err(e),
+        }
+    }
+}
+
+fn main() {
+    let radius = "    3 ";
+    let circle: Circle = radius.parse().unwrap();
+    println!("{:?}", circle);
 }
 ```
 


### PR DESCRIPTION
I'm learning Rust by working my way through both the main book and (the excellent) Rust By Example, but I missed having an example of actually implementing the FromStr trait for the Circle type on the 'To and From Strings' page. This is my beginner's attempt at providing one.