### PR TITLE
Use `From::from` fn pointer to convert to boxed errors

### DIFF
--- a/src/error/multiple_error_types/boxing_errors.md
+++ b/src/error/multiple_error_types/boxing_errors.md
@@ -28,10 +28,10 @@ impl error::Error for EmptyVec {}
 
 fn double_first(vec: Vec<&str>) -> Result<i32> {
     vec.first()
-        .ok_or_else(|| EmptyVec.into()) // Converts to Box
+        .ok_or_else(|| EmptyVec.into()) // Converts to Box using Into trait.
         .and_then(|s| {
             s.parse::<i32>()
-                .map_err(|e| e.into()) // Converts to Box
+                .map_err(From::from) // Converts to Box using From::from fn pointer.
                 .map(|i| 2 * i)
         })
 }


### PR DESCRIPTION
This PR changes the recommended way to convert to a boxed error `Box<dyn Error>` for types that impl `Error`. It changes the `map_err(|e| e.into())` to `map_err(From::from)` which I believe is much more concise and idiomatic (and satisfying!). 

### Motivation 
Like a lot of people I bashed my head on this problem of getting the compiler to accept the mapped error as a `Box<dyn Error>` and not a `Box<CustomError>`. I eventually found `e.into()` and then I realized that means I can use `From::from`. 

I have done some searching on the StackOverflow and the Rust user forums to see how everyone else is solving  this problem and I have yet to find an example of someone recommending `From::from` fn pointer. Everyone just suggests `|e| e.into()` even though the former does the same thing more concisely. 

I think it is just an oversight and it doesn't occur to the person helping that if `e.into` works, that means `From::from(e)` necessarily works as well. So I figured I would share this solution in the official example book if it is indeed an improvement over the current recommended method.

Any way, let know what you guys think!