### PR TITLE
add clarification on overflowing_literals lint

### DIFF
--- a/src/types/cast.md
+++ b/src/types/cast.md
@@ -8,7 +8,7 @@ except in cases where C has undefined behavior. The behavior of all casts
 between integral types is well defined in Rust.
 
 ```rust,editable,ignore,mdbook-runnable
-// Suppress all warnings from casts which overflow.
+// Suppress all errors from casts which overflow.
 #![allow(overflowing_literals)]
 
 fn main() {
@@ -31,7 +31,8 @@ fn main() {
 
     // when casting any value to an unsigned type, T,
     // T::MAX + 1 is added or subtracted until the value
-    // fits into the new type
+    // fits into the new type ONLY when the #![allow(overflowing_literals)]
+    // lint is specified like above. Otherwise there will be a compiler error.
 
     // 1000 already fits in a u16
     println!("1000 as a u16 is: {}", 1000 as u16);


### PR DESCRIPTION
In a previous PR (#605) a change was made to suppress warnings from casts which overflow. In [this commit for rust](https://github.com/rust-lang/rust/commit/c6549681008a09b9a267f1470fe959b428d69736) the default behavior for the orverflowing_literals lint was changed from warn to deny. 

This PR updates language to emphasize that failing to include the lint will result in errors.