### PR TITLE
Upgrade actions/upload-artifact action

### DIFF
--- a/.github/workflows/rbe.yml
+++ b/.github/workflows/rbe.yml
@@ -72,7 +72,7 @@ jobs:
         done
 
     - name: Upload Artifact
-      uses: actions/upload-artifact@v3
+      uses: actions/upload-artifact@v4
       with:
         name: rust-by-example
         path: book


### PR DESCRIPTION
GitHub has announced that v3 of the [actions/upload-artifact] action will be deprecated on November 30, 2024[^1]. The action has been upgraded to its most recent version to continue functioning after this date.

[actions/upload-artifact]: https://github.com/actions/upload-artifact
[^1]: https://github.blog/changelog/2024-04-16-deprecation-notice-v3-of-the-artifact-actions