### PR TITLE
link the _tuple_ page instead "TupleStruct"

### DIFF
--- a/src/generics/phantom.md
+++ b/src/generics/phantom.md
@@ -55,9 +55,8 @@ fn main() {
 
 ### See also:
 
-[Derive], [struct], and [TupleStructs]
+[Derive], [struct], and [tuple](../primitives/tuples.html).
 
 [Derive]: ../trait/derive.md
 [struct]: ../custom_types/structs.md
-[TupleStructs]: ../custom_types/structs.md
 [std::marker::PhantomData]: https://doc.rust-lang.org/std/marker/struct.PhantomData.html


### PR DESCRIPTION
I'm not sure what that meant to be initially, but this looks more useful now.