### PR TITLE
Update lifetime_bounds.md

### DIFF
--- a/src/scope/lifetime/lifetime_bounds.md
+++ b/src/scope/lifetime/lifetime_bounds.md
@@ -16,7 +16,7 @@ use std::fmt::Debug; // Trait to bound with.
 #[derive(Debug)]
 struct Ref<'a, T: 'a>(&'a T);
 // `Ref` contains a reference to a generic type `T` that has
-// an unknown lifetime `'a`. `T` is bounded such that any
+// some lifetime `'a` unknown by `Ref`. `T` is bounded such that any
 // *references* in `T` must outlive `'a`. Additionally, the lifetime
 // of `Ref` may not exceed `'a`.
 


### PR DESCRIPTION
The wording on this page was a little confusing to me at first. It read as if the lifetime was unknown at compile time, but it's just unknown to `Ref`