### PR TITLE
remove debug printing for the u32 and bool in variable_bindings.md

### DIFF
--- a/src/variable_bindings.md
+++ b/src/variable_bindings.md
@@ -16,8 +16,8 @@ fn main() {
     // copy `an_integer` into `copied_integer`
     let copied_integer = an_integer;
 
-    println!("An integer: {:?}", copied_integer);
-    println!("A boolean: {:?}", a_boolean);
+    println!("An integer: {}", copied_integer);
+    println!("A boolean: {}", a_boolean);
     println!("Meet the unit value: {:?}", unit);
 
     // The compiler warns about unused variable bindings; these warnings can


### PR DESCRIPTION
not needed as std::fmt::Display and std::fmt::Debug are the same for u32 and bool