### PR TITLE
Add example to comment.md to teach how to toggle a whole code block using block comments

### DIFF
--- a/src/hello/comment.md
+++ b/src/hello/comment.md
@@ -34,6 +34,19 @@ fn main() {
     no actual need for it.
     */
 
+    // Here's another powerful use of block comments: you can uncomment
+    // and comment a whole block by simply adding or removing a single
+    // '/' character:
+
+    /* <- add another '/' before the 1st one to uncomment the whole block
+
+    println!("Now");
+    println!("everything");
+    println!("executes!");
+    // line comments inside are not affected by either state
+
+    // */
+
     // You can manipulate expressions more easily with block comments
     // than with line comments. Try deleting the comment delimiters
     // to change the result:


### PR DESCRIPTION
Block comments allow people to uncomment/comment a whole code block by adding/removing a single '/' character.

None of the existing examples clearly demonstrates this ability, so I thought it'd be useful to do so here.

The chapter is already very small, so adding a few extra lines should be acceptable.

I actually learned this from [Haskell](https://en.wikibooks.org/wiki/Haskell/Variables_and_functions#Comments), although I don't use it as often as Rust.

Toggling an entire code block by adding/removing a single character seems very, very useful, so I think it is worth teaching it to users and it deserves a prominent spot in this popular learning resource.