### PR TITLE
Remove the link to Japanese translation

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,7 +68,6 @@ Please see the [TRANSLATING.md] file for more details.
 
 * [Bulgarian](https://github.com/kberov/rust-by-example-bg)
 * [Chinese](https://github.com/rust-lang-cn/rust-by-example-cn)
-* [Japanese](https://github.com/rust-lang-ja/rust-by-example-ja)
 * [French](https://github.com/Songbird0/FR_RBE)
 * [Russian](https://github.com/ruRust/rust-by-example)
 * [Vietnamese](https://github.com/EyesCrypto-Insights/rust-by-example-vn)


### PR DESCRIPTION
This PR removes the link to Japanese translation because it was merged into this repository.