### PR TITLE
docs: mark illustrative 'static lifetime example with `ignore`

### DIFF
--- a/src/scope/lifetime/static_lifetime.md
+++ b/src/scope/lifetime/static_lifetime.md
@@ -3,7 +3,7 @@
 Rust has a few reserved lifetime names. One of those is `'static`. You
 might encounter it in two situations:
 
-```rust, editable
+```rust, ignore
 // A reference with 'static lifetime:
 let s: &'static str = "hello world";
 


### PR DESCRIPTION
The example demonstrating `'static` lifetime usage is not meant to be compiled. Changed the code block annotation from `editable` to `ignore` to better reflect its purpose and avoid confusion.