### PR TITLE
Improve the activity instructions in `print_display`

### DIFF
--- a/src/hello/print/print_display.md
+++ b/src/hello/print/print_display.md
@@ -111,9 +111,19 @@ guide to add a `Complex` struct to the example. When printed in the same
 way, the output should be:
 
 ```txt
-Display: 3.3 + 7.2i
+Display: 3.3 +7.2i
 Debug: Complex { real: 3.3, imag: 7.2 }
+
+Display: 4.7 -2.3i
+Debug: Complex { real: 4.7, imag: -2.3 }
 ```
+
+Bonus: Add a space before the `+`/`-` signs.
+
+Hints in case you get stuck:
+
+- Check the documentation for [`Sign/#/0`][fmt_sign0] in `std::fmt`.
+- Bonus: Check [`if`-`else`][if_else] branching and the [`abs`][f64_abs] function.
 
 ### See also:
 
@@ -121,7 +131,10 @@ Debug: Complex { real: 3.3, imag: 7.2 }
 [`trait`][traits], and [`use`][use]
 
 [derive]: ../../trait/derive.md
+[f64_abs]: https://doc.rust-lang.org/std/primitive.f64.html#method.abs
 [fmt]: https://doc.rust-lang.org/std/fmt/
+[fmt_sign0]: https://doc.rust-lang.org/std/fmt/#sign0
+[if_else]: ../../flow_control/if_else.md
 [macros]: ../../macros.md
 [structs]: ../../custom_types/structs.md
 [traits]: https://doc.rust-lang.org/std/fmt/#formatting-traits


### PR DESCRIPTION
Related to https://github.com/rust-lang/rust-by-example/issues/1678

As mentioned in the issue, the expected solution was likely to be 
```Rust
write!(f, "{} {:+}i", self.real, self.imag)
```
It seems that adding a space after `+`/`-` isn't directly supported by `std::fmt`, but it can be solved with a conditional statement and the `abs()` function, for example:

```Rust
let sign = if self.imag >= 0.0 { "+" } else { "-" };
write!(f, "{} {} {}i", self.real, sign, self.imag.abs())
```

I've tried to clarify the instructions and hints. I'm open to suggestions for improving this exercise.