### PR TITLE
The example is not meant to be compiled with out passing arguments.

### DIFF
--- a/src/std_misc/arg/matching.md
+++ b/src/std_misc/arg/matching.md
@@ -2,7 +2,7 @@
 
 Matching can be used to parse simple arguments:
 
-```rust,editable
+```rust,ignore
 use std::env;
 
 fn increase(number: i32) {


### PR DESCRIPTION
The example is not meant to be compiled. Changed the code block annotation from editable to ignore to better reflect its purpose and avoid confusion as there require the arguments to run the code properly with out any errors