### PR TITLE
Minor Update to vec.md to fix compiler error

### DIFF
--- a/src/std/vec.md
+++ b/src/std/vec.md
@@ -15,7 +15,7 @@ needs to be surpassed, the vector is reallocated with a larger capacity.
 ```rust,editable,ignore,mdbook-runnable
 fn main() {
     // Iterators can be collected into vectors
-    let collected_iterator: Vec<i32> = (0..10).collect();
+    let mut collected_iterator: Vec<i32> = (0..10).collect();
     println!("Collected (0..10) into: {:?}", collected_iterator);
 
     // The `vec!` macro can be used to initialize a vector


### PR DESCRIPTION
Without `mut` before the `collected_iterator` variable the compiler throws an error when the program is ran.