### PR TITLE
fix(doc): correct small errors in pipes.md

### DIFF
--- a/src/std_misc/process/pipe.md
+++ b/src/std_misc/process/pipe.md
@@ -1,6 +1,6 @@
 # Pipes
 
-The `std::Child` struct represents a running child process, and exposes the
+The `std::process::Child` struct represents a child process, and exposes the
 `stdin`, `stdout` and `stderr` handles for interaction with the underlying
 process via pipes.
 


### PR DESCRIPTION
- Fixed mistake referring to `std::Child` rather than `std::process::Child`
- From [the docs](https://doc.rust-lang.org/std/process/struct.Child.html), `std::process::Child` can either represent a running _or_ exited child process. If it's only mentioned that it represents a "running" process, then I think it can be unclear where the process result will go. However, specifying "running or child" makes the next bit of text awkward in that line, so I think it makes more sense to lean towards just not being that specific at all and letting the documentation go into that sort of depth.