### PR TITLE
Fix drop order explanation in trait > drop

### DIFF
--- a/src/trait/drop.md
+++ b/src/trait/drop.md
@@ -6,7 +6,7 @@ resources that the implementor instance owns.
 
 `Box`, `Vec`, `String`, `File`, and `Process` are some examples of types that
 implement the `Drop` trait to free resources. The `Drop` trait can also be
-manually implemented for any custom data type. 
+manually implemented for any custom data type.
 
 The following example adds a print to console to the `drop` function to announce
 when it is called.

--- a/src/trait/drop.md
+++ b/src/trait/drop.md
@@ -6,7 +6,7 @@ resources that the implementor instance owns.
 
 `Box`, `Vec`, `String`, `File`, and `Process` are some examples of types that
 implement the `Drop` trait to free resources. The `Drop` trait can also be
-manually implemented for any custom data type.
+manually implemented for any custom data type. 
 
 The following example adds a print to console to the `drop` function to announce
 when it is called.
@@ -76,15 +76,15 @@ impl TempFile {
 }
 
 // When TempFile is dropped:
-// 1. First, the File will be automatically closed (Drop for File)
-// 2. Then our drop implementation will remove the file
+// 1. First, our drop implementation will remove the file's name from the filesystem.
+// 2. Then, File's drop will close the file, removing its underlying content from the disk.
 impl Drop for TempFile {
     fn drop(&mut self) {
-        // Note: File is already closed at this point
         if let Err(e) = std::fs::remove_file(&self.path) {
             eprintln!("Failed to remove temporary file: {}", e);
         }
         println!("> Dropped temporary file: {:?}", self.path);
+        // File's drop is implicitly called here because it is a field of this struct.
     }
 }
 


### PR DESCRIPTION
The current explanation for trait > drop asserts that `drop` for struct fields are called before the `drop` implementation of the struct itself. But this is incorrect, the order is actually reversed. (e.g., [this sample](https://play.rust-lang.org/?version=stable&mode=debug&edition=2021&gist=0e79d64af2e5f5a02f17912195c15adb)). 

This PR fixes the previous explanation to have the correct order of operations.