### PR TITLE
Fix function name in new_types.md in Japanese

### DIFF
--- a/po/ja.po
+++ b/po/ja.po
@@ -8638,7 +8638,7 @@ msgid ""
 "For example, an age verification function that checks age in years, _must_ "
 "be given a value of type `Years`."
 msgstr ""
-"例えば、年齢を年単位で確認する`old_enough`には「Years」という型の値を *与えな"
+"例えば、年齢を年単位で確認する`is_adult`には「Years」という型の値を *与えな"
 "ければならない* ようにすることが可能です。"
 
 #: src/generics/new_types.md:22


### PR DESCRIPTION
The function name has been changed in https://github.com/rust-lang/rust-by-example/commit/596b7dfc30550254e13a96000da881958a9152d7