### PR TITLE
Update primitives.md with examples

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,9 +1,6 @@
 # Rust By Example
 
-[![Build Status][travis-badge]][travis-repo]
-
-[travis-badge]: https://travis-ci.com/rust-lang/rust-by-example.svg?branch=master
-[travis-repo]: https://travis-ci.com/rust-lang/rust-by-example
+[![Build Status](https://github.com/rust-lang/rust-by-example/actions/workflows/rbe.yml/badge.svg)](https://github.com/rust-lang/rust-by-example/actions)
 
 Learn Rust with examples (Live code editor included)
 

--- a/src/primitives.md
+++ b/src/primitives.md
@@ -50,7 +50,7 @@ fn main() {
     // Variables can be overwritten with shadowing.
     let mutable = true;
 
-    /* Compound types - Array and Tuples */
+    /* Compound types - Array and Tuple */
 
     // Array signature consists of Type T and length as [T; length].
     let my_array: [i32; 5] = [1, 2, 3, 4, 5];

--- a/src/primitives.md
+++ b/src/primitives.md
@@ -49,6 +49,15 @@ fn main() {
 
     // Variables can be overwritten with shadowing.
     let mutable = true;
+
+    /* Compound types - Array and Tuples */
+
+    // Array signature consists of Type T and length as [T; length].
+    let my_array: [i32; 5] = [1, 2, 3, 4, 5];
+
+    // Tuple is a collection of values of different types 
+    // and is constructed using parentheses ().
+    let my_tuple = (5u32, 1u8, true, -5.04f32);
 }
 ```
 


### PR DESCRIPTION
This is related to the issue https://github.com/rust-lang/rust-by-example/issues/1873

I agree with the author of the issue. 

Hence added one simple example each, for array and tuple. It also helps as the scalar types are introduced on the same page.


