### PR TITLE
Update book.toml rename `author` field to `authors`

### DIFF
--- a/book.toml
+++ b/book.toml
@@ -1,7 +1,7 @@
 [book]
 title = "Rust By Example"
 description = "Rust by Example (RBE) is a collection of runnable examples that illustrate various Rust concepts and standard libraries."
-author = "The Rust Community"
+authors = ["The Rust Community"]
 
 [output.html.playpen]
 editable = true


### PR DESCRIPTION
See the [mdbook documentation](https://rust-lang.github.io/mdBook/format/configuration/general.html)
Apparently the `author` was field was [incorrect documentation](https://github.com/rust-lang/mdBook/issues/2623)