### PR TITLE
Fix syntax highligting

### DIFF
--- a/.github/workflows/rbe.yml
+++ b/.github/workflows/rbe.yml
@@ -27,7 +27,7 @@ jobs:
     - name: Install mdbook
       run: |
         mkdir bin
-        curl -sSL https://github.com/rust-lang/mdBook/releases/download/v0.4.46/mdbook-v0.4.46-x86_64-unknown-linux-gnu.tar.gz | tar -xz --directory=bin
+        curl -sSL https://github.com/rust-lang/mdBook/releases/download/v0.4.51/mdbook-v0.4.51-x86_64-unknown-linux-gnu.tar.gz | tar -xz --directory=bin
         echo "$(pwd)/bin" >> ${GITHUB_PATH}
 
     - name: Install mdbook-i18n-helpers


### PR DESCRIPTION
Resolves https://github.com/rust-lang/rust-by-example/issues/1933

This PR brings back syntax highlighting for editable rust code samples.

The build workflow [uses](https://github.com/rust-lang/rust-by-example/blob/21f4e32b8b40d36453fae16ec07ad4b857c445b6/.github/workflows/rbe.yml#L30) `mdbook@0.4.46` while the latest version `mdbook@0.4.51` has a [fix](https://github.com/rust-lang/mdBook/pull/2710) for syntax highliting. I tested it locally and was able to reproduce the bug with `mdbook@0.4.46` while with the latest `mdbook@0.4.51` the syntax highlighting works as expected. 

