### PR TITLE
Fix ambiguous comment on 2.3 Arrays and Slices page

### DIFF
--- a/src/primitives/array.md
+++ b/src/primitives/array.md
@@ -63,7 +63,7 @@ fn main() {
         }
     }
 
-    // Out of bound indexing on array causes compile time error.
+    // Out of bound indexing on array with constant value causes compile time error.
     //println!("{}", xs[5]);
     // Out of bound indexing on slice causes runtime error.
     //println!("{}", xs[..][5]);


### PR DESCRIPTION
Comment from the page seems ambiguous since out of bound indexing on array with variables may cause runtime error.

```rust
// Out of bound indexing on array can cause runtime error
fn main() {
    let xs = [1, 2, 3, 4, 5];

    let idx = create_five();
    println!("{}", xs[idx]);
}

fn create_five() -> usize {
    5
}
```

The Rust Reference also mentions array indexing in the following link
https://doc.rust-lang.org/reference/expressions/array-expr.html#array-and-slice-indexing-expressions
**Array access is a [constant expression](https://doc.rust-lang.org/reference/const_eval.html#constant-expressions), so bounds can be checked at compile-time with a constant index value. Otherwise a check will be performed at run-time that will put the thread in a panicked state if it fails.**

