### PR TITLE
Update documentation for `any` function in iter_any.md

### DIFF
--- a/src/fn/closures/closure_examples/iter_any.md
+++ b/src/fn/closures/closure_examples/iter_any.md
@@ -13,8 +13,9 @@ pub trait Iterator {
     // and modified, but not consumed.
     fn any<F>(&mut self, f: F) -> bool where
         // `FnMut` meaning any captured variable may at most be
-        // modified, not consumed. `Self::Item` states it takes
-        // arguments to the closure by value.
+        // modified, not consumed. `Self::Item` is the closure parameter type,
+        // which is determined by the iterator (e.g., `&T` for `.iter()`,
+        // `T` for `.into_iter()`).
         F: FnMut(Self::Item) -> bool;
 }
 ```


### PR DESCRIPTION
Clarify the description of the `any` function parameters.

## Summary
Improved the clarity of the comment explaining `Self::Item` in the `Iterator::any` trait example to help readers better understand how the parameter type is determined.

## Changes
- Replaced the potentially confusing phrase "`Self::Item` states it takes arguments to the closure by value" with a clearer explanation
- Added concrete examples showing that `Self::Item` is determined by the iterator type (e.g., `&T` for `.iter()`, `T` for `.into_iter()`)

## Motivation
The original comment could be misinterpreted to mean that `Self::Item` is always an owned value, when in fact it can be a reference type depending on the iterator. This clarification helps readers understand that:
- The iterator implementation defines what `Self::Item` is
- Different iterator methods (`.iter()`, `.into_iter()`, `.iter_mut()`) yield different types
- The closure parameter type matches whatever `Self::Item` is for that specific iterator