### PR TITLE
Rename count to index for clarity

### DIFF
--- a/src/hello/print/print_display/testcase_list.md
+++ b/src/hello/print/print_display/testcase_list.md
@@ -31,11 +31,11 @@ impl fmt::Display for List {
         write!(f, "[")?;
 
         // Iterate over `v` in `vec` while enumerating the iteration
-        // count in `count`.
-        for (count, v) in vec.iter().enumerate() {
+        // index in `index`.
+        for (index, v) in vec.iter().enumerate() {
             // For every element except the first, add a comma.
             // Use the ? operator to return on errors.
-            if count != 0 { write!(f, ", ")?; }
+            if index != 0 { write!(f, ", ")?; }
             write!(f, "{}", v)?;
         }
 


### PR DESCRIPTION
In the following code, "`count`" is misleading, as it is actually an index.
```rust
// Iterate over `v` in `vec` while enumerating the iteration
// count in `count `.
for (count, v) in vec.iter().enumerate() {
    // For every element except the first, add a comma.
    // Use the ? operator to return on errors.
    if count != 0 { write!(f, ", ")?; }
    write!(f, "{}", v)?;
}
```

---
this PR just replaces "`count`" with "`index`"
```rust
// Iterate over `v` in `vec` while enumerating the iteration
// index in `index `.
for (index, v) in vec.iter().enumerate() {
    // For every element except the first, add a comma.
    // Use the ? operator to return on errors.
    if index != 0 { write!(f, ", ")?; }
    write!(f, "{}", v)?;
}
```
