### PR TITLE
Support building books using mdbook in main (v0.5.x)

### DIFF
--- a/book.toml
+++ b/book.toml
@@ -5,7 +5,6 @@ authors = ["The Rust Community"]
 
 [output.html.playpen]
 editable = true
-editor = "ace"
 line-numbers = true
 
 [output.html.fold]
@@ -27,4 +26,5 @@ edition = "2021"
 extra-watch-dirs = ["po"]
 
 [preprocessor.gettext]
+optional = true
 after = ["links"]


### PR DESCRIPTION
- Missing preprocessors are now an error unless the `optional` field is set: https://github.com/rust-lang/mdBook/commit/d7892f56013ea2cab11c7c581f2c5f2c1d3cb2c6
- Fix: [ERROR] (mdbook_core::utils): Error: Failed to deserialize `{name}`. Caused By: unknown field `editor`, expected one of `editable`, `copyable`, `copy-js`, `line-numbers`, `runnable`