### PR TITLE
`read_lines`: Use `.map_while(Result::ok)` instead of `.flatten()`.

### DIFF
--- a/src/std_misc/file/read_lines.md
+++ b/src/std_misc/file/read_lines.md
@@ -56,7 +56,7 @@ fn main() {
     // File hosts.txt must exist in the current path
     if let Ok(lines) = read_lines("./hosts.txt") {
         // Consumes the iterator, returns an (Optional) String
-        for line in lines.flatten() {
+        for line in lines.map_while(Result::ok) {
             println!("{}", line);
         }
     }


### PR DESCRIPTION
Clippy gives a warning when using `.flatten()`: https://rust-lang.github.io/rust-clippy/master/index.html#lines_filter_map_ok