### PR TITLE
Fixing grammar in panic section

### DIFF
--- a/src/error/panic.md
+++ b/src/error/panic.md
@@ -6,7 +6,7 @@ Here, we explicitly call `panic` on our error condition:
 
 ```rust,editable,ignore,mdbook-runnable
 fn drink(beverage: &str) {
-    // You shouldn't drink too much sugary beverages.
+    // You shouldn't drink too many sugary beverages.
     if beverage == "lemonade" { panic!("AAAaaaaa!!!!"); }
 
     println!("Some refreshing {} is all I need.", beverage);


### PR DESCRIPTION
"too much sugary beverages" -> "too many sugary beverages"