### PR TITLE
Include a link to The Rust Reference in flow_control/match/destructuring

### DIFF
--- a/src/flow_control/match/destructuring.md
+++ b/src/flow_control/match/destructuring.md
@@ -13,3 +13,7 @@ A `match` block can destructure items in a variety of ways.
 [struct]: destructuring/destructure_structures.md
 [tuple]: destructuring/destructure_tuple.md
 [slice]: destructuring/destructure_slice.md
+
+### See also:
+
+[The Rust Reference for Destructuring](https://doc.rust-lang.org/reference/patterns.html#r-patterns.destructure)


### PR DESCRIPTION
<img width="1739" height="481" alt="Destructuring - Rust By Example" src="https://github.com/user-attachments/assets/dd359ae1-4bbc-496c-b1f7-56ffcb7d6559" />
