### PR TITLE
Update expression.md: renamed variable x_cube to x_cubed

### DIFF
--- a/src/expression.md
+++ b/src/expression.md
@@ -36,10 +36,10 @@ fn main() {
 
     let y = {
         let x_squared = x * x;
-        let x_cube = x_squared * x;
+        let x_cubed = x_squared * x;
 
         // This expression will be assigned to `y`
-        x_cube + x_squared + x
+        x_cubed + x_squared + x
     };
 
     let z = {


### PR DESCRIPTION
another variable in that code block is called x_squared, so this name matches its pattern more cleanly