### PR TITLE
Update enum_use.md

### DIFF
--- a/src/custom_types/enum/enum_use.md
+++ b/src/custom_types/enum/enum_use.md
@@ -19,9 +19,9 @@ enum Role {
 fn main() {
     // Explicitly `use` each name so they are available without
     // manual scoping.
-    use crate::Stage::{Beginner, Advanced};
+    use Stage::{Beginner, Advanced};
     // Automatically `use` each name inside `Role`.
-    use crate::Role::*;
+    use Role::*;
 
     // Equivalent to `Stage::Beginner`.
     let stage = Beginner;


### PR DESCRIPTION
Make code more idiomatic.

A person learning Rust for the first time seeing `use crate::Role::*` gets spun into a rabbit hole of:

- understanding what "crate::" means here
- is a single file a crate? (look it up in the docs)
- do even enums local to the file have to be specified with an absolute path from crate root?

Besides, `use crate:: ...` is taught in the example for use later on, which is linked to at the bottom of this document. Using this document to only teach about unpacking enums into the name space, and then using the other document to introduce `use crate::`, means less things need to be learned all at once, reducing confusion.