### PR TITLE
Document drawbacks of alternatives to match binding

### DIFF
--- a/src/flow_control/match/binding.md
+++ b/src/flow_control/match/binding.md
@@ -16,8 +16,13 @@ fn main() {
     match age() {
         0             => println!("I haven't celebrated my first birthday yet"),
         // Could `match` 1 ..= 12 directly but then what age
-        // would the child be? Instead, bind to `n` for the
-        // sequence of 1 ..= 12. Now the age can be reported.
+        // would the child be?
+        // Could `match` n and use an `if` guard, but would
+        // not contribute to exhaustiveness checks.
+        // (Although in this case that would not matter since
+        // a "catch-all" pattern is present at the bottom)
+        // Instead, bind to `n` for the sequence of 1 ..= 12.
+        // Now the age can be reported.
         n @ 1  ..= 12 => println!("I'm a child of age {:?}", n),
         n @ 13 ..= 19 => println!("I'm a teen of age {:?}", n),
         // Nothing bound. Return the result.
@@ -37,6 +42,13 @@ fn main() {
     match some_number() {
         // Got `Some` variant, match if its value, bound to `n`,
         // is equal to 42.
+        // Could also use `Some(42)` and print `"The Awnser: 42!"`
+        // but that would require changing `42` in 2 spots should
+        // you ever wish to change it.
+        // Could also use `Some(n) if n == 42` and print `"The Awnser: {n}!"`
+        // but that would not contribute to exhaustiveness checks.
+        // (Although in this case that would not matter since
+        // the next arm is a "catch-all" pattern)
         Some(n @ 42) => println!("The Answer: {}!", n),
         // Match any other number.
         Some(n)      => println!("Not interesting... {}", n),


### PR DESCRIPTION
Page should also probably also explicitly state that binding can be used in any place a pattern is used (same goes for `if let`, `let-else` and `while-let`) and that bindings can be nested (ex: `x @ Some(n @ 42)`)