### PR TITLE
fix(docs): standardize on `no_run` attribute for documentation examples

### DIFF
--- a/src/std_misc/file/read_lines.md
+++ b/src/std_misc/file/read_lines.md
@@ -5,7 +5,7 @@
 This might be a reasonable first attempt for a beginner's first
 implementation for reading lines from a file.
 
-```rust,norun
+```rust,no_run
 use std::fs::read_to_string;
 
 fn read_lines(filename: &str) -> Vec<String> {
@@ -23,7 +23,7 @@ Since the method `lines()` returns an iterator over the lines in the file,
 we can also perform a map inline and collect the results, yielding a more
 concise and fluent expression.
 
-```rust,norun
+```rust,no_run
 use std::fs::read_to_string;
 
 fn read_lines(filename: &str) -> Vec<String> {


### PR DESCRIPTION
- Replaced `norun` with `no_run` to align with current documentation standards