### PR TITLE
  The example is not meant to be compiled. Changed the code block ann…

### DIFF
--- a/src/error/option_unwrap/question_mark.md
+++ b/src/error/option_unwrap/question_mark.md
@@ -5,7 +5,7 @@ use the `?` operator. If `x` is an `Option`, then evaluating `x?` will return
 the underlying value if `x` is `Some`, otherwise it will terminate whatever
 function is being executed and return `None`.
 
-```rust,editable
+```rust,ignore
 fn next_birthday(current_age: Option<u8>) -> Option<String> {
     // If `current_age` is `None`, this returns `None`.
     // If `current_age` is `Some`, the inner `u8` value + 1


### PR DESCRIPTION
…otation from editable to ignore to better reflect its purpose and avoid confusion.

The next_birthday function is not meant to be compiled as there is missing main function. Changed the code block annotation from editable to ignore to better reflect its purpose and avoid confusion.