### PR TITLE
Fix HOF.MD sum of odd squares algorithm

### DIFF
--- a/src/fn/hof.md
+++ b/src/fn/hof.md
@@ -26,18 +26,17 @@ fn main() {
             break;
         } else if is_odd(n_squared) {
             // Accumulate value, if it's odd
-            acc += n_squared;
+            acc += n;
         }
     }
     println!("imperative style: {}", acc);
 
     // Functional approach
-    let sum_of_squared_odd_numbers: u32 =
-        (0..).map(|n| n * n)                             // All natural numbers squared
-             .take_while(|&n_squared| n_squared < upper) // Below upper limit
-             .filter(|&n_squared| is_odd(n_squared))     // That are odd
-             .sum();                                     // Sum them
-    println!("functional style: {}", sum_of_squared_odd_numbers);
+    let sum: u32 =
+        (0..).take_while(|&n| n * n < upper) // Below upper limit
+             .filter(|&n| is_odd(n * n))     // That are odd
+             .sum();                         // Sum them
+    println!("functional style: {}", sum);
 }
 ```
 


### PR DESCRIPTION
The algorithm to "Find the sum of all the numbers with odd squares under 1000" is wrong. It was calculating the sum of odd squares under 1000.

The numbers with odd squares under 1000 are: 1 + 3 + 5 + 7 + 9 + 11 + 13 + 15 + 17 + 19 + 21 + 23 + 25 + 27 + 29 + 31 = 256

The current code on the website calculates: 1² + 3² + 5² + 7² + 9² + 11² + 13² + 15² + 17² + 19² + 21² + 23² + 25² + 27² + 29² + 31² = 5456

Another possible solution is to change the message "Find the sum of all the numbers with odd squares under 1000" to "Find the sum of all odd squares less than 1000"