### PR TITLE
Add Portuguese (Brazil) translation files

### DIFF
--- a/TRANSLATING_PT.md
+++ b/TRANSLATING_PT.md
@@ -1,0 +1,108 @@
+# Diretrizes de tradução do Rust by Example
+
+Por favor, consulte o arquivo [CONTRIBUTING.md](https://github.com/rust-lang/rust-by-example/blob/master/CONTRIBUTING.md?utm_source=chatgpt.com) para as diretrizes gerais de contribuição.
+Este arquivo descreve o fluxo de trabalho de tradução.
+
+## Fluxo de trabalho de tradução
+
+### Preparação
+
+O RBE utiliza o [mdbook-i18n-helpers](https://github.com/google/mdbook-i18n-helpers?utm_source=chatgpt.com) como framework de tradução.
+As seguintes ferramentas são necessárias:
+
+* Utilitários GNU gettext (`msgmerge` e `msgcat`)
+* mdbook-i18n-helpers (`cargo install mdbook-i18n-helpers`)
+
+---
+
+## Criando e Atualizando Traduções
+
+Consulte o arquivo [USAGE do mdbook-i18n-helpers](https://github.com/google/mdbook-i18n-helpers/blob/main/i18n-helpers/USAGE.md?utm_source=chatgpt.com) para obter instruções detalhadas de uso do mdbook-i18n-helpers.
+Abaixo está um resumo dos comandos principais:
+
+### Gerando um template de mensagens
+
+O template gerado `po/messages.pot` é necessário para criar ou atualizar traduções.
+
+```bash
+MDBOOK_OUTPUT='{"xgettext": {"pot-file": "messages.pot"}}' \
+  mdbook build -d po
+```
+
+### Criando um novo recurso de tradução
+
+`xx` é o código de idioma [ISO 639](https://en.wikipedia.org/wiki/List_of_ISO_639-1_codes).
+
+```bash
+msginit -i po/messages.pot -l xx -o po/xx.po
+```
+
+### Atualizando um recurso de tradução existente
+
+```bash
+msgmerge --update po/xx.po po/messages.pot
+```
+
+### Acompanhando o progresso da tradução
+
+```bash
+msgfmt --statistics po/xx.po
+```
+
+---
+
+## Editando recursos de tradução
+
+Após gerar um recurso de tradução `po/xx.po`, você pode escrever as mensagens traduzidas na entrada `msgstr` do arquivo `po/xx.po`.
+
+Para compilar um livro traduzido, utilize os seguintes comandos:
+
+```bash
+MDBOOK_BOOK__LANGUAGE=xx mdbook build
+MDBOOK_BOOK__LANGUAGE=xx mdbook serve
+```
+
+---
+
+## Adicionando uma entrada de idioma
+
+Por favor, adicione uma entrada de idioma em:
+
+* `.github/workflows/rbe.yml`
+* `theme/head.hbs`
+* `src/bootstrap/src/core/build_steps/doc.rs`
+
+no repositório [rust-lang/rust](https://github.com/rust-lang/rust?utm_source=chatgpt.com), conforme abaixo:
+
+### `rbe.yml`
+
+```yml
+env:
+  # Atualize o seletor de idiomas em index.hbs para incluir novos idiomas.
+  LANGUAGES: xx yy zz
+```
+
+### `head.hbs`
+
+```html
+<ul id="language-list" class="theme-popup" aria-label="Languages" role="menu">
+  <li role="none"><button role="menuitem" class="theme">
+      <a id="en">English</a>
+  </button></li>
+  <li role="none"><button role="menuitem" class="theme">
+      <a id="xx">Idioma XX</a>
+  </button></li>
+  <li role="none"><button role="menuitem" class="theme">
+      <a id="yy">Idioma YY</a>
+  </button></li>
+  <li role="none"><button role="menuitem" class="theme">
+      <a id="zz">Idioma ZZ</a>
+  </button></li>
+</ul>
+```
+
+### `src/bootstrap/src/core/build_steps/doc.rs`
+
+```rust
+RustByExample, "src/doc/rust-by-example", "rust-by-example", &["xx", "yy", "zz"], submodule;
+```

--- a/po/pt.po
+++ b/po/pt.po
@@ -1,0 +1,16986 @@
+msgid ""
+msgstr ""
+"Project-Id-Version: Rust By Example\n"
+"POT-Creation-Date: 2026-05-10T15:16:19\n"
+"PO-Revision-Date: \n"
+"Last-Translator: Bruno Freschi <bruno.freschi89@gmail.com>\n"
+"Language-Team: Portugues \n"
+"Language: pt\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"Plural-Forms: nplurals=1; plural=;\n"
+
+#: src/SUMMARY.md:1
+msgid "Summary"
+msgstr "Resumo"
+
+#: src/SUMMARY.md:3
+msgid "Introduction"
+msgstr "Introdução"
+
+#: src/SUMMARY.md:5 src/hello.md:1
+msgid "Hello World"
+msgstr "Olá Mundo"
+
+#: src/SUMMARY.md:6 src/hello/comment.md:1
+msgid "Comments"
+msgstr "Comentários"
+
+#: src/SUMMARY.md:7 src/hello/print.md:1
+msgid "Formatted print"
+msgstr "Impressão com formatação"
+
+#: src/SUMMARY.md:8 src/hello/print/print_debug.md:1
+msgid "Debug"
+msgstr "Depuração"
+
+#: src/SUMMARY.md:9 src/hello/print/print_display.md:1
+msgid "Display"
+msgstr "Display"
+
+#: src/SUMMARY.md:10 src/hello/print/print_display/testcase_list.md:1
+msgid "Testcase: List"
+msgstr "Exemplo: Lista"
+
+#: src/SUMMARY.md:11 src/hello/print/fmt.md:1
+msgid "Formatting"
+msgstr "Formatação"
+
+#: src/SUMMARY.md:13 src/primitives.md:1
+msgid "Primitives"
+msgstr "Primitivas"
+
+#: src/SUMMARY.md:14 src/primitives/literals.md:1
+msgid "Literals and operators"
+msgstr "Operadores e Literais"
+
+#: src/SUMMARY.md:15 src/primitives/tuples.md:1
+msgid "Tuples"
+msgstr "Tuplas"
+
+#: src/SUMMARY.md:16 src/primitives/array.md:1
+msgid "Arrays and Slices"
+msgstr "Arrays e slices"
+
+#: src/SUMMARY.md:18 src/custom_types.md:1
+msgid "Custom Types"
+msgstr "Tipos Personalizados"
+
+#: src/SUMMARY.md:19 src/custom_types/structs.md:1
+msgid "Structures"
+msgstr "Estruturas"
+
+#: src/SUMMARY.md:20 src/custom_types/enum.md:1
+msgid "Enums"
+msgstr "Enums"
+
+#: src/SUMMARY.md:21 src/custom_types/enum/enum_use.md:1
+msgid "use"
+msgstr "use"
+
+#: src/SUMMARY.md:22 src/custom_types/enum/c_like.md:1
+msgid "C-like"
+msgstr "Herança de C"
+
+#: src/SUMMARY.md:23 src/custom_types/enum/testcase_linked_list.md:1
+msgid "Testcase: linked-list"
+msgstr "Exemplo: lista ligada"
+
+#: src/SUMMARY.md:24 src/custom_types/constants.md:1
+msgid "constants"
+msgstr "constantes"
+
+#: src/SUMMARY.md:26 src/variable_bindings.md:1
+msgid "Variable Bindings"
+msgstr "Vinculações de variáveis"
+
+#: src/SUMMARY.md:27 src/SUMMARY.md:120 src/SUMMARY.md:123
+#: src/variable_bindings/mut.md:1 src/scope/move/mut.md:1
+#: src/scope/borrow/mut.md:1
+msgid "Mutability"
+msgstr "Mutabilidade"
+
+#: src/SUMMARY.md:28 src/variable_bindings/scope.md:1
+msgid "Scope and Shadowing"
+msgstr "Escopo e sombreamento"
+
+#: src/SUMMARY.md:29 src/variable_bindings/declare.md:1
+msgid "Declare first"
+msgstr "Declara primeiro"
+
+#: src/SUMMARY.md:30 src/variable_bindings/freeze.md:1
+msgid "Freezing"
+msgstr "Congelar"
+
+#: src/SUMMARY.md:32 src/types.md:1
+msgid "Types"
+msgstr "Tipos"
+
+#: src/SUMMARY.md:33 src/types/cast.md:1
+msgid "Casting"
+msgstr "Conversão de tipo"
+
+#: src/SUMMARY.md:34 src/types/literals.md:1
+msgid "Literals"
+msgstr "Literais"
+
+#: src/SUMMARY.md:35 src/types/inference.md:1
+msgid "Inference"
+msgstr "Inferência"
+
+#: src/SUMMARY.md:36 src/SUMMARY.md:124 src/types/alias.md:1
+#: src/scope/borrow/alias.md:1
+msgid "Aliasing"
+msgstr "Aliasing"
+
+#: src/SUMMARY.md:38 src/conversion.md:1
+msgid "Conversion"
+msgstr "Conversão"
+
+#: src/SUMMARY.md:39 src/conversion/from_into.md:1
+msgid "`From` and `Into`"
+msgstr "`From` e `Into`"
+
+#: src/SUMMARY.md:40 src/conversion/try_from_try_into.md:1
+msgid "`TryFrom` and `TryInto`"
+msgstr "`TryFrom` e `TryInto`"
+
+#: src/SUMMARY.md:41
+msgid "To and from `String`s"
+msgstr "De e para `String`s"
+
+#: src/SUMMARY.md:43 src/expression.md:1
+msgid "Expressions"
+msgstr "Expressões"
+
+#: src/SUMMARY.md:45 src/flow_control.md:1
+msgid "Flow of Control"
+msgstr "Controle de Fluxo"
+
+#: src/SUMMARY.md:46 src/flow_control/if_else.md:1
+msgid "if/else"
+msgstr "if/else"
+
+#: src/SUMMARY.md:47 src/flow_control/loop.md:1
+msgid "loop"
+msgstr "loop"
+
+#: src/SUMMARY.md:48 src/flow_control/loop/nested.md:1
+msgid "Nesting and labels"
+msgstr "Aninhamento e rótulos"
+
+#: src/SUMMARY.md:49 src/flow_control/loop/return.md:1
+msgid "Returning from loops"
+msgstr "Retornar de loops"
+
+#: src/SUMMARY.md:50 src/flow_control/while.md:1
+msgid "while"
+msgstr "while"
+
+#: src/SUMMARY.md:51 src/flow_control/for.md:3
+msgid "for and range"
+msgstr "for e range"
+
+#: src/SUMMARY.md:52 src/flow_control/match.md:1
+msgid "match"
+msgstr "match"
+
+#: src/SUMMARY.md:53 src/flow_control/match/destructuring.md:1
+msgid "Destructuring"
+msgstr "Desestruturação"
+
+#: src/SUMMARY.md:54
+#: src/flow_control/match/destructuring/destructure_tuple.md:1
+msgid "tuples"
+msgstr "tuplas"
+
+#: src/SUMMARY.md:55
+#: src/flow_control/match/destructuring/destructure_slice.md:1
+msgid "arrays/slices"
+msgstr "arrays/slices"
+
+#: src/SUMMARY.md:56 src/flow_control/match/destructuring/destructure_enum.md:1
+msgid "enums"
+msgstr "enums"
+
+#: src/SUMMARY.md:57
+#: src/flow_control/match/destructuring/destructure_pointers.md:1
+msgid "pointers/ref"
+msgstr "ponteiros/ref"
+
+#: src/SUMMARY.md:58
+#: src/flow_control/match/destructuring/destructure_structures.md:1
+msgid "structs"
+msgstr "structs"
+
+#: src/SUMMARY.md:59 src/flow_control/match/guard.md:1
+msgid "Guards"
+msgstr "Guardas"
+
+#: src/SUMMARY.md:60 src/flow_control/match/binding.md:1
+msgid "Binding"
+msgstr "Vinculações"
+
+#: src/SUMMARY.md:61 src/flow_control/if_let.md:1
+msgid "if let"
+msgstr "if let"
+
+#: src/SUMMARY.md:62 src/flow_control/let_else.md:1
+msgid "let-else"
+msgstr "let-else"
+
+#: src/SUMMARY.md:63 src/flow_control/while_let.md:1
+msgid "while let"
+msgstr "while let"
+
+#: src/SUMMARY.md:65 src/SUMMARY.md:103 src/SUMMARY.md:128 src/fn.md:1
+#: src/generics/gen_fn.md:1 src/scope/lifetime/fn.md:1
+msgid "Functions"
+msgstr "Funções"
+
+#: src/SUMMARY.md:66 src/SUMMARY.md:129 src/scope/lifetime/methods.md:1
+msgid "Methods"
+msgstr "Métodos"
+
+#: src/SUMMARY.md:67 src/fn/closures.md:1
+msgid "Closures"
+msgstr "Closures"
+
+#: src/SUMMARY.md:68 src/fn/closures/capture.md:1
+msgid "Capturing"
+msgstr "Capturas"
+
+#: src/SUMMARY.md:69 src/fn/closures/input_parameters.md:1
+msgid "As input parameters"
+msgstr "Como parâmetros de entrada"
+
+#: src/SUMMARY.md:70 src/fn/closures/anonymity.md:1
+msgid "Type anonymity"
+msgstr "Anonimidade de tipos"
+
+#: src/SUMMARY.md:71 src/fn/closures/input_functions.md:1
+msgid "Input functions"
+msgstr "Funções de entrada"
+
+#: src/SUMMARY.md:72 src/fn/closures/output_parameters.md:1
+msgid "As output parameters"
+msgstr "Como parâmetros de saída"
+
+#: src/SUMMARY.md:73 src/fn/closures/closure_examples.md:1
+msgid "Examples in `std`"
+msgstr "Exemplos de `std`"
+
+#: src/SUMMARY.md:74 src/fn/closures/closure_examples/iter_any.md:1
+msgid "Iterator::any"
+msgstr "Iterator::any"
+
+#: src/SUMMARY.md:75 src/fn/closures/closure_examples/iter_find.md:1
+msgid "Searching through iterators"
+msgstr "Buscando com iteradores"
+
+#: src/SUMMARY.md:76 src/fn/hof.md:1
+msgid "Higher Order Functions"
+msgstr "Funções de Ordem Superior"
+
+#: src/SUMMARY.md:77 src/fn/diverging.md:1
+msgid "Diverging functions"
+msgstr "Funções Divergentes"
+
+#: src/SUMMARY.md:79 src/mod.md:1
+msgid "Modules"
+msgstr "Módulos"
+
+#: src/SUMMARY.md:80 src/mod/visibility.md:1
+msgid "Visibility"
+msgstr "Visibilidade"
+
+#: src/SUMMARY.md:81 src/mod/struct_visibility.md:1
+msgid "Struct visibility"
+msgstr "Visibilidade de estruturas"
+
+#: src/SUMMARY.md:82 src/mod/use.md:1
+msgid "The `use` declaration"
+msgstr "A declaração `use`"
+
+#: src/SUMMARY.md:83 src/mod/super.md:1
+msgid "`super` and `self`"
+msgstr "`super` e `self`"
+
+#: src/SUMMARY.md:84 src/mod/split.md:1
+msgid "File hierarchy"
+msgstr "Hierarquia de arquivos"
+
+#: src/SUMMARY.md:86 src/SUMMARY.md:98 src/crates.md:1 src/attribute/crate.md:1
+#: src/std_misc/arg.md:30
+msgid "Crates"
+msgstr "Crates"
+
+#: src/SUMMARY.md:87 src/crates/lib.md:1
+msgid "Creating a Library"
+msgstr "Criando uma Biblioteca"
+
+#: src/SUMMARY.md:88 src/crates/using_lib.md:1
+msgid "Using a Library"
+msgstr "Usando um Library"
+
+#: src/SUMMARY.md:90 src/cargo.md:1
+msgid "Cargo"
+msgstr "Cargo"
+
+#: src/SUMMARY.md:91 src/cargo/deps.md:1
+msgid "Dependencies"
+msgstr "Dependências"
+
+#: src/SUMMARY.md:92 src/cargo/conventions.md:1
+msgid "Conventions"
+msgstr "Convenções"
+
+#: src/SUMMARY.md:93
+msgid "Tests"
+msgstr "Testes"
+
+#: src/SUMMARY.md:94 src/cargo/build_scripts.md:1
+msgid "Build Scripts"
+msgstr "Scripts de Build"
+
+#: src/SUMMARY.md:96 src/attribute.md:1
+msgid "Attributes"
+msgstr "Atributos"
+
+#: src/SUMMARY.md:97 src/attribute/unused.md:1
+msgid "`dead_code`"
+msgstr "`dead_code`"
+
+#: src/SUMMARY.md:99 src/attribute/cfg.md:1
+msgid "`cfg`"
+msgstr "`cfg`"
+
+#: src/SUMMARY.md:100 src/attribute/cfg/custom.md:1
+msgid "Custom"
+msgstr "Personalizações"
+
+#: src/SUMMARY.md:102 src/generics.md:1
+msgid "Generics"
+msgstr "Genéricos"
+
+#: src/SUMMARY.md:104 src/generics/impl.md:1
+msgid "Implementation"
+msgstr "Implementação"
+
+#: src/SUMMARY.md:105 src/SUMMARY.md:131 src/SUMMARY.md:137
+#: src/generics/gen_trait.md:1 src/scope/lifetime/trait.md:1 src/trait.md:1
+msgid "Traits"
+msgstr "Traits"
+
+#: src/SUMMARY.md:106 src/SUMMARY.md:132 src/generics/bounds.md:1
+#: src/scope/lifetime/lifetime_bounds.md:1
+msgid "Bounds"
+msgstr "Limites"
+
+#: src/SUMMARY.md:107 src/generics/bounds/testcase_empty.md:1
+msgid "Testcase: empty bounds"
+msgstr "Exemplo: limites vazias"
+
+#: src/SUMMARY.md:108 src/generics/multi_bounds.md:1
+msgid "Multiple bounds"
+msgstr "Limites Múltiplos"
+
+#: src/SUMMARY.md:109 src/generics/where.md:1
+msgid "Where clauses"
+msgstr "Cláusulas where"
+
+#: src/SUMMARY.md:110 src/generics/new_types.md:1
+msgid "New Type Idiom"
+msgstr "Modismo New Type"
+
+#: src/SUMMARY.md:111 src/generics/assoc_items.md:1
+msgid "Associated items"
+msgstr "Ítems associados"
+
+#: src/SUMMARY.md:112 src/generics/assoc_items/the_problem.md:1
+msgid "The Problem"
+msgstr "Ou Problema"
+
+#: src/SUMMARY.md:113 src/generics/assoc_items/types.md:1
+msgid "Associated types"
+msgstr "Tipos Associados"
+
+#: src/SUMMARY.md:114 src/generics/phantom.md:1
+msgid "Phantom type parameters"
+msgstr "Parâmetros Phantom Type"
+
+#: src/SUMMARY.md:115 src/generics/phantom/testcase_units.md:1
+msgid "Testcase: unit clarification"
+msgstr "Exemplo: esclarecimento de unidades"
+
+#: src/SUMMARY.md:117 src/scope.md:1
+msgid "Scoping rules"
+msgstr "Regras de escopo"
+
+#: src/SUMMARY.md:118 src/scope/raii.md:1
+msgid "RAII"
+msgstr "RAII"
+
+#: src/SUMMARY.md:119 src/scope/move.md:1
+msgid "Ownership and moves"
+msgstr "Ownership e moves"
+
+#: src/SUMMARY.md:121 src/scope/move/partial_move.md:1
+msgid "Partial moves"
+msgstr "Moves parciais"
+
+#: src/SUMMARY.md:122 src/scope/borrow.md:1
+msgid "Borrowing"
+msgstr "Borrowing"
+
+#: src/SUMMARY.md:125 src/scope/borrow/ref.md:1
+msgid "The ref pattern"
+msgstr "Ou padrão de ref"
+
+#: src/SUMMARY.md:126 src/scope/lifetime.md:1
+msgid "Lifetimes"
+msgstr "Lifetimes"
+
+#: src/SUMMARY.md:127 src/scope/lifetime/explicit.md:1
+msgid "Explicit annotation"
+msgstr "Anotação explícita"
+
+#: src/SUMMARY.md:130 src/scope/lifetime/struct.md:1
+msgid "Structs"
+msgstr "Structs"
+
+#: src/SUMMARY.md:133 src/scope/lifetime/lifetime_coercion.md:1
+msgid "Coercion"
+msgstr "Coerção"
+
+#: src/SUMMARY.md:134 src/scope/lifetime/static_lifetime.md:1
+msgid "Static"
+msgstr "Static"
+
+#: src/SUMMARY.md:135 src/scope/lifetime/elision.md:1
+msgid "Elision"
+msgstr "Elisão"
+
+#: src/SUMMARY.md:138 src/trait/derive.md:1
+msgid "Derive"
+msgstr "Derive"
+
+#: src/SUMMARY.md:139 src/trait/dyn.md:1
+msgid "Returning Traits with `dyn`"
+msgstr "Retornando Traits com `dyn`"
+
+#: src/SUMMARY.md:140 src/trait/ops.md:1
+msgid "Operator Overloading"
+msgstr "Sobrecarga de Operadores"
+
+#: src/SUMMARY.md:141 src/trait/drop.md:1
+msgid "Drop"
+msgstr "Drop"
+
+#: src/SUMMARY.md:142 src/trait/iter.md:1
+msgid "Iterators"
+msgstr "Iteradores"
+
+#: src/SUMMARY.md:143 src/trait/impl_trait.md:1
+msgid "`impl Trait`"
+msgstr "`impl Trait`"
+
+#: src/SUMMARY.md:144 src/trait/clone.md:1
+msgid "Clone"
+msgstr "Clone"
+
+#: src/SUMMARY.md:145 src/trait/supertraits.md:1
+msgid "Supertraits"
+msgstr "Supertraits"
+
+#: src/SUMMARY.md:146 src/trait/disambiguating.md:1
+msgid "Disambiguating overlapping traits"
+msgstr "Desambiguando traits sobrepostos"
+
+#: src/SUMMARY.md:148
+msgid "macro_rules!"
+msgstr "macro_rules!"
+
+#: src/SUMMARY.md:149 src/macros/syntax.md:1
+msgid "Syntax"
+msgstr "Sintaxe"
+
+#: src/SUMMARY.md:150 src/macros/designators.md:1
+msgid "Designators"
+msgstr "Designadores"
+
+#: src/SUMMARY.md:151 src/macros/overload.md:1
+msgid "Overload"
+msgstr "Sobrecarga"
+
+#: src/SUMMARY.md:152 src/macros/repeat.md:1
+msgid "Repeat"
+msgstr "Repetição"
+
+#: src/SUMMARY.md:153 src/macros/dry.md:1
+msgid "DRY (Don't Repeat Yourself)"
+msgstr "DRY (Don't Repeat Yourself)"
+
+#: src/SUMMARY.md:154
+msgid "DSL (Domain Specific Languages)"
+msgstr "DSL (Domain Specific Languages)"
+
+#: src/SUMMARY.md:155
+msgid "Variadics"
+msgstr "Variádicas"
+
+#: src/SUMMARY.md:157 src/error.md:1
+msgid "Error handling"
+msgstr "Tratamento de Erros"
+
+#: src/SUMMARY.md:158 src/error/panic.md:1
+msgid "`panic`"
+msgstr "`panic`"
+
+#: src/SUMMARY.md:159
+msgid "`abort` & `unwind`"
+msgstr "`abort` & `unwind`"
+
+#: src/SUMMARY.md:160 src/error/option_unwrap.md:1
+msgid "`Option` & `unwrap`"
+msgstr "`Option` & `unwrap`"
+
+#: src/SUMMARY.md:161 src/error/option_unwrap/question_mark.md:1
+msgid "Unpacking options with `?`"
+msgstr "Desempacotando Options com `?`"
+
+#: src/SUMMARY.md:162 src/error/option_unwrap/map.md:1
+msgid "Combinators: `map`"
+msgstr "Combinadores: `map`"
+
+#: src/SUMMARY.md:163 src/error/option_unwrap/and_then.md:1
+msgid "Combinators: `and_then`"
+msgstr "Combinadores: `and_then`"
+
+#: src/SUMMARY.md:164
+msgid "Defaults: `or`, `or_else`, `get_or_insert`, `get_or_insert_with`"
+msgstr "Defaults: `or`, `or_else`, `get_or_insert`, `get_or_insert_with`"
+
+#: src/SUMMARY.md:165 src/SUMMARY.md:183 src/error/result.md:1
+#: src/std/result.md:1
+msgid "`Result`"
+msgstr "`Result`"
+
+#: src/SUMMARY.md:166 src/error/result/result_map.md:1
+msgid "`map` for `Result`"
+msgstr "`map` para `Result`"
+
+#: src/SUMMARY.md:167 src/error/result/result_alias.md:1
+msgid "aliases for `Result`"
+msgstr "aliases para `Result`"
+
+#: src/SUMMARY.md:168 src/error/result/early_returns.md:1
+msgid "Early returns"
+msgstr "Retornos antecipados"
+
+#: src/SUMMARY.md:169 src/error/result/enter_question_mark.md:1
+msgid "Introducing `?`"
+msgstr "Introduzindo `?`"
+
+#: src/SUMMARY.md:170 src/error/multiple_error_types.md:1
+msgid "Multiple error types"
+msgstr "Múltiplos tipos de erros"
+
+#: src/SUMMARY.md:171 src/error/multiple_error_types/option_result.md:1
+msgid "Pulling `Result`s out of `Option`s"
+msgstr "Extraindo `Result`s de `Option`s"
+
+#: src/SUMMARY.md:172 src/error/multiple_error_types/define_error_type.md:1
+msgid "Defining an error type"
+msgstr "Definindo um tipo de erro"
+
+#: src/SUMMARY.md:173 src/error/multiple_error_types/boxing_errors.md:1
+msgid "`Box`ing errors"
+msgstr "`Box`ing de erros"
+
+#: src/SUMMARY.md:174 src/error/multiple_error_types/reenter_question_mark.md:1
+msgid "Other uses of `?`"
+msgstr "Outros usos de `?`"
+
+#: src/SUMMARY.md:175 src/error/multiple_error_types/wrap_error.md:1
+msgid "Wrapping errors"
+msgstr "Envolvendo erros"
+
+#: src/SUMMARY.md:176 src/error/iter_result.md:1
+msgid "Iterating over `Result`s"
+msgstr "Iterando sobre `Result`s"
+
+#: src/SUMMARY.md:178 src/std.md:1
+msgid "Std library types"
+msgstr "Tipos da biblioteca std"
+
+#: src/SUMMARY.md:179 src/std/box.md:1
+msgid "Box, stack and heap"
+msgstr "Box, stack e heap"
+
+#: src/SUMMARY.md:180 src/std/vec.md:1
+msgid "Vectors"
+msgstr "Vetores"
+
+#: src/SUMMARY.md:181 src/std/str.md:1
+msgid "Strings"
+msgstr "Strings"
+
+#: src/SUMMARY.md:182 src/std/option.md:1
+msgid "`Option`"
+msgstr "`Option`"
+
+#: src/SUMMARY.md:184 src/std/result/question_mark.md:1
+msgid "`?`"
+msgstr "`?`"
+
+#: src/SUMMARY.md:185 src/std/panic.md:1
+msgid "`panic!`"
+msgstr "`panic!`"
+
+#: src/SUMMARY.md:186 src/std/hash.md:1
+msgid "HashMap"
+msgstr "HashMap"
+
+#: src/SUMMARY.md:187 src/std/hash/alt_key_types.md:1
+msgid "Alternate/custom key types"
+msgstr "Tipos de chaves personalizadas/alternativas"
+
+#: src/SUMMARY.md:188 src/std/hash/hashset.md:1
+msgid "HashSet"
+msgstr "HashSet"
+
+#: src/SUMMARY.md:189 src/std/rc.md:1
+msgid "`Rc`"
+msgstr "`Rc`"
+
+#: src/SUMMARY.md:190
+msgid "`Arc`"
+msgstr "`Arc`"
+
+#: src/SUMMARY.md:192 src/std_misc.md:1
+msgid "Std misc"
+msgstr "Std misc"
+
+#: src/SUMMARY.md:193 src/std_misc.md:6 src/std_misc/threads.md:1
+msgid "Threads"
+msgstr "Threads"
+
+#: src/SUMMARY.md:194 src/std_misc/threads/testcase_mapreduce.md:1
+msgid "Testcase: map-reduce"
+msgstr "Exemplo: map-reduce"
+
+#: src/SUMMARY.md:195 src/std_misc.md:7 src/std_misc/channels.md:1
+msgid "Channels"
+msgstr "Canais"
+
+#: src/SUMMARY.md:196 src/std_misc/path.md:1
+msgid "Path"
+msgstr "Path"
+
+#: src/SUMMARY.md:197 src/std_misc.md:8 src/std_misc/file.md:1
+msgid "File I/O"
+msgstr "E/S de arquivos"
+
+#: src/SUMMARY.md:198 src/std_misc/file/open.md:1
+msgid "`open`"
+msgstr "`open`"
+
+#: src/SUMMARY.md:199 src/std_misc/file/create.md:1
+msgid "`create`"
+msgstr "`create`"
+
+#: src/SUMMARY.md:200 src/std_misc/file/read_lines.md:1
+msgid "`read_lines`"
+msgstr "`read_lines`"
+
+#: src/SUMMARY.md:201 src/std_misc/process.md:1
+msgid "Child processes"
+msgstr "Processos filhos"
+
+#: src/SUMMARY.md:202 src/std_misc/process/pipe.md:1
+msgid "Pipes"
+msgstr "Pipes"
+
+#: src/SUMMARY.md:203 src/std_misc/process/wait.md:1
+msgid "Wait"
+msgstr "Wait"
+
+#: src/SUMMARY.md:204 src/std_misc/fs.md:1
+msgid "Filesystem Operations"
+msgstr "Operações de Sistema Operacional"
+
+#: src/SUMMARY.md:205 src/std_misc/arg.md:1
+msgid "Program arguments"
+msgstr "Argumentos do Programa"
+
+#: src/SUMMARY.md:206 src/std_misc/arg/matching.md:1
+msgid "Argument parsing"
+msgstr "Parse de argumentos"
+
+#: src/SUMMARY.md:207 src/std_misc/ffi.md:1
+msgid "Foreign Function Interface"
+msgstr "Interface de função estrangeira"
+
+#: src/SUMMARY.md:209 src/cargo/test.md:1 src/testing.md:1
+msgid "Testing"
+msgstr "Testes"
+
+#: src/SUMMARY.md:210 src/testing/unit_testing.md:1
+msgid "Unit testing"
+msgstr "Testes Unitários"
+
+#: src/SUMMARY.md:211 src/testing/doc_testing.md:1
+msgid "Documentation testing"
+msgstr "Testes de Documentação"
+
+#: src/SUMMARY.md:212 src/testing/integration_testing.md:1
+msgid "Integration testing"
+msgstr "Testes de integração"
+
+#: src/SUMMARY.md:213
+msgid "Dev-dependencies"
+msgstr "Dependências de desenvolvimento"
+
+#: src/SUMMARY.md:215 src/unsafe.md:1
+msgid "Unsafe Operations"
+msgstr "Operações Unsafe"
+
+#: src/SUMMARY.md:216 src/unsafe/asm.md:1
+msgid "Inline assembly"
+msgstr "Assembly Inline"
+
+#: src/SUMMARY.md:218 src/compatibility.md:1
+msgid "Compatibility"
+msgstr "Compatibilidade "
+
+#: src/SUMMARY.md:219 src/compatibility/raw_identifiers.md:1
+msgid "Raw identifiers"
+msgstr "Identificadores simples"
+
+#: src/SUMMARY.md:221 src/meta.md:1
+msgid "Meta"
+msgstr "Meta"
+
+#: src/SUMMARY.md:222 src/meta/doc.md:1
+msgid "Documentation"
+msgstr "Documentação"
+
+#: src/SUMMARY.md:223 src/meta/playground.md:1
+msgid "Playground"
+msgstr "Playground"
+
+#: src/index.md:1
+msgid "Rust by Example"
+msgstr "Rust by Exemplos"
+
+#: src/index.md:3
+msgid ""
+"[Rust](https://www.rust-lang.org/) is a modern systems programming language "
+"focusing on safety, speed, and concurrency. It accomplishes these goals by "
+"being memory safe without using garbage collection."
+msgstr ""
+"[Rust] (https://www.rust-lang.org/) é uma linguagem de programação de "
+"sistemas modernos concentrado na segurança, velocidade e a "
+"concorrência. Consegue esses objetivos ao manter a segurança de memória sem usar a "
+"coleta de lixo."
+
+#: src/index.md:7
+msgid ""
+"Rust by Example (RBE) is a collection of runnable examples that illustrate "
+"various Rust concepts and standard libraries. To get even more out of these "
+"examples, don't forget to [install Rust locally](https://www.rust-lang.org/"
+"tools/install) and check out the [official docs](https://doc.rust-lang.org/"
+"std/). Additionally for the curious, you can also [check out the source code "
+"for this site](https://github.com/rust-lang/rust-by-example)."
+msgstr ""
+"Rust By Example (RBE) é uma coleção de exemplos executáveis que ilustra "
+"vários conceitos de Rust e da biblioteca padrão. Para aproveitar ainda mais "
+"estes exemplos, não se esqueça de [instalar Rust localmente](https://www."
+"rust-lang.org/tools/install) e consultar a [documentação oficial](https://doc."
+"rust-lang.org/std/). Além disso, para quem tiver curiosidade, também pode "
+"[ver o código-fonte deste site](https://github.com/rust-lang/rust-by-example)."
+
+#: src/index.md:12
+msgid "Now let's begin!"
+msgstr "Vamos começar!"
+
+#: src/index.md:14
+msgid "[Hello World](hello.md) - Start with a traditional Hello World program."
+msgstr ""
+"[Olá Mundo](hello.md) - Comece com o programa tradicional Olá Mundo."
+
+#: src/index.md:16
+msgid ""
+"[Primitives](primitives.md) - Learn about signed integers, unsigned integers "
+"and other primitives."
+msgstr ""
+"[Primitivas](primitives.md) - Aprenda sobre inteiros com sinal, inteiros sem "
+"signo e outras primitivas."
+
+#: src/index.md:18
+msgid "[Custom Types](custom_types.md) - `struct` and `enum`."
+msgstr "[Tipos Personalizados](custom_types.md) - `struct` e `enum`."
+
+#: src/index.md:20
+msgid ""
+"[Variable Bindings](variable_bindings.md) - mutable bindings, scope, "
+"shadowing."
+msgstr ""
+"[Vinculações de Variáveis](variable_bindings.md) - vinculações mutáveis, escopo, "
+"sombreamento."
+
+#: src/index.md:22
+msgid "[Types](types.md) - Learn about changing and defining types."
+msgstr "[Tipos](types.md) - Aprenda como alterar e definir tipos."
+
+#: src/index.md:24
+msgid ""
+"[Conversion](conversion.md) - Convert between different types, such as "
+"strings, integers, and floats."
+msgstr ""
+"[Conversão](conversion.md) - Converter entre diferentes tipos, como "
+"strings, inteiros e flutuantes."
+
+#: src/index.md:26
+msgid ""
+"[Expressions](expression.md) - Learn about Expressions & how to use them."
+msgstr ""
+"[Expressões](expression.md) - Aprenda sobre expressões e como usá-as."
+
+#: src/index.md:28
+msgid "[Flow of Control](flow_control.md) - `if`/`else`, `for`, and others."
+msgstr "[Controle de Fluxo](flow_control.md) - `if`/`else`, `for`, e outros."
+
+#: src/index.md:30
+msgid ""
+"[Functions](fn.md) - Learn about Methods, Closures and Higher Order "
+"Functions."
+msgstr ""
+"[Funções](fn.md) - Aprenda sobre métodos, closures e funções de ordem "
+"superior."
+
+#: src/index.md:32
+msgid "[Modules](mod.md) - Organize code using modules"
+msgstr "[Módulos](mod.md) - Organizar código usando módulos"
+
+#: src/index.md:34
+msgid ""
+"[Crates](crates.md) - A crate is a compilation unit in Rust. Learn to create "
+"a library."
+msgstr ""
+"[Crates](crates.md) - Um crate é uma unidade de compilação em Rust. Aprenda "
+"a criar uma biblioteca."
+
+#: src/index.md:36
+msgid ""
+"[Cargo](cargo.md) - Go through some basic features of the official Rust "
+"package management tool."
+msgstr ""
+"[Cargo](cargo.md) - Veja alguns recursos básicos da ferramenta oficial de "
+"gerenciamento de pacotes do Rust."
+
+#: src/index.md:38
+msgid ""
+"[Attributes](attribute.md) - An attribute is metadata applied to some "
+"module, crate or item."
+msgstr ""
+"[Atributos](attribute.md) - Um atributo é metadado aplicado a algum módulo, "
+"crate ou item."
+
+#: src/index.md:40
+msgid ""
+"[Generics](generics.md) - Learn about writing a function or data type which "
+"can work for multiple types of arguments."
+msgstr ""
+"[Genéricos](generics.md) - Aprenda a escrever uma função o tipo de dado "
+"que pode funcionar para múltiplos tipos de argumentos."
+
+#: src/index.md:42
+msgid ""
+"[Scoping rules](scope.md) - Scopes play an important part in ownership, "
+"borrowing, and lifetimes."
+msgstr ""
+"[Regras de escopo](scope.md) - Os escopos têm um papel importante em "
+"ownership, borrowing e lifetimes."
+
+#: src/index.md:44
+msgid ""
+"[Traits](trait.md) - A trait is a collection of methods defined for an "
+"unknown type: `Self`"
+msgstr ""
+"[Traits](trait.md) - Um trait é uma coleção de métodos definidos para um "
+"tipo desconhecido: `Self`"
+
+#: src/index.md:46
+msgid ""
+"[Macros](macros.md) - Macros are a way of writing code that writes other "
+"code, which is known as metaprogramming."
+msgstr ""
+"[Macros](macros.md) - Macros são uma forma de escrever código que escreve "
+"outro código, ou que é conhecido como metaprogramação."
+
+#: src/index.md:48
+msgid "[Error handling](error.md) - Learn Rust way of handling failures."
+msgstr "[Tratamento de Erros](error.md) - Aprenda a tratar erros com Rust."
+
+#: src/index.md:50
+msgid ""
+"[Std library types](std.md) - Learn about some custom types provided by "
+"`std` library."
+msgstr ""
+"[Tipos da biblioteca std](std.md) - Aprenda sobre alguns tipos da biblioteca "
+"`std`."
+
+#: src/index.md:52
+msgid "[Std misc](std_misc.md) - More custom types for file handling, threads."
+msgstr ""
+"[Std misc](std_misc.md) - Mais tipos personalizados para o tratamento de "
+"arquivos, threads."
+
+#: src/index.md:54
+#, fuzzy
+msgid "[Testing](testing.md) - All sorts of testing in Rust."
+msgstr "[Testes](testing.md) - Todo tipo de testes em Rust."
+
+#: src/index.md:56
+msgid ""
+"[Unsafe Operations](unsafe.md) - Learn about entering a block of unsafe "
+"operations."
+msgstr ""
+"[Operações Unsafe](unsafe.md) - Aprenda sobre o uso de blocos de "
+"operações unsafe."
+
+#: src/index.md:58
+msgid ""
+"[Compatibility](compatibility.md) - Handling Rust's evolution and potential "
+"compatibility issues."
+msgstr ""
+"[Compatibilidade](compatibility.md) - Tratamento da evolução de Rust e "
+"possíveis problemas de compatibilidade."
+
+#: src/index.md:60
+msgid "[Meta](meta.md) - Documentation, Benchmarking."
+msgstr "[Meta](meta.md) - Documentação, Benchmarking."
+
+#: src/hello.md:3
+msgid "This is the source code of the traditional Hello World program."
+msgstr "Este é o código-fonte do programa tradicional Hello World."
+
+#: src/hello.md:6
+msgid ""
+"// This is a comment, and is ignored by the compiler.\n"
+"// You can test this code by clicking the \"Run\" button over there ->\n"
+"// or if you prefer to use your keyboard, you can use the \"Ctrl + Enter\"\n"
+"// shortcut.\n"
+msgstr ""
+"// Este é um comentário e é ignorado pelo compilador.\n"
+"// Pode testar este código clicando no botão \"Run\" ali -> \n"
+"// ou se preferir usar seu teclado, pode usar o atalho \"Ctrl + Enter\".\n"
+
+#: src/hello.md:10
+msgid ""
+"// This code is editable, feel free to hack it!\n"
+"// You can always return to the original code by clicking the \"Reset\" "
+"button ->\n"
+msgstr ""
+"// Este código é editável, sinta-se à vontade para modificá-lo!\n"
+"// Você sempre pode voltar ao código original clicando no botão \"Reset\" -> \n"
+
+#: src/hello.md:13
+msgid "// This is the main function.\n"
+msgstr "// Esta é a função main"
+
+#: src/hello.md:16
+msgid "// Statements here are executed when the compiled binary is called.\n"
+msgstr ""
+"// As instruções aqui são executadas quando o binário compilado é chamado.\n"
+
+#: src/hello.md:18
+msgid "// Print text to the console.\n"
+msgstr "// Imprime o texto no console.\n"
+
+#: src/hello.md:19 src/error/result.md:55 src/meta/playground.md:12
+msgid "\"Hello World!\""
+msgstr "\"Hello World!\""
+
+#: src/hello.md:23
+msgid "`println!` is a [_macro_](macros.md) that prints text to the console."
+msgstr "`println!` é um [_macro_](macros.md) que imprime o texto no console."
+
+#: src/hello.md:26
+msgid "A binary can be generated using the Rust compiler: `rustc`."
+msgstr "Um binário pode-se gerar usando o compilador de Rust: `rustc`."
+
+#: src/hello.md:32
+msgid "`rustc` will produce a `hello` binary that can be executed."
+msgstr "`rustc` produzirá um binário `hello` que pode ser executado."
+
+#: src/hello.md:39 src/hello/print/print_display.md:107
+#: src/hello/print/print_display/testcase_list.md:53 src/hello/print/fmt.md:70
+#: src/primitives/tuples.md:64 src/custom_types/structs.md:89
+msgid "Activity"
+msgstr "Atividade"
+
+#: src/hello.md:41
+msgid ""
+"Click 'Run' above to see the expected output. Next, add a new line with a "
+"second `println!` macro so that the output shows:"
+msgstr ""
+"Clique em 'Run' acima para ver a saída esperada. Em seguida, "
+"adicione uma nova linha com um segundo `println!` macro para que a saída "
+"mostre:"
+
+#: src/hello/comment.md:3
+msgid ""
+"Any program requires comments, and Rust supports a few different varieties:"
+msgstr ""
+"Qualquer programa requerem comentários, e Rust admite algumas variedades "
+"diferentes:"
+
+#: src/hello/comment.md:6
+msgid "_Regular comments_ which are ignored by the compiler:"
+msgstr "_Comentários regulares_ que o compilador ignora:"
+
+#: src/hello/comment.md:7
+msgid "`// Line comments which go to the end of the line.`"
+msgstr "`// Comentários de linha que vão ao final da linha.`"
+
+#: src/hello/comment.md:8
+msgid "`/* Block comments which go to the closing delimiter. */`"
+msgstr "`/* Comentários de bloco que vão ao delimitador de encerramento. */`"
+
+#: src/hello/comment.md:9
+msgid ""
+"_Doc comments_ which are parsed into HTML library [documentation](../meta/"
+"doc.md):"
+msgstr ""
+"_Comentários de Doc_ que são convertidos na [documentação](../meta/doc.md) "
+"HTML da biblioteca:"
+
+#: src/hello/comment.md:10
+msgid "`/// Generate library docs for the following item.`"
+msgstr "`/// Gera docs de biblioteca para o item a seguir.`"
+
+#: src/hello/comment.md:11
+msgid "`//! Generate library docs for the enclosing item.`"
+msgstr "`//! Gera docs de biblioteca para o item envolvente.`"
+
+#: src/hello/comment.md:15
+msgid ""
+"// This is an example of a line comment.\n"
+"    // There are two slashes at the beginning of the line.\n"
+"    // And nothing written after these will be read by the compiler.\n"
+msgstr ""
+"// Este é um exemplo de comentário de linha.\n"
+"   // Há duas barras não início da linha.\n"
+"   // E nada escrito depois disso será lido pelo compilador.\n"
+
+#: src/hello/comment.md:19
+msgid "// println!(\"Hello, world!\");\n"
+msgstr ""
+"// println!(\"Hello, world!\");\n"
+
+#: src/hello/comment.md:21
+msgid "// Run it. See? Now try deleting the two slashes, and run it again.\n"
+msgstr ""
+"// Execute. Viu? Agora tente remover as duas barras e execute novamente.\n"
+
+#: src/hello/comment.md:23
+msgid ""
+"/*\n"
+"     * This is another type of comment, a block comment. In general,\n"
+"     * line comments are the recommended comment style. But block comments\n"
+"     * are extremely useful for temporarily disabling chunks of code.\n"
+"     * /* Block comments can be /* nested, */ */ so it takes only a few\n"
+"     * keystrokes to comment out everything in this main() function.\n"
+"     * /*/*/* Try it yourself! */*/*/\n"
+"     */"
+msgstr ""
+"/*\n"
+"     * Este é outro tipo de comentário, um comentário em bloco. Em geral,\n"
+"     * comentários de linha são o estilo recomendado. Mas comentários de bloco\n"
+"     * são extremamente úteis para desabilitar temporariamente trechos de código.\n"
+"     * /* Comentários de bloco podem ser /* aninhados, */ */ então bastam\n"
+"     * poucas teclas para comentar tudo nesta função main().\n"
+"     * /*/*/* Experimente! */*/*/\n"
+" */"
+
+#: src/hello/comment.md:32
+msgid ""
+"/*\n"
+"    Note: The previous column of `*` was entirely for style. There's\n"
+"    no actual need for it.\n"
+"    */"
+msgstr ""
+"/*\n"
+"   Nota: a columna anterior a `*` é completamente por estilo. Não há\n"
+"   há necesidad real para ello. \n"
+"    */"
+
+#: src/hello/comment.md:37
+msgid ""
+"// You can manipulate expressions more easily with block comments\n"
+"    // than with line comments. Try deleting the comment delimiters\n"
+"    // to change the result:\n"
+msgstr ""
+"// Pode manipular expressões mais fácilmente com comentários de bloco \n"
+"    // que com comentários de linha. Tente remover os delimitadores de "
+"comentários\n"
+"    // para alterar o resultado:\n"
+
+#: src/hello/comment.md:40
+msgid "/* 90 + */"
+msgstr "/* 90 + */"
+
+#: src/hello/comment.md:41
+msgid "\"Is `x` 10 or 100? x = {}\""
+msgstr "\"`x` é 10 ou 100? x = {}\""
+
+#: src/hello/comment.md:45 src/hello/print.md:103
+#: src/hello/print/print_debug.md:75 src/hello/print/print_display.md:118
+#: src/hello/print/print_display/testcase_list.md:62 src/hello/print/fmt.md:89
+#: src/primitives.md:64 src/custom_types/enum.md:100
+#: src/custom_types/enum/enum_use.md:45 src/custom_types/enum/c_like.md:33
+#: src/custom_types/enum/testcase_linked_list.md:77
+#: src/custom_types/constants.md:35 src/types/alias.md:30
+#: src/flow_control/for.md:121
+#: src/flow_control/match/destructuring/destructure_tuple.md:25
+#: src/flow_control/match/destructuring/destructure_slice.md:46
+#: src/flow_control/match/destructuring/destructure_enum.md:48
+#: src/flow_control/match/destructuring/destructure_pointers.md:63
+#: src/flow_control/match/destructuring/destructure_structures.md:45
+#: src/flow_control/match/guard.md:43 src/flow_control/match/binding.md:49
+#: src/flow_control/if_let.md:118 src/flow_control/let_else.md:55
+#: src/flow_control/while_let.md:56 src/fn/closures/capture.md:110
+#: src/fn/closures/input_parameters.md:84 src/fn/closures/anonymity.md:47
+#: src/fn/closures/input_functions.md:32
+#: src/fn/closures/output_parameters.md:49
+#: src/fn/closures/closure_examples/iter_any.md:50
+#: src/fn/closures/closure_examples/iter_find.md:68
+#: src/mod/struct_visibility.md:53 src/attribute/cfg.md:39 src/generics.md:59
+#: src/generics/gen_fn.md:54 src/generics/impl.md:48
+#: src/generics/gen_trait.md:39 src/generics/bounds.md:73
+#: src/generics/bounds/testcase_empty.md:37 src/generics/multi_bounds.md:32
+#: src/generics/where.md:49 src/generics/new_types.md:54
+#: src/generics/assoc_items.md:10 src/generics/assoc_items/the_problem.md:62
+#: src/generics/phantom.md:56 src/generics/phantom/testcase_units.md:75
+#: src/scope/raii.md:92 src/scope/move/partial_move.md:57
+#: src/scope/borrow/mut.md:56 src/scope/lifetime/explicit.md:68
+#: src/scope/lifetime/fn.md:58 src/scope/lifetime/methods.md:24
+#: src/scope/lifetime/struct.md:41 src/scope/lifetime/trait.md:28
+#: src/scope/lifetime/lifetime_bounds.md:46
+#: src/scope/lifetime/static_lifetime.md:133 src/scope/lifetime/elision.md:39
+#: src/trait/derive.md:65 src/trait/supertraits.md:40
+#: src/trait/disambiguating.md:60 src/error/option_unwrap/map.md:79
+#: src/error/option_unwrap/and_then.md:73
+#: src/error/option_unwrap/defaults.md:115 src/error/result/result_alias.md:41
+#: src/error/multiple_error_types/boxing_errors.md:57
+#: src/error/multiple_error_types/reenter_question_mark.md:74
+#: src/error/multiple_error_types/wrap_error.md:91 src/std.md:12
+#: src/std/rc.md:55 src/std_misc.md:12
+#: src/std_misc/threads/testcase_mapreduce.md:129 src/std_misc/path.md:54
+#: src/std_misc/fs.md:150 src/meta/doc.md:109 src/meta/playground.md:49
+msgid "See also:"
+msgstr "Ver também"
+
+#: src/hello/comment.md:47
+msgid "[Library documentation](../meta/doc.md)"
+msgstr "[Documentação de Bibliotecas](../meta/doc.md)"
+
+#: src/hello/print.md:3
+msgid ""
+"Printing is handled by a series of [`macros`](../macros.md) defined in "
+"[`std::fmt`](https://doc.rust-lang.org/std/fmt/) some of which are:"
+msgstr ""
+"A impressão é tratada por uma série de [`macros`](../macros.md) definidas "
+"em [`std::fmt`](https://doc.rust-lang.org/std/fmt/), algumas das quais "
+"são: "
+
+#: src/hello/print.md:6
+msgid "`format!`: write formatted text to [`String`](../std/str.md)"
+msgstr "`format!`: escreve o texto formatado a um [`String`](../std/str.md)"
+
+#: src/hello/print.md:7
+msgid ""
+"`print!`: same as `format!` but the text is printed to the console (io::"
+"stdout)."
+msgstr ""
+"`print!`: igual a `format!` mas o texto é impresso no console (io::"
+"stdout)."
+
+#: src/hello/print.md:9
+msgid "`println!`: same as `print!` but a newline is appended."
+msgstr "`println!`: é igual a `print!` mas adiciona uma quebra de linha"
+
+#: src/hello/print.md:10
+msgid ""
+"`eprint!`: same as `print!` but the text is printed to the standard error "
+"(io::stderr)."
+msgstr ""
+"`eprint!`: igual a `print!` mas o texto é impresso para o erro padrão "
+"(io::stderr)."
+
+#: src/hello/print.md:12
+msgid "`eprintln!`: same as `eprint!` but a newline is appended."
+msgstr "`eprintln!`: é igual a `eprint!` mas adiciona uma quebra de linha"
+
+#: src/hello/print.md:14
+#, fuzzy
+msgid ""
+"All parse text in the same fashion. As a plus, Rust checks formatting "
+"correctness at compile time."
+msgstr ""
+"Analisa todo o texto da mesma forma. Como benefício, Rust verifica ou "
+"formato dos argumentos. Serão convertidos em strings.\n"
+
+#: src/hello/print.md:19
+#, fuzzy
+msgid ""
+"// In general, the `{}` will be automatically replaced with any\n"
+"    // arguments. These will be stringified.\n"
+msgstr ""
+"Analisa todo o texto da mesma forma. Como benefício, Rust verifica ou "
+"formato dos argumentos. Serão convertidos em strings.\n"
+
+#: src/hello/print.md:21
+msgid "\"{} days\""
+msgstr "\"{} dias\""
+
+#: src/hello/print.md:23
+msgid ""
+"// Positional arguments can be used. Specifying an integer inside `{}`\n"
+"    // determines which additional argument will be replaced. Arguments "
+"start\n"
+"    // at 0 immediately after the format string.\n"
+msgstr ""
+"// Podem-se usar argumentos posicionais. Especificar um inteiro dentro de "
+"`{}`\n"
+"   // determina que argumento adicional será substituído. Os "
+"argumentos começam \n"
+"   // em 0 imediatamente após a string de formatação.\n"
+
+#: src/hello/print.md:26
+msgid "\"{0}, this is {1}. {1}, this is {0}\""
+msgstr "\"{0}, isto é {1}. {1}, este é {0}\""
+
+#: src/hello/print.md:26 src/scope/move/partial_move.md:31
+msgid "\"Alice\""
+msgstr "\"Alice\""
+
+#: src/hello/print.md:26 src/flow_control/for.md:65 src/flow_control/for.md:85
+#: src/flow_control/for.md:104
+msgid "\"Bob\""
+msgstr "\"Bob\""
+
+#: src/hello/print.md:28
+msgid "// As can named arguments.\n"
+msgstr "// Como os argumentos nomeados.\n"
+
+#: src/hello/print.md:29
+msgid "\"{subject} {verb} {object}\""
+msgstr "\"{sujeito} {verbo} {objeto}\""
+
+#: src/hello/print.md:30
+msgid "\"the lazy dog\""
+msgstr "\"o lazy dog\""
+
+#: src/hello/print.md:31
+msgid "\"the quick brown fox\""
+msgstr "\"o quick brown fox\""
+
+#: src/hello/print.md:32
+msgid "\"jumps over\""
+msgstr "\"jumps over\""
+
+#: src/hello/print.md:34
+msgid ""
+"// Different formatting can be invoked by specifying the format character\n"
+"    // after a `:`.\n"
+msgstr ""
+"// Pode-se invocar diferentes formatos especificando o caractere do "
+"formato\n"
+"   // após um `:`.\n"
+
+#: src/hello/print.md:36
+msgid "\"Base 10:               {}\""
+msgstr "\"Base 10:               {}\""
+
+#: src/hello/print.md:36
+msgid "// 69420\n"
+msgstr ""
+"// 69420\n"
+
+#: src/hello/print.md:37
+msgid "\"Base 2 (binary):       {:b}\""
+msgstr "\"Base 2 (binário):       {:b}\""
+
+#: src/hello/print.md:37
+msgid "// 10000111100101100\n"
+msgstr ""
+"// 10000111100101100\n"
+
+#: src/hello/print.md:38
+msgid "\"Base 8 (octal):        {:o}\""
+msgstr "\"Base 8 (octal):        {:o}\""
+
+#: src/hello/print.md:38
+msgid "// 207454\n"
+msgstr ""
+"// 207454\n"
+
+#: src/hello/print.md:39
+msgid "\"Base 16 (hexadecimal): {:x}\""
+msgstr "\"Base 16 (hexadecimal): {:x}\""
+
+#: src/hello/print.md:39
+msgid "// 10f2c\n"
+msgstr ""
+"// 10f2c\n"
+
+#: src/hello/print.md:41
+msgid ""
+"// You can right-justify text with a specified width. This will\n"
+"    // output \"    1\". (Four white spaces and a \"1\", for a total width "
+"of 5.)\n"
+msgstr ""
+"// Você pode justificar o texto à direita com uma largura especificada. Isto "
+"será\n"
+"// saída \"    1 \". (Quatro espaços brancos e um \"1\", para uma largura "
+"total de 5.)\n"
+
+#: src/hello/print.md:43
+msgid "\"{number:>5}\""
+msgstr "\"{numero:>5}\""
+
+#: src/hello/print.md:45
+msgid "// You can pad numbers with extra zeroes,\n"
+msgstr "// Você pode preencher números com zeros adicionais,\n"
+
+#: src/hello/print.md:46
+msgid "\"{number:0>5}\""
+msgstr "\"{numero:0>5}\""
+
+#: src/hello/print.md:46
+msgid ""
+"// 00001\n"
+"    // and left-adjust by flipping the sign. This will output \"10000\".\n"
+msgstr ""
+"// 00001\n"
+"    // e justificar à esquerda invertendo o sinal. Isto imprimirá "
+"\"10000\".\n"
+
+#: src/hello/print.md:48
+msgid "\"{number:0<5}\""
+msgstr "\"{numero:0<5}\""
+
+#: src/hello/print.md:48
+msgid "// 10000\n"
+msgstr ""
+"// 10000\n"
+
+#: src/hello/print.md:50
+msgid ""
+"// You can use named arguments in the format specifier by appending a `$`.\n"
+msgstr ""
+"// Pode usar argumentos nomeados no especificador de formatação adicionando um "
+"`$`.\n"
+
+#: src/hello/print.md:51
+msgid "\"{number:0>width$}\""
+msgstr "\"{numero:0>largura$}\""
+
+#: src/hello/print.md:53
+msgid ""
+"// Rust even checks to make sure the correct number of arguments are used.\n"
+msgstr ""
+"// Rust também verifica para garantir de que se use o número correto "
+"de argumentos.\n"
+
+#: src/hello/print.md:54
+msgid "\"My name is {0}, {1} {0}\""
+msgstr "\"Meu nome é {0}, {1} {0}\""
+
+#: src/hello/print.md:54
+msgid "\"Bond\""
+msgstr "\"Bond\""
+
+#: src/hello/print.md:55
+msgid "// FIXME ^ Add the missing argument: \"James\"\n"
+msgstr ""
+"// FIXME ^ Adiciona o missing argumento: \"James\"\n"
+
+#: src/hello/print.md:57
+msgid ""
+"// Only types that implement fmt::Display can be formatted with `{}`. User-\n"
+"    // defined types do not implement fmt::Display by default.\n"
+msgstr ""
+"// Somente os tipos que implementam `fmt::Display` podem ser formatados com `{}"
+"`.\n"
+"   // Os tipos definidos por usuário não implementam `fmt::Display` de forma "
+"padrão.\n"
+
+#: src/hello/print.md:60
+msgid "// disable `dead_code` which warn against unused module\n"
+msgstr "// desabilita `dead_code` o qual adverte contra módulos não usados\n"
+
+#: src/hello/print.md:63
+msgid ""
+"// This will not compile because `Structure` does not implement\n"
+"    // fmt::Display.\n"
+"    // println!(\"This struct `{}` won't print...\", Structure(3));\n"
+"    // TODO ^ Try uncommenting this line\n"
+msgstr ""
+"// Isto não se compilará porque `Structure` não implementa \n"
+"    // `fmt::Display`.\n"
+"   // println!(\"esta estrutura `{}` não será impressa... \", "
+"Structure(3));\n"
+"   // TAREFA ^ tente remover o comentário desta linha \n"
+
+#: src/hello/print.md:68
+msgid ""
+"// For Rust 1.58 and above, you can directly capture the argument from a\n"
+"    // surrounding variable. Just like the above, this will output\n"
+"    // \"    1\", 4 white spaces and a \"1\".\n"
+msgstr ""
+"// Para Rust 1.58 e superior, pode capturar diretamente o argumento de "
+"uma\n"
+"// variável no ambiente. Assim como acima, isto imprimirá \n"
+"// \"     1\", 4 espaços brancos e a \"1\".\n"
+
+#: src/hello/print.md:73
+msgid "\"{number:>width$}\""
+msgstr "\"{numero:>largura$}\""
+
+#: src/hello/print.md:77
+msgid ""
+"[`std::fmt`](https://doc.rust-lang.org/std/fmt/) contains many [`traits`]"
+"(https://doc.rust-lang.org/std/fmt/#formatting-traits) which govern the "
+"display of text. The base form of two important ones are listed below:"
+msgstr ""
+"[`std::fmt`](https://doc.rust-lang.org/std/fmt/) contém muitos [`traits`]"
+"(https://doc.rust-lang.org/std/fmt/#formatting-traits) que rege "
+"visualização de texto. A forma básica de dois deles é listada a "
+"seguir:"
+
+#: src/hello/print.md:80
+msgid ""
+"`fmt::Debug`: Uses the `{:?}` marker. Format text for debugging purposes."
+msgstr ""
+"`fmt::Debug`: Usa o marcador `{:?}`. Formata o texto para fins de "
+"depuração."
+
+#: src/hello/print.md:81
+msgid ""
+"`fmt::Display`: Uses the `{}` marker. Format text in a more elegant, user "
+"friendly fashion."
+msgstr ""
+"`fmt::Display`: Usa o marcador `{}`. Formata texto de uma forma mais "
+"elegante e amistosa."
+
+#: src/hello/print.md:84
+msgid ""
+"Here, we used `fmt::Display` because the std library provides "
+"implementations for these types. To print text for custom types, more steps "
+"are required."
+msgstr ""
+"Aqui, usamos `fmt::Display` porque a biblioteca std fornece "
+"implementações para estes tipos. Para imprimir tipos personalizados, mais "
+"passos são necessários"
+
+#: src/hello/print.md:87
+msgid ""
+"Implementing the `fmt::Display` trait automatically implements the "
+"[`ToString`](https://doc.rust-lang.org/std/string/trait.ToString.html) trait "
+"which allows us to [convert](../conversion/string.md) the type to [`String`]"
+"(../std/str.md)."
+msgstr ""
+"Implementar o trait `fmt::Display` implementa automaticamente o trait "
+"[`ToString`](https://doc.rust-lang.org/std/string/trait.ToString.html) que "
+"nos permite [converter](../conversion/string.md) o tipo em [`String`](../"
+"std/str.md)."
+
+#: src/hello/print.md:90
+msgid ""
+"In _line 43_, `#[allow(dead_code)]` is an [attribute](../attribute.md) which "
+"only applies to the module after it."
+msgstr ""
+"Na _linha 43_,`#[allow(dead_code)]` é um [atributo](../ attribute.md) "
+"que apenas se aplica ao módulo depois de ele."
+
+#: src/hello/print.md:92
+msgid "Activities"
+msgstr "Atividades"
+
+#: src/hello/print.md:94
+msgid ""
+"Fix the issue in the above code (see FIXME) so that it runs without error."
+msgstr ""
+"Resolva o problema no código anterior (veja o FIXME) para que se "
+"execute sem erro."
+
+#: src/hello/print.md:96
+msgid ""
+"Try uncommenting the line that attempts to format the `Structure` struct "
+"(see TODO)"
+msgstr ""
+"Tente remover o comentário de a linha que tenta formatar a estrutura "
+"`Structure`(ver TAREFA)"
+
+#: src/hello/print.md:98
+msgid ""
+"Add a `println!` macro call that prints: `Pi is roughly 3.142` by "
+"controlling the number of decimal places shown. For the purposes of this "
+"exercise, use `let pi = 3.141592` as an estimate for pi. (Hint: you may need "
+"to check the [`std::fmt`](https://doc.rust-lang.org/std/fmt/) documentation "
+"for setting the number of decimals to display)"
+msgstr ""
+"Adicione um macro `println!` que imprima: ` Pi es aproximadamente 3.142` "
+"controlando o número de decimais mostrados. Para os fins deste exercício, "
+"use `let Pi = 3.141592` como uma estimativa para pi. (Sugestão: "
+"pode consultar a documentação de [`std::fmt`](https://doc.rust-lang.org/"
+"std/fmt/) para configurar o número de decimais exibidos)"
+
+#: src/hello/print.md:105
+msgid ""
+"[`std::fmt`](https://doc.rust-lang.org/std/fmt/), [`macros`](../macros.md), "
+"[`struct`](../custom_types/structs.md), [`traits`](https://doc.rust-lang.org/"
+"std/fmt/#formatting-traits), and [`dead_code`](../attribute/unused.md)"
+msgstr ""
+"[`std::fmt`](https://doc.rust-lang.org/std/fmt/), [`macros`](../macros.md), "
+"[`struct`](../custom_types/structs.md), [`traits`](https://doc.rust-lang.org/"
+"std/fmt/#formatting-traits), e [`dead_code`](../attribute/unused.md)"
+
+#: src/hello/print/print_debug.md:3
+msgid ""
+"All types which want to use `std::fmt` formatting `traits` require an "
+"implementation to be printable. Automatic implementations are only provided "
+"for types such as in the `std` library. All others _must_ be manually "
+"implemented somehow."
+msgstr ""
+"Todos os tipos que querem usar os traits de `std::fmt` requerem "
+"uma implementação para serem imprimíveis. As implementações automáticas somente "
+"se fornecem para tipos como em a biblioteca `std`. Todos os outros tipos "
+"_deven_ ser manualmente implementados de alguma forma."
+
+#: src/hello/print/print_debug.md:8
+msgid ""
+"The `fmt::Debug` `trait` makes this very straightforward. _All_ types can "
+"`derive` (automatically create) the `fmt::Debug` implementation. This is not "
+"true for `fmt::Display` which must be manually implemented."
+msgstr ""
+"O trait `fmt::Debug` faz com que isto seja muito simples. Todos os tipos "
+"podem`Derive` (criar automaticamente) a implementação `fmt::Debug`. Isto "
+"não é verdade para `fmt::Display` o qual deve ser implementado manualmente."
+
+#: src/hello/print/print_debug.md:13
+msgid ""
+"// This structure cannot be printed either with `fmt::Display` or\n"
+"// with `fmt::Debug`.\n"
+msgstr ""
+"// Esta estrutura não pode-se imprimir com `fmt::Display` ou \n"
+"// com `fmt::Debug`.\n"
+" "
+
+#: src/hello/print/print_debug.md:16
+msgid ""
+"// The `derive` attribute automatically creates the implementation\n"
+"// required to make this `struct` printable with `fmt::Debug`.\n"
+msgstr ""
+"// O atributo `derive` cria automaticamente a implementação \n"
+" // necessária para fazer essa `struct` imprimível com `fmt::Debug`. \n"
+
+#: src/hello/print/print_debug.md:23
+msgid "All `std` library types are automatically printable with `{:?}` too:"
+msgstr ""
+"Todos os tipos da biblioteca `std` podem ser impressos automaticamente com "
+"`{:?}` também:"
+
+#: src/hello/print/print_debug.md:26
+msgid ""
+"// Derive the `fmt::Debug` implementation for `Structure`. `Structure`\n"
+"// is a structure which contains a single `i32`.\n"
+msgstr ""
+"// Derive a implementação `fmt::Debug` para `Structure`. `Structure`\n"
+"// é uma estrutura que contém um único `i32`.\n"
+" "
+
+#: src/hello/print/print_debug.md:30
+msgid ""
+"// Put a `Structure` inside of the structure `Deep`. Make it printable\n"
+"// also.\n"
+msgstr ""
+"// Coloque uma `Structure` dentro de a estrutura `Deep`. Torne-a imprimível \n"
+"// também.\n"
+
+#: src/hello/print/print_debug.md:37
+msgid "// Printing with `{:?}` is similar to with `{}`.\n"
+msgstr "// Imprimir com `{:?}` é similar a imprimir com `{}`.\n"
+
+#: src/hello/print/print_debug.md:38
+msgid "\"{:?} months in a year.\""
+msgstr "\"{:?} meses em um ano.\""
+
+#: src/hello/print/print_debug.md:39
+msgid "\"{1:?} {0:?} is the {actor:?} name.\""
+msgstr "\"{1:?} {0:?} é o nome do {actor:?}.\""
+
+#: src/hello/print/print_debug.md:40
+msgid "\"Slater\""
+msgstr "\"Slater\""
+
+#: src/hello/print/print_debug.md:41
+msgid "\"Christian\""
+msgstr "\"Christian\""
+
+#: src/hello/print/print_debug.md:42
+msgid "\"actor's\""
+msgstr "\"actor's\""
+
+#: src/hello/print/print_debug.md:44
+msgid "// `Structure` is printable!\n"
+msgstr "// `Structure` também pode ser impressa!\n"
+
+#: src/hello/print/print_debug.md:45 src/hello/print/print_debug.md:49
+msgid "\"Now {:?} will print!\""
+msgstr "\"Agora {:?} imprimirá \""
+
+#: src/hello/print/print_debug.md:47
+msgid ""
+"// The problem with `derive` is there is no control over how\n"
+"    // the results look. What if I want this to just show a `7`?\n"
+msgstr ""
+"// O problema com `derive` é que não há controle sobre como\n"
+"   // os resultados aparecem. E se eu quiser que isso mostre apenas um `7`?\n"
+
+#: src/hello/print/print_debug.md:53
+msgid ""
+"So `fmt::Debug` definitely makes this printable but sacrifices some "
+"elegance. Rust also provides \"pretty printing\" with `{:#?}`."
+msgstr ""
+"Então `fmt::Debug` definitivamente faz isto imprimível mas sacrifica "
+"algo de elegância. Rust também fornece \"Impressão bonita\" com `{:#?}`."
+
+#: src/hello/print/print_debug.md:64 src/custom_types/structs.md:42
+msgid "\"Peter\""
+msgstr "\"Peter\""
+
+#: src/hello/print/print_debug.md:68
+msgid "// Pretty print\n"
+msgstr "// Impresión bonita"
+
+#: src/hello/print/print_debug.md:69
+msgid "\"{:#?}\""
+msgstr "\"{:#?}\""
+
+#: src/hello/print/print_debug.md:73
+msgid "One can manually implement `fmt::Display` to control the display."
+msgstr ""
+"Pode-se implementar manualmente `fmt::Display` para controlar a impressão."
+
+#: src/hello/print/print_debug.md:77
+msgid ""
+"[`attributes`](https://doc.rust-lang.org/reference/attributes.html), "
+"[`derive`](../../trait/derive.md), [`std::fmt`](https://doc.rust-lang.org/"
+"std/fmt/), and [`struct`](../../custom_types/structs.md)"
+msgstr ""
+"[`attributes`](https://doc.rust-lang.org/reference/attributes.html), "
+"[`derive`](../../trait/derive.md), [`std::fmt`](https://doc.rust-lang.org/"
+"std/fmt/), e [`struct`](../../custom_types/structs.md)"
+
+#: src/hello/print/print_display.md:3
+msgid ""
+"`fmt::Debug` hardly looks compact and clean, so it is often advantageous to "
+"customize the output appearance. This is done by manually implementing "
+"[`fmt::Display`](https://doc.rust-lang.org/std/fmt/), which uses the `{}` "
+"print marker. Implementing it looks like this:"
+msgstr ""
+"`fmt::Debug` raramente parece compacto e limpo, portanto, frequentemente é "
+"vantajoso personalizar a aparência de saída. Isto se faz implementando "
+"manualmente[`fmt::Display`](https://doc.rust-lang.org/std/fmt/), que usa o "
+"marcador `{}`. Implementá-lo fica assim:"
+
+#: src/hello/print/print_display.md:9
+msgid "// Import (via `use`) the `fmt` module to make it available.\n"
+msgstr ""
+"// Importar (através de `use`) o módulo `fmt` para disponibilizá-lo.\n"
+
+#: src/hello/print/print_display.md:11
+msgid ""
+"// Define a structure for which `fmt::Display` will be implemented. This is\n"
+"// a tuple struct named `Structure` that contains an `i32`.\n"
+msgstr ""
+"// Defina uma estrutura para a qual será implementado `fmt::Display`. Isto "
+"é\n"
+" // uma estrutura de tupla chamada `Estrutura` que contém um `i32`. \n"
+
+#: src/hello/print/print_display.md:15
+msgid ""
+"// To use the `{}` marker, the trait `fmt::Display` must be implemented\n"
+"// manually for the type.\n"
+msgstr ""
+"// Para usar o marcador `{}`, o trait `fmt::Display` deve ser implementado\n"
+"// manualmente para o tipo. \n"
+
+#: src/hello/print/print_display.md:19
+msgid "// This trait requires `fmt` with this exact signature.\n"
+msgstr "// Este trait requer de `fmt` com estes tipos exatos.\n"
+
+#: src/hello/print/print_display.md:21
+msgid ""
+"// Write strictly the first element into the supplied output\n"
+"        // stream: `f`. Returns `fmt::Result` which indicates whether the\n"
+"        // operation succeeded or failed. Note that `write!` uses syntax "
+"which\n"
+"        // is very similar to `println!`.\n"
+msgstr ""
+"// Escreve somente o primeiro elemento na saída fornecida \n"
+"// stream: `f`. Retorna `fmt::Result` que indica se\n"
+"// a operação teve sucesso ou falhou. Observe que `write!` usa uma "
+"sintaxe que \n"
+"// é muito similar a `println!`. \n"
+
+#: src/hello/print/print_display.md:25
+#: src/hello/print/print_display/testcase_list.md:13
+#: src/hello/print/print_display/testcase_list.md:39
+#: src/hello/print/print_display/testcase_list.md:49 src/hello/print/fmt.md:53
+#: src/custom_types/enum/testcase_linked_list.md:73 src/conversion/string.md:25
+#: src/flow_control/loop.md:26 src/flow_control/while.md:21
+#: src/flow_control/for.md:23 src/flow_control/for.md:43 src/fn.md:40
+#: src/fn/closures/capture.md:96 src/fn/closures/capture.md:97
+#: src/fn/closures/anonymity.md:41 src/generics/bounds.md:12
+#: src/macros/repeat.md:24 src/macros/repeat.md:25 src/macros/repeat.md:26
+#: src/error/result.md:73 src/std/str.md:92 src/std/str.md:102
+#: src/std/str.md:106 src/std/str.md:111 src/std/result.md:72
+#: src/std/result/question_mark.md:57 src/std/result/question_mark.md:65
+#: src/std_misc/file/read_lines.md:60 src/std_misc/arg/matching.md:9
+#: src/std_misc/arg/matching.md:13
+msgid "\"{}\""
+msgstr "\"{}\""
+
+#: src/hello/print/print_display.md:30
+msgid ""
+"`fmt::Display` may be cleaner than `fmt::Debug` but this presents a problem "
+"for the `std` library. How should ambiguous types be displayed? For example, "
+"if the `std` library implemented a single style for all `Vec<T>`, what style "
+"should it be? Would it be either of these two?"
+msgstr ""
+"`fmt::Display` pode ser mais limpo que `fmt::Debug`, mas isso apresenta um "
+"problema para a biblioteca `std`. Como tipos ambíguos devem ser exibidos? "
+"Por exemplo, se a biblioteca `std` implementasse um único estilo para todo "
+"`Vec<T>`, qual estilo deveria ser? Seria qualquer um destes dois?"
+
+#: src/hello/print/print_display.md:35
+msgid "`Vec<path>`: `/:/etc:/home/username:/bin` (split on `:`)"
+msgstr "`Vec<path>`: `/:/etc:/home/usuario:/bin` (split on `:`)"
+
+#: src/hello/print/print_display.md:36
+msgid "`Vec<number>`: `1,2,3` (split on `,`)"
+msgstr "`Vec<numero>`: `1,2,3` (dividido em `,`)"
+
+#: src/hello/print/print_display.md:38
+msgid ""
+"No, because there is no ideal style for all types and the `std` library "
+"doesn't presume to dictate one. `fmt::Display` is not implemented for "
+"`Vec<T>` or for any other generic containers. `fmt::Debug` must then be used "
+"for these generic cases."
+msgstr ""
+"Não, porque não há um estilo ideal para todos os tipos e a biblioteca `std` "
+"não presume ditar um. `fmt::Display` não se implementa para `Vec<T>` ou para "
+"qualquer outro contêiner genérico. `Fmt::Debug` deve ser usado para estes "
+"casos genéricos."
+
+#: src/hello/print/print_display.md:43
+msgid ""
+"This is not a problem though because for any new _container_ type which is "
+"_not_ generic, `fmt::Display` can be implemented."
+msgstr ""
+"Não entanto, isto não é um problema porque para qualquer novo tipo "
+"_container_ que não seja genérico, pode-se implementar `fmt::Display`."
+
+#: src/hello/print/print_display.md:47
+msgid "// Import `fmt`\n"
+msgstr "// Importar `fmt`\n"
+
+#: src/hello/print/print_display.md:48
+msgid ""
+"// A structure holding two numbers. `Debug` will be derived so the results "
+"can\n"
+"// be contrasted with `Display`.\n"
+msgstr ""
+"// Uma estrutura que contém dois números. Será derivado `Debug` para que os "
+"resultados possam// ser contrastados com `Display`.\n"
+
+#: src/hello/print/print_display.md:53
+msgid "// Implement `Display` for `MinMax`.\n"
+msgstr "// Implementa `Display` para `MinMax`.\n"
+
+#: src/hello/print/print_display.md:57
+msgid "// Use `self.number` to refer to each positional data point.\n"
+msgstr "// Use `self.number` para se referir a cada dado posicional.\n"
+
+#: src/hello/print/print_display.md:58
+msgid "\"({}, {})\""
+msgstr "\"({}, {})\""
+
+#: src/hello/print/print_display.md:61
+msgid "// Define a structure where the fields are nameable for comparison.\n"
+msgstr ""
+"// Defina uma estrutura onde os campos possam ser nomeados para "
+"comparação.\n"
+
+#: src/hello/print/print_display.md:68
+msgid "// Similarly, implement `Display` for `Point2D`.\n"
+msgstr "// Similarmente, implementa `Display` para `Point2D`.\n"
+
+#: src/hello/print/print_display.md:72
+msgid "// Customize so only `x` and `y` are denoted.\n"
+msgstr "// Personalize para que apenas `x` e `y` sejam denotados.\n"
+
+#: src/hello/print/print_display.md:73
+msgid "\"x: {}, y: {}\""
+msgstr "\"x: {}, y: {}\""
+
+#: src/hello/print/print_display.md:80
+msgid "\"Compare structures:\""
+msgstr "\"Compara estruturas:\""
+
+#: src/hello/print/print_display.md:81 src/hello/print/print_display.md:94
+msgid "\"Display: {}\""
+msgstr "\"Display: {}\""
+
+#: src/hello/print/print_display.md:82 src/hello/print/print_display.md:95
+msgid "\"Debug: {:?}\""
+msgstr "\"Debug: {:?}\""
+
+#: src/hello/print/print_display.md:87
+msgid "\"The big range is {big} and the small is {small}\""
+msgstr "\"O grande intervalo é {big} e o pequeno é {small}\""
+
+#: src/hello/print/print_display.md:93
+msgid "\"Compare points:\""
+msgstr "\" Compara pontos:\""
+
+#: src/hello/print/print_display.md:97
+msgid ""
+"// Error. Both `Debug` and `Display` were implemented, but `{:b}`\n"
+"    // requires `fmt::Binary` to be implemented. This will not work.\n"
+"    // println!(\"What does Point2D look like in binary: {:b}?\", point);\n"
+msgstr ""
+"// Erro. Tanto `Debug` quanto `Display` foram implementados, mas `{:b}`\n"
+"   // exige a implementação de `fmt::Binary`. Isso não vai funcionar.\n"
+"   // println!(\"Como o Point2D fica em binário: {:b}?\", point);\n"
+
+#: src/hello/print/print_display.md:103
+msgid ""
+"So, `fmt::Display` has been implemented but `fmt::Binary` has not, and "
+"therefore cannot be used. `std::fmt` has many such [`traits`](https://doc."
+"rust-lang.org/std/fmt/#formatting-traits) and each requires its own "
+"implementation. This is detailed further in [`std::fmt`](https://doc.rust-"
+"lang.org/std/fmt/)."
+msgstr ""
+"Então, `fmt::Display` foi implementado mas `fmt::Binary` não, e portanto "
+"tanto, não pode ser usado. `std::fmt` tem muitos desses [`traits`](https://"
+"doc.rust-lang.org/std/fmt/#formatting-traits) e cada um exige "
+"sua implementação. Isto é detalhado mais em [`std::fmt`](https://doc.rust-"
+"lang.org/std/fmt/)."
+
+#: src/hello/print/print_display.md:109
+msgid ""
+"After checking the output of the above example, use the `Point2D` struct as "
+"a guide to add a `Complex` struct to the example. When printed in the same "
+"way, the output should be:"
+msgstr ""
+"Após verificar a saída do exemplo anterior, use a struct `Point2D` como "
+"guia para adicionar uma struct `Complex` ao exemplo. Quando impressa da "
+"mesma forma, a saída deve ser:"
+
+#: src/hello/print/print_display.md:120
+msgid ""
+"[`derive`](../../trait/derive.md), [`std::fmt`](https://doc.rust-lang.org/"
+"std/fmt/), [`macros`](../../macros.md), [`struct`](../../custom_types/"
+"structs.md), [`trait`](https://doc.rust-lang.org/std/fmt/#formatting-"
+"traits), and [`use`](../../mod/use.md)"
+msgstr ""
+"[`derive`](../../trait/derive.md), [`std::fmt`](https://doc.rust-lang.org/"
+"std/fmt/), [`macros`](../../macros.md), [`struct`](../../custom_types/"
+"structs.md), [`trait`](https://doc.rust-lang.org/std/fmt/#formatting-"
+"traits) e [`use`](../../mod/use.md)"
+
+#: src/hello/print/print_display/testcase_list.md:3
+msgid ""
+"Implementing `fmt::Display` for a structure where the elements must each be "
+"handled sequentially is tricky. The problem is that each `write!` generates "
+"a `fmt::Result`. Proper handling of this requires dealing with _all_ the "
+"results. Rust provides the `?` operator for exactly this purpose."
+msgstr ""
+"Implementar `fmt::Display` para uma estrutura onde os elementos devem ser "
+"cada um tratados sequencialmente é complicado. O problema é que cada "
+"`write!` gera um `fmt::Result`. O tratamento adequado de isto requerem tratar "
+"com _todos_ os resultados. Rust fornece o operador `?` para exatamente "
+"este propósito."
+
+#: src/hello/print/print_display/testcase_list.md:8
+msgid "Using `?` on `write!` looks like this:"
+msgstr "Usar `?` com `write!` se ve así:"
+
+#: src/hello/print/print_display/testcase_list.md:11
+msgid ""
+"// Try `write!` to see if it errors. If it errors, return\n"
+"// the error. Otherwise continue.\n"
+msgstr ""
+"// Usa `write!` para ver se falha. Se houver erros, retorna\n"
+"// o erro. Caso contrário, continua.\n"
+
+#: src/hello/print/print_display/testcase_list.md:16
+msgid ""
+"With `?` available, implementing `fmt::Display` for a `Vec` is "
+"straightforward:"
+msgstr ""
+"Com `?`, implementar `fmt::Display` para um `Vec` é direto:"
+
+#: src/hello/print/print_display/testcase_list.md:20
+msgid "// Import the `fmt` module.\n"
+msgstr "// Importar o módulo `fmt`.\n"
+
+#: src/hello/print/print_display/testcase_list.md:21
+msgid "// Define a structure named `List` containing a `Vec`.\n"
+msgstr "// Define uma estrutura chamada `List` que contém um `Vec`.\n"
+
+#: src/hello/print/print_display/testcase_list.md:27
+msgid ""
+"// Extract the value using tuple indexing,\n"
+"        // and create a reference to `vec`.\n"
+msgstr ""
+"// Extrai o valor usando indexação de tuplas,\n"
+"       // e cria uma referência a `vec`.\n"
+
+#: src/hello/print/print_display/testcase_list.md:31
+msgid "\"[\""
+msgstr "\"[\""
+
+#: src/hello/print/print_display/testcase_list.md:33
+msgid ""
+"// Iterate over `v` in `vec` while enumerating the iteration\n"
+"        // count in `count`.\n"
+msgstr ""
+"// Itera sobre `v` em um `vec` enquanto enumera a contagem\n"
+"       // da iteração em `count`.\n"
+
+#: src/hello/print/print_display/testcase_list.md:36
+msgid ""
+"// For every element except the first, add a comma.\n"
+"            // Use the ? operator to return on errors.\n"
+msgstr ""
+"// Para cada element exceto o primeiro, adicione uma vírgula.\n"
+"           // Usa o operador ? para regresar erros.\n"
+
+#: src/hello/print/print_display/testcase_list.md:38 src/std/str.md:36
+msgid "\", \""
+msgstr "\", \""
+
+#: src/hello/print/print_display/testcase_list.md:42
+msgid "// Close the opened bracket and return a fmt::Result value.\n"
+msgstr "// Fecha a chave aberta e retorna um valor de `fmt::Result`.\n"
+
+#: src/hello/print/print_display/testcase_list.md:43
+msgid "\"]\""
+msgstr "\"]\""
+
+#: src/hello/print/print_display/testcase_list.md:55
+msgid ""
+"Try changing the program so that the index of each element in the vector is "
+"also printed. The new output should look like this:"
+msgstr ""
+"Tente alterar o programa para que o índice de cada elemento no vetor também "
+"seja impresso. A nova saída deve ficar assim:"
+
+#: src/hello/print/print_display/testcase_list.md:64
+msgid ""
+"[`for`](../../../flow_control/for.md), [`ref`](../../../scope/borrow/ref."
+"md), [`Result`](../../../std/result.md), [`struct`](../../../custom_types/"
+"structs.md), [`?`](../../../std/result/question_mark.md), and [`vec!`]"
+"(../../../std/vec.md)"
+msgstr ""
+"[`for`](../../../flow_control/for.md), [`ref`](../../../scope/borrow/ref."
+"md), [`Result`](../../../std/result.md), [`struct`](../../../custom_types/"
+"structs.md), [`?`](../../../std/result/question_mark.md), e [`vec!`]"
+"(../../../std/vec.md)"
+
+#: src/hello/print/fmt.md:3
+msgid "We've seen that formatting is specified via a _format string_:"
+msgstr ""
+"Vimos que este formato é especificado via uma _string de formatação_:"
+
+#: src/hello/print/fmt.md:5
+msgid "`format!(\"{}\", foo)` -> `\"3735928559\"`"
+msgstr "`format!(\"{}\", foo)` -> `\"3735928559\"`"
+
+#: src/hello/print/fmt.md:6
+msgid ""
+"`format!(\"0x{:X}\", foo)` -> [`\"0xDEADBEEF\"`](https://en.wikipedia.org/"
+"wiki/Deadbeef#Magic_debug_values)"
+msgstr "`format!(\"0x{:X}\", foo)` -> [`\"0xDEADBEEF\"`](https://en.wikipedia.org/wiki/Deadbeef#Magic_debug_values)"
+
+#: src/hello/print/fmt.md:7
+msgid "`format!(\"0o{:o}\", foo)` -> `\"0o33653337357\"`"
+msgstr "`format!(\"0o{:o}\", foo)` -> `\"0o33653337357\"`"
+
+#: src/hello/print/fmt.md:9
+msgid ""
+"The same variable (`foo`) can be formatted differently depending on which "
+"_argument type_ is used: `X` vs `o` vs _unspecified_."
+msgstr ""
+"A mesma variável (`foo`) pode ser formatada de forma diferente dependendo "
+"de qual seja _tipo de argumento_ utilizado: `X` vs `o` vs _no especificado_."
+
+#: src/hello/print/fmt.md:12
+msgid ""
+"This formatting functionality is implemented via traits, and there is one "
+"trait for each argument type. The most common formatting trait is `Display`, "
+"which handles cases where the argument type is left unspecified: `{}` for "
+"instance."
+msgstr ""
+"Esta funcionalidade de formatação é implementada através de traits, e há um trait "
+"para cada tipo de argumento. O trait de formatação mais comum é `Display`, "
+"que manipula casos nos quais o tipo de argumento é deixado sem especificar: `{}"
+"`, por exemplo."
+
+#: src/hello/print/fmt.md:21
+msgid "// Latitude\n"
+msgstr "// Latitude\n"
+
+#: src/hello/print/fmt.md:23
+msgid "// Longitude\n"
+msgstr "// Longitude\n"
+
+#: src/hello/print/fmt.md:28
+msgid ""
+"// `f` is a buffer, and this method must write the formatted string into "
+"it.\n"
+msgstr ""
+"// `f` é um buffer, e este método é usado para formatar e meterle uma "
+"string.\n"
+
+#: src/hello/print/fmt.md:30
+msgid "'N'"
+msgstr "'N'"
+
+#: src/hello/print/fmt.md:30
+msgid "'S'"
+msgstr "'S'"
+
+#: src/hello/print/fmt.md:31
+msgid "'E'"
+msgstr "'E'"
+
+#: src/hello/print/fmt.md:31
+msgid "'W'"
+msgstr "'W'"
+
+#: src/hello/print/fmt.md:33
+msgid ""
+"// `write!` is like `format!`, but it will write the formatted string\n"
+"        // into a buffer (the first argument).\n"
+msgstr ""
+"// `write!` é como `format!`, mas escreverá a string formatada\n"
+"        // no buffer (o primeiro argumento).\n"
+
+#: src/hello/print/fmt.md:35
+msgid "\"{}: {:.3}°{} {:.3}°{}\""
+msgstr "\"{}: {:.3}°{} {:.3}°{}\""
+
+#: src/hello/print/fmt.md:49
+msgid "\"Dublin\""
+msgstr "\"Dublin\""
+
+#: src/hello/print/fmt.md:50
+msgid "\"Oslo\""
+msgstr "\"Oslo\""
+
+#: src/hello/print/fmt.md:51
+msgid "\"Vancouver\""
+msgstr "\"Vancouver\""
+
+#: src/hello/print/fmt.md:60
+msgid ""
+"// Switch this to use {} once you've added an implementation\n"
+"        // for fmt::Display.\n"
+msgstr ""
+"// Altera isto a {} uma vez que tenha adicionado uma implementação\n"
+"        // para fmt::Display.\n"
+
+#: src/hello/print/fmt.md:62 src/primitives/tuples.md:60
+#: src/custom_types/structs.md:47 src/types/inference.md:23
+#: src/conversion/string.md:76 src/generics/bounds.md:49
+#: src/generics/where.md:38 src/std/str.md:137 src/std/result.md:59
+#: src/std/result.md:61 src/std/result.md:63 src/std/arc.md:26
+#: src/std_misc/channels.md:53
+msgid "\"{:?}\""
+msgstr "\"{:?}\""
+
+#: src/hello/print/fmt.md:67
+msgid ""
+"You can view a [full list of formatting traits](https://doc.rust-lang.org/"
+"std/fmt/#formatting-traits) and their argument types in the [`std::fmt`]"
+"(https://doc.rust-lang.org/std/fmt/) documentation."
+msgstr ""
+"Pode ver uma [lista completa de traits de formatação](https://doc.rust-lang."
+"org/std/fmt/#formatting-traits) e seus tipos de argumentos na "
+"documentação de [`std::fmt`](https://doc.rust-lang.org/std/fmt/)."
+
+#: src/hello/print/fmt.md:72
+msgid ""
+"Add an implementation of the `fmt::Display` trait for the `Color` struct "
+"above so that the output displays as:"
+msgstr ""
+"Adicione uma implementação do trait `fmt::Display` para a estrutura "
+"`Color`acima para que a saída se mostre como:"
+
+#: src/hello/print/fmt.md:81
+msgid "Three hints if you get stuck:"
+msgstr "Três dicas se você travar:"
+
+#: src/hello/print/fmt.md:83
+msgid ""
+"The formula for calculating a color in the RGB color space is: `RGB = "
+"(R*65536)+(G*256)+B , (when R is RED, G is GREEN and B is BLUE)`. For more "
+"see [RGB color format & calculation](https://www.rapidtables.com/web/color/"
+"RGB_Color.html#rgb-format)."
+msgstr ""
+"A fórmula para calcular um cor em ou espaço de cor RGB é: `RGB = "
+"(R*65536)+(G*256)+B, (quando R é ROJO, G é VERDE e B é AZUL)`. Para mais "
+"ver [Formato de cor RGB e seu cálculo](https://www.rapidtables.com/web/color/"
+"RGB_Color.html#rgb-format)."
+
+#: src/hello/print/fmt.md:86
+msgid ""
+"You [may need to list each color more than once](https://doc.rust-lang.org/"
+"std/fmt/#named-parameters)."
+msgstr ""
+"Pode que [precise enumerar cada cor mais de uma vez](https://doc.rust-lang.org/"
+"std/fmt/#named-parameters)."
+
+#: src/hello/print/fmt.md:87
+msgid ""
+"You can [pad with zeros to a width of 2](https://doc.rust-lang.org/std/fmt/"
+"#width) with `:0>2`."
+msgstr ""
+"Pode [preencher com zeros a uma largura de 2](https://doc.rust-lang.org/std/fmt/"
+"#width) usando `:0>2`."
+
+#: src/hello/print/fmt.md:91
+msgid "[`std::fmt`](https://doc.rust-lang.org/std/fmt/)"
+msgstr "[`std::fmt`](https://doc.rust-lang.org/std/fmt/)"
+
+#: src/primitives.md:3
+msgid ""
+"Rust provides access to a wide variety of `primitives`. A sample includes:"
+msgstr ""
+"Rust fornece acesso a uma ampla variedade de `primitivas`. Alguns exemplos são:"
+
+#: src/primitives.md:5
+msgid "Scalar Types"
+msgstr "Tipos Escalares"
+
+#: src/primitives.md:7
+msgid ""
+"Signed integers: `i8`, `i16`, `i32`, `i64`, `i128` and `isize` (pointer size)"
+msgstr ""
+"Inteiros com signo: `i8`, `i16`, `i32`, `i64`, `i128` e `isize` (o tamanho do ponteiro)"
+
+#: src/primitives.md:8
+msgid ""
+"Unsigned integers: `u8`, `u16`, `u32`, `u64`, `u128` and `usize` (pointer "
+"size)"
+msgstr ""
+"Inteiros sem signo: `u8`, `u16`, `u32`, `u64`, `u128` e `usize` (o tamanho do ponteiro"
+")"
+
+#: src/primitives.md:10
+msgid "Floating point: `f32`, `f64`"
+msgstr "Ponto ponto flutuante: `f32`, `f64`"
+
+#: src/primitives.md:11
+msgid "`char` Unicode scalar values like `'a'`, `'α'` and `'∞'` (4 bytes each)"
+msgstr "`char` Valores de Unicode escalares como `'a'`, `'α'` e `'∞'` (4 bytes cada um)"
+
+#: src/primitives.md:12
+msgid "`bool` either `true` or `false`"
+msgstr "`bool` pode ser `true` ou `falso`"
+
+#: src/primitives.md:13
+msgid "The unit type `()`, whose only possible value is an empty tuple: `()`"
+msgstr "O tipo unitário `()`, cujo único possível valor é a tupla vazia: `()`"
+
+#: src/primitives.md:15
+msgid ""
+"Despite the value of a unit type being a tuple, it is not considered a "
+"compound type because it does not contain multiple values."
+msgstr ""
+"Apesar de o valor de um tipo de unidade é uma tupla, não se considera um"
+"tipo de composto porque não contém múltiplos valores."
+
+#: src/primitives.md:18
+msgid "Compound Types"
+msgstr "Tipos Compostos"
+
+#: src/primitives.md:20
+msgid "Arrays like `[1, 2, 3]`"
+msgstr "Arrays como `[1, 2, 3]`"
+
+#: src/primitives.md:21
+msgid "Tuples like `(1, true)`"
+msgstr "Tuplas como `(1, true)`"
+
+#: src/primitives.md:23
+msgid ""
+"Variables can always be _type annotated_. Numbers may additionally be "
+"annotated via a _suffix_ or _by default_. Integers default to `i32` and "
+"floats to `f64`. Note that Rust can also infer types from context."
+msgstr ""
+"As variáveis sempre podem ter _anotación de tipos_. Os números também podem ser"
+"anotados através de um _sufijo_ ou _por default_. Os inteiros usam como padrão `i32` e "
+"os flutuantes usam a `f64`. Observe que Rust pode também pode inferir tipos."
+
+#: src/primitives.md:29
+msgid "// Variables can be type annotated.\n"
+msgstr "// As variáveis podem carregar anotações de tipo.\n"
+
+#: src/primitives.md:32
+msgid "// Regular annotation\n"
+msgstr "// Anotação regular\n"
+
+#: src/primitives.md:33
+msgid "// Suffix annotation\n"
+msgstr "// Anotação com sufixo\n"
+
+#: src/primitives.md:35
+msgid "// Or a default will be used.\n"
+msgstr "// Ou se usará um padrão.\n"
+
+#: src/primitives.md:36
+msgid "// `f64`\n"
+msgstr ""
+"// `f64`\n"
+
+#: src/primitives.md:37
+msgid "// `i32`\n"
+msgstr ""
+"// `i32`\n"
+
+#: src/primitives.md:39
+msgid "// A type can also be inferred from context.\n"
+msgstr "// Um tipo também pode-se inferir por contexto.\n"
+
+#: src/primitives.md:40
+msgid "// Type i64 is inferred from another line.\n"
+msgstr "// O tipo i64 pode-se inferir de outra linha.\n"
+
+#: src/primitives.md:43
+msgid "// A mutable variable's value can be changed.\n"
+msgstr "// Uma variável mutável pode alterar.\n"
+
+#: src/primitives.md:44
+msgid "// Mutable `i32`\n"
+msgstr "// `i32` Mutável\n"
+
+#: src/primitives.md:47
+msgid "// Error! The type of a variable can't be changed.\n"
+msgstr "// Erro! O tipo da variável não pode-se alterar.\n"
+
+#: src/primitives.md:50
+msgid "// Variables can be overwritten with shadowing.\n"
+msgstr "// As variáveis pode-se sobreescrever com sombreamento.\n"
+
+#: src/primitives.md:53
+msgid "/* Compound types - Array and Tuple */"
+msgstr "/* Tipos compostos - Arreglo e Tupla */"
+
+#: src/primitives.md:55
+msgid "// Array signature consists of Type T and length as [T; length].\n"
+msgstr "// A declaração do tipo de Arreglo consiste do tipo T e a comprimento como [T; comprimento].\n"
+
+#: src/primitives.md:58
+msgid ""
+"// Tuple is a collection of values of different types \n"
+"    // and is constructed using parentheses ().\n"
+msgstr ""
+"// Uma tupla é uma coleção de valores de diferentes tipos\n"
+"   // e se constrói usando parênteses ().\n"
+
+#: src/primitives.md:66
+msgid ""
+"[the `std` library](https://doc.rust-lang.org/std/), [`mut`]"
+"(variable_bindings/mut.md), [`inference`](types/inference.md), and "
+"[`shadowing`](variable_bindings/scope.md)"
+msgstr ""
+"[the `std` library](https://doc.rust-lang.org/std/), [`mut`]"
+"(variable_bindings/mut.md), [`inference`](types/inference.md), e "
+"[`shadowing`](variable_bindings/scope.md)"
+
+#: src/primitives/literals.md:3
+msgid ""
+"Integers `1`, floats `1.2`, characters `'a'`, strings `\"abc\"`, booleans "
+"`true` and the unit type `()` can be expressed using literals."
+msgstr ""
+"Inteiros `1`, flutuantes `1.2`, caractéres `'a'`, strings `\"abc\"`, booleanos "
+"`true` e o tipo unitário `()` pode-se expresar com literais."
+
+#: src/primitives/literals.md:6
+msgid ""
+"Integers can, alternatively, be expressed using hexadecimal, octal or binary "
+"notation using these prefixes respectively: `0x`, `0o` or `0b`."
+msgstr ""
+"Os inteiros podem, alternativamente, ser expressos usando notação hexadecimal, octal ou binária"
+"usando estes prefixos respectivamente: `0x`, `0o` ou` 0b`."
+
+#: src/primitives/literals.md:9
+msgid ""
+"Underscores can be inserted in numeric literals to improve readability, e.g. "
+"`1_000` is the same as `1000`, and `0.000_001` is the same as `0.000001`."
+msgstr ""
+"Pode-se inserir sublinhados em literais numéricos para melhorar a "
+"legibilidade, por exemplo, `1_000` é o mesmo que `1000`, e `0.000_001` é ou "
+"mesmo que `0.000001`."
+
+#: src/primitives/literals.md:12
+msgid ""
+"Rust also supports scientific [E-notation](https://en.wikipedia.org/wiki/"
+"Scientific_notation#E_notation), e.g. `1e6`, `7.6e-4`. The associated type "
+"is `f64`."
+msgstr ""
+"Rust também admite [notação E científica](https://en.wikipedia.org/wiki/"
+"Scientific_notation#E_notation), e.g. `1e6`, `7.6e-4`. O tipo associado é "
+"`f64`."
+
+#: src/primitives/literals.md:15
+msgid ""
+"We need to tell the compiler the type of the literals we use. For now, we'll "
+"use the `u32` suffix to indicate that the literal is an unsigned 32-bit "
+"integer, and the `i32` suffix to indicate that it's a signed 32-bit integer."
+msgstr ""
+"Precisamos dizer ao compilador o tipo de literais que usamos. Por enquanto, faremos isso"
+"usando o sufixo `u32` para indicar que o literal é um inteiro sem signo de 32 bits "
+", e o sufixo `i32` para indicar que é um inteiro com signo de 32 bits."
+
+#: src/primitives/literals.md:19
+msgid ""
+"The operators available and their precedence [in Rust](https://doc.rust-lang."
+"org/reference/expressions.html#expression-precedence) are similar to other "
+"[C-like languages](https://en.wikipedia.org/wiki/"
+"Operator_precedence#Programming_languages)."
+msgstr ""
+"Os operadores disponíveis e sua precedência [em Rust](https://doc.rust-lang."
+"org/reference/expressions.html#expression-precedence) é similar a outros "
+"[linguagens como C](https://en.wikipedia.org/wiki/"
+"Operator_precedence#Programming_languages)."
+
+#: src/primitives/literals.md:24
+msgid "// Integer addition\n"
+msgstr "// Suma de inteiros"
+
+#: src/primitives/literals.md:25
+msgid "\"1 + 2 = {}\""
+msgstr "\"1 + 2 = {}\""
+
+#: src/primitives/literals.md:27
+msgid "// Integer subtraction\n"
+msgstr "// Resta de inteiros"
+
+#: src/primitives/literals.md:28
+msgid "\"1 - 2 = {}\""
+msgstr "\"1 - 2 = {}\""
+
+#: src/primitives/literals.md:29
+msgid ""
+"// TODO ^ Try changing `1i32` to `1u32` to see why the type is important\n"
+msgstr ""
+"// TAREFA ^ Tenta alterar `1i32` a `1u32` para ver por quê o tipo é importante\n"
+
+#: src/primitives/literals.md:31
+msgid "// Scientific notation\n"
+msgstr "// Notação científica"
+
+#: src/primitives/literals.md:32
+msgid "\"1e4 is {}, -2.5e-3 is {}\""
+msgstr "\"1e4 é {}, -2.5e-3 é {}\""
+
+#: src/primitives/literals.md:34
+msgid "// Short-circuiting boolean logic\n"
+msgstr "// Lógica booleana de corto circuito"
+
+#: src/primitives/literals.md:35
+msgid "\"true AND false is {}\""
+msgstr "\"true E false é {}\""
+
+#: src/primitives/literals.md:36
+msgid "\"true OR false is {}\""
+msgstr "\"true Ou false é {}\""
+
+#: src/primitives/literals.md:37
+msgid "\"NOT true is {}\""
+msgstr "\"NOT true é {}\""
+
+#: src/primitives/literals.md:39
+msgid "// Bitwise operations\n"
+msgstr "// Operações sobre bits"
+
+#: src/primitives/literals.md:40
+msgid "\"0011 AND 0101 is {:04b}\""
+msgstr "\"0011 AND 0101 é {:04b}\""
+
+#: src/primitives/literals.md:41
+msgid "\"0011 OR 0101 is {:04b}\""
+msgstr "\"0011 OR 0101 é {:04b}\""
+
+#: src/primitives/literals.md:42
+msgid "\"0011 XOR 0101 is {:04b}\""
+msgstr "\"0011 XOR 0101 é {:04b}\""
+
+#: src/primitives/literals.md:43
+msgid "\"1 << 5 is {}\""
+msgstr "\"1 << 5 é {}\""
+
+#: src/primitives/literals.md:44
+msgid "\"0x80 >> 2 is 0x{:x}\""
+msgstr "\"0x80 >> 2 é 0x{:x}\""
+
+#: src/primitives/literals.md:46
+msgid "// Use underscores to improve readability!\n"
+msgstr "// Use sublinhados para melhorar a legibilidade!\n"
+
+#: src/primitives/literals.md:47
+msgid "\"One million is written as {}\""
+msgstr "\" Um millón se escreve como {}\""
+
+#: src/primitives/tuples.md:3
+msgid ""
+"A tuple is a collection of values of different types. Tuples are constructed "
+"using parentheses `()`, and each tuple itself is a value with type signature "
+"`(T1, T2, ...)`, where `T1`, `T2` are the types of its members. Functions "
+"can use tuples to return multiple values, as tuples can hold any number of "
+"values."
+msgstr ""
+"Uma tupla é uma coleção de valores de diferentes tipos. Se são construídas tuplas"
+"usando parênteses `()`, e cada tupla em sim é um valor com a anotação de tipo"
+"`(T1, t2, ...) `, onde `t1`, `t2` são os tipos de seus membros. As funções"
+"podem usar tuplas para retornar múltiplos valores, já que as tuplas podem conter qualquer número de"
+"valores."
+
+#: src/primitives/tuples.md:9
+msgid "// Tuples can be used as function arguments and as return values.\n"
+msgstr "// As tuplas podem-se como argumentos de funções e como seus valores de retorno.\n"
+
+#: src/primitives/tuples.md:11
+msgid "// `let` can be used to bind the members of a tuple to variables.\n"
+msgstr "// `let` pode-se usar para ligar os membros de a tupla a variáveis.\n"
+
+#: src/primitives/tuples.md:16
+msgid "// The following struct is for the activity.\n"
+msgstr "// A seguinte `struct` é para a atividade.\n"
+
+#: src/primitives/tuples.md:22
+msgid "// A tuple with a bunch of different types.\n"
+msgstr "// Uma tupla é montón de tipos diferentes.\n"
+
+#: src/primitives/tuples.md:26 src/generics.md:50 src/generics.md:55
+#: src/generics/gen_fn.md:47
+msgid "'a'"
+msgstr "'um'"
+
+#: src/primitives/tuples.md:28
+msgid "// Values can be extracted from the tuple using tuple indexing.\n"
+msgstr "// Podem-se extraer valores de a tupla indexando"
+
+#: src/primitives/tuples.md:29
+msgid "\"Long tuple first value: {}\""
+msgstr "\"Tupla grande primer valor: {}\""
+
+#: src/primitives/tuples.md:30
+msgid "\"Long tuple second value: {}\""
+msgstr "\"Tupla grande segundo valor: {}\""
+
+#: src/primitives/tuples.md:32
+msgid "// Tuples can be tuple members.\n"
+msgstr "// Tuplas com tuplas como membros.\n"
+
+#: src/primitives/tuples.md:35
+msgid "// Tuples are printable.\n"
+msgstr "// As tuples podem ser impressos.\n"
+
+#: src/primitives/tuples.md:36
+msgid "\"tuple of tuples: {:?}\""
+msgstr "\"tupla de tuplas: {:?}\""
+
+#: src/primitives/tuples.md:38
+msgid ""
+"// But long Tuples (more than 12 elements) cannot be printed.\n"
+"    //let too_long_tuple = (1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13);\n"
+"    //println!(\"Too long tuple: {:?}\", too_long_tuple);\n"
+"    // TODO ^ Uncomment the above 2 lines to see the compiler error\n"
+msgstr ""
+"// Mas não podem ser impressos tuplas grandes demais (mais de 12 elementos).\n"
+"   // let tupla_grande_demais = (1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13);\n"
+"   // println!(\"Tupla grande demais: {:?}\", tupla_grande_demais);\n"
+"   // TAREFA ^ Remova o comentário das 2 linhas anteriores para ver o erro do compilador\n"
+
+#: src/primitives/tuples.md:44
+msgid "\"Pair is {:?}\""
+msgstr "\"Par é {:?}\""
+
+#: src/primitives/tuples.md:46
+msgid "\"The reversed pair is {:?}\""
+msgstr "\"O par invertido é {:?}\""
+
+#: src/primitives/tuples.md:48
+msgid ""
+"// To create one element tuples, the comma is required to tell them apart\n"
+"    // from a literal surrounded by parentheses.\n"
+msgstr ""
+"// Para criar um tuplas de um único elemento, se requerem a vírgula para distinguirlas\n"
+"   // de um literal rodeado de parênteses.\n"
+
+#: src/primitives/tuples.md:50
+msgid "\"One element tuple: {:?}\""
+msgstr "\"Uma tupla de 1 elemento: {:?}\""
+
+#: src/primitives/tuples.md:51
+msgid "\"Just an integer: {:?}\""
+msgstr "\"Somente um inteiro: {:?}\""
+
+#: src/primitives/tuples.md:53
+msgid "// Tuples can be destructured to create bindings.\n"
+msgstr "// As tuplas pode desestruturar para criar variáveis.\n"
+
+#: src/primitives/tuples.md:54 src/conversion/from_into.md:17
+#: src/fn/closures/input_parameters.md:52 src/std_misc/fs.md:51
+msgid "\"hello\""
+msgstr "\"hello\""
+
+#: src/primitives/tuples.md:57
+msgid "\"{:?}, {:?}, {:?}, {:?}\""
+msgstr "\"{:?}, {:?}, {:?}, {:?}\""
+
+#: src/primitives/tuples.md:66
+msgid ""
+"_Recap_: Add the `fmt::Display` trait to the `Matrix` struct in the above "
+"example, so that if you switch from printing the debug format `{:?}` to the "
+"display format `{}`, you see the following output:"
+msgstr ""
+"_Recapitulando_: adicione o trait `fmt::Display` à struct `Matrix` no exemplo "
+"anterior, de modo que ao trocar a impressão do formato de depuração `{:?}` "
+"para o formato de exibição `{}`, você veja a seguinte saída:"
+
+#: src/primitives/tuples.md:75
+msgid ""
+"You may want to refer back to the example for [print display](../hello/print/"
+"print_display.md)."
+msgstr ""
+"Você pode querer consultar o exemplo de [impressão com display](../hello/"
+"print/print_display.md)."
+
+#: src/primitives/tuples.md:76
+msgid ""
+"Add a `transpose` function using the `reverse` function as a template, which "
+"accepts a matrix as an argument, and returns a matrix in which two elements "
+"have been swapped. For example:"
+msgstr ""
+"Adicione uma função `transpose` usando a função `reverse` como modelo, que "
+"aceita uma array como argumento e devolve uma array na qual dois elementos "
+"foram trocados. Por exemplo:"
+
+#: src/primitives/tuples.md:81
+msgid "\"Matrix:\\n{}\""
+msgstr "\"Array:\\n{}\""
+
+#: src/primitives/tuples.md:82
+msgid "\"Transpose:\\n{}\""
+msgstr "\"Transposta:\\n{}\""
+
+#: src/primitives/tuples.md:85
+msgid "Results in the output:"
+msgstr "Resultados na saída:"
+
+#: src/primitives/array.md:3
+msgid ""
+"An array is a collection of objects of the same type `T`, stored in "
+"contiguous memory. Arrays are created using brackets `[]`, and their length, "
+"which is known at compile time, is part of their type signature `[T; "
+"length]`."
+msgstr ""
+"Um array é uma coleção de objetos do mesmo tipo `t`, armazenado em "
+"memória contigua. Os arrays são criados usando colchetes `[]`, e seu comprimento, "
+"que é conhecido no momento da compilação, é parte de sua anotação de tipo `[T; "
+"comprimento]`."
+
+#: src/primitives/array.md:7
+msgid ""
+"Slices are similar to arrays, but their length is not known at compile time. "
+"Instead, a slice is a two-word object; the first word is a pointer to the "
+"data, the second word is the length of the slice. The word size is the same "
+"as usize, determined by the processor architecture, e.g. 64 bits on an "
+"x86-64. Slices can be used to borrow a section of an array and have the type "
+"signature `&[T]`."
+msgstr ""
+"As slices são similares aos arrays, mas seu comprimento não é conhecido no momento da compilação."
+"Em vez disso, um slice é um objeto de duas 'words' do processador; a primeira palavra é um ponteiro para os"
+"dados, a segunda palavra é o comprimento da slice. O tamanho da palavra é o mesmo"
+"que usize, o qual se determina pela arquitetura do processador, e.g. 64 bits em "
+"x86-64. Os slices podem-se usar para tomar um `borrow` de uma seção de um array e ter a anotação"
+"de tipo `&[t]`."
+
+#: src/primitives/array.md:15
+msgid "// This function borrows a slice.\n"
+msgstr "// Esta função faz borrow a uma slice.\n"
+
+#: src/primitives/array.md:18
+msgid "\"First element of the slice: {}\""
+msgstr "\" O primeiro elemento de um slice: {}\""
+
+#: src/primitives/array.md:19
+msgid "\"The slice has {} elements\""
+msgstr "\"A slice tem {} elementos\""
+
+#: src/primitives/array.md:23
+msgid "// Fixed-size array (type signature is superfluous).\n"
+msgstr "// Arrays de tamanho fixo (sua anotação de tipo é superflua).\n"
+
+#: src/primitives/array.md:26
+msgid "// All elements can be initialized to the same value.\n"
+msgstr "// Todos os elementos podem ser inicializados com o mesmo valor.\n"
+
+#: src/primitives/array.md:29
+msgid "// Indexing starts at 0.\n"
+msgstr "// Os índices empiezan em 0.\n"
+
+#: src/primitives/array.md:30
+msgid "\"First element of the array: {}\""
+msgstr "\"O primeiro elemento do array: {}\""
+
+#: src/primitives/array.md:31
+msgid "\"Second element of the array: {}\""
+msgstr "\"Ou segundo elemento do array: {}\""
+
+#: src/primitives/array.md:33
+msgid "// `len` returns the count of elements in the array.\n"
+msgstr "// `len` retorna quantos elementos há no array.\n"
+
+#: src/primitives/array.md:34
+msgid "\"Number of elements in array: {}\""
+msgstr "\"Número de elementos no array: {} \""
+
+#: src/primitives/array.md:36
+msgid "// Arrays are stack allocated.\n"
+msgstr "// Os arrays são alocados na stack.\n"
+
+#: src/primitives/array.md:37
+msgid "\"Array occupies {} bytes\""
+msgstr "\"Os arrays ocupam {} bytes\""
+
+#: src/primitives/array.md:39
+msgid "// Arrays can be automatically borrowed as slices.\n"
+msgstr "// Os arrays podem ser `borrowed` como slices.\n"
+
+#: src/primitives/array.md:40
+msgid "\"Borrow the whole array as a slice.\""
+msgstr "\"Faz borrow de todo o array como um slice.\""
+
+#: src/primitives/array.md:43
+msgid ""
+"// Slices can point to a section of an array.\n"
+"    // They are of the form [starting_index..ending_index].\n"
+"    // `starting_index` is the first position in the slice.\n"
+"    // `ending_index` is one more than the last position in the slice.\n"
+msgstr ""
+"// Os slices podem apontar a uma seção de um array.\n"
+"   // Estes são de a forma [índice_inicial..índice_final].\n"
+"   // `índice_inicial` é a primeira posição na slice.\n"
+"   // `índice_final` é um mais que a última posição na porção.\n"
+
+#: src/primitives/array.md:47
+msgid "\"Borrow a section of the array as a slice.\""
+msgstr "\"Faça borrow de uma seção do arrae como um slice.\""
+
+#: src/primitives/array.md:50
+msgid "// Example of empty slice `&[]`:\n"
+msgstr "// Um exemplo de um slice vazio `&[]`:\n"
+
+#: src/primitives/array.md:53
+msgid "// Same but more verbose\n"
+msgstr "// O mesmo mas menos conciso"
+
+#: src/primitives/array.md:55
+msgid ""
+"// Arrays can be safely accessed using `.get`, which returns an\n"
+"    // `Option`. This can be matched as shown below, or used with\n"
+"    // `.expect()` if you would like the program to exit with a nice\n"
+"    // message instead of happily continue.\n"
+msgstr ""
+"// Podem-se acessar a as arrays de forma segura usando `.get`, o qual retorna um \n"
+"    // `Option'. Aqui pode-se usar um match como se mostra a seguir, ou em seu caso com \n"
+"    // `.expect()` se desejar que o programa termine com um amigável\n"
+"    // mensagem em vez de continuar felizmente.\n"
+
+#: src/primitives/array.md:59
+msgid "// Oops, one element too far!\n"
+msgstr "// Oops, um elemento além do limite.\n"
+
+#: src/primitives/array.md:61
+msgid "\"{}: {}\""
+msgstr "\"{}: {}\""
+
+#: src/primitives/array.md:62
+msgid "\"Slow down! {} is too far!\""
+msgstr "\"Devagar! {} está longe demais\""
+
+#: src/primitives/array.md:66
+msgid ""
+"// Out of bound indexing on array with constant value causes compile time "
+"error.\n"
+"    //println!(\"{}\", xs[5]);\n"
+"    // Out of bound indexing on slice causes runtime error.\n"
+"    //println!(\"{}\", xs[..][5]);\n"
+msgstr ""
+"// Usar um índice constante que está fora do intervalo válido causa um erro de compilação.\n"
+"    //println!(\"{}\", xs[5]);\n"
+"    // Usar um índice fuera de rango em um slice causa um erro de compilação.\n"
+"    //println!(\"{}\", xs[..][5]);\n"
+
+#: src/custom_types.md:3
+msgid "Rust custom data types are formed mainly through the two keywords:"
+msgstr "Os tipos de dados personalizados em Rust se são obtidos principalmente com 2 palavras-chave:"
+
+#: src/custom_types.md:5
+msgid "`struct`: define a structure"
+msgstr "`struct`: define uma estrutura"
+
+#: src/custom_types.md:6
+msgid "`enum`: define an enumeration"
+msgstr "`enum`: define uma enumeración"
+
+#: src/custom_types.md:8
+msgid "Constants can also be created via the `const` and `static` keywords."
+msgstr "As constantes são criados com as palavras-chave `const` ou `static`."
+
+#: src/custom_types/structs.md:3
+msgid ""
+"There are three types of structures (\"structs\") that can be created using "
+"the `struct` keyword:"
+msgstr ""
+"Há três tipos de estruturas (\"struct\") que podem-se criar usando"
+"a palavra-chave 'struct`:"
+
+#: src/custom_types/structs.md:6
+msgid "Tuple structs, which are, basically, named tuples."
+msgstr "Estruturas de tupla, que são basicamente tuplas nomeadas."
+
+#: src/custom_types/structs.md:7
+msgid ""
+"The classic [C structs](https://en.wikipedia.org/wiki/"
+"Struct_(C_programming_language))"
+msgstr ""
+"As clássicas estruturas [struct de C](https://en.wikipedia.org/wiki/"
+"Struct_(C_programming_language))"
+
+#: src/custom_types/structs.md:8
+msgid "Unit structs, which are field-less, are useful for generics."
+msgstr "As structs unitários, as quais não têm campos, e são úteis para os genéricos."
+
+#: src/custom_types/structs.md:11 src/custom_types/enum/enum_use.md:6
+#: src/custom_types/enum/c_like.md:6
+msgid "// An attribute to hide warnings for unused code.\n"
+msgstr "// Um atributo para esconder as avisos do código não utilizado.\n"
+
+#: src/custom_types/structs.md:19
+msgid "// A unit struct\n"
+msgstr "// Uma struct unitária"
+
+#: src/custom_types/structs.md:22
+msgid "// A tuple struct\n"
+msgstr "// Uma struct de tupla"
+
+#: src/custom_types/structs.md:25
+msgid "// A struct with two fields\n"
+msgstr "// Uma struct de dois campos\n"
+
+#: src/custom_types/structs.md:31
+msgid "// Structs can be reused as fields of another struct\n"
+msgstr "// As Structs podem reutilizar os campos de outras structs\n"
+
+#: src/custom_types/structs.md:34
+msgid ""
+"// A rectangle can be specified by where the top left and bottom right\n"
+"    // corners are in space.\n"
+msgstr ""
+"// Um retângulo pode-se especificar por onde os cantos superior esquerdo e inferior direito"
+"    // estão no espaço.\n"
+
+#: src/custom_types/structs.md:41
+msgid "// Create struct with field init shorthand\n"
+msgstr "// Abreviação para criar um struct com um campo já inicializado\n"
+
+#: src/custom_types/structs.md:46
+msgid "// Print debug struct\n"
+msgstr "// Imprime um struct de depuração\n"
+
+#: src/custom_types/structs.md:49
+msgid "// Instantiate a `Point`\n"
+msgstr "// Instanciar um `Point`\n"
+
+#: src/custom_types/structs.md:53
+msgid "// Access the fields of the point\n"
+msgstr "// Acessa os campos do ponto\n"
+
+#: src/custom_types/structs.md:54
+msgid "\"point coordinates: ({}, {})\""
+msgstr "\"coordenadas do ponto: ({}, {})\""
+
+#: src/custom_types/structs.md:56
+msgid ""
+"// Make a new point by using struct update syntax to use the fields of our\n"
+"    // other one\n"
+msgstr ""
+"// Cria um novo ponto usando a sintaxe de atualização de struct para usar os campos\n"
+"    // da outra struct\n"
+
+#: src/custom_types/structs.md:60
+msgid ""
+"// `bottom_right.y` will be the same as `another_point.y` because we used "
+"that field\n"
+"    // from `another_point`\n"
+msgstr ""
+"// `abajo_derecha.y` será o mesmo que `otro_punto.y` porque usamos esse "
+"campo \n"
+"    // de `otro_punto`\n"
+
+#: src/custom_types/structs.md:62
+msgid "\"second point: ({}, {})\""
+msgstr "\"segundo ponto: ({}, {})\""
+
+#: src/custom_types/structs.md:64
+msgid "// Destructure the point using a `let` binding\n"
+msgstr "// Desestruturação do ponto com um enlace `let`\n"
+
+#: src/custom_types/structs.md:68
+msgid "// struct instantiation is an expression too\n"
+msgstr "// também pode-se fazer a instanciação de um struct com uma expressão"
+
+#: src/custom_types/structs.md:73
+msgid "// Instantiate a unit struct\n"
+msgstr "// Instancia uma struct unitária"
+
+#: src/custom_types/structs.md:76
+msgid "// Instantiate a tuple struct\n"
+msgstr "// Instancia uma estrutura de tupla\n"
+
+#: src/custom_types/structs.md:79
+msgid "// Access the fields of a tuple struct\n"
+msgstr "// Acessa os campos de uma estrutura de tupla\n"
+
+#: src/custom_types/structs.md:80 src/custom_types/structs.md:85
+msgid "\"pair contains {:?} and {:?}\""
+msgstr "\"um par contém {:?} e {:?}\""
+
+#: src/custom_types/structs.md:82
+msgid "// Destructure a tuple struct\n"
+msgstr "// Desestruturação uma estrutura de tupla"
+
+#: src/custom_types/structs.md:91
+msgid ""
+"Add a function `rect_area` which calculates the area of a `Rectangle` (try "
+"using nested destructuring)."
+msgstr ""
+"Adicione uma função `rect_area` que calcula a área de um `Rectangle` (tenta"
+"usar de a desestruturação aninhada)."
+
+#: src/custom_types/structs.md:93
+msgid ""
+"Add a function `square` which takes a `Point` and a `f32` as arguments, and "
+"returns a `Rectangle` with its top left corner on the point, and a width and "
+"height corresponding to the `f32`."
+msgstr ""
+"Adicione uma função `square` que recebe um `Punto` e um `f32` como argumentos, e "
+"retorna um `Rectangle` com seu canto superior izquierda no ponto, e uma largura e"
+"altura correspondente ao `f32`."
+
+#: src/custom_types/structs.md:97
+msgid "See also"
+msgstr "Veja também"
+
+#: src/custom_types/structs.md:99
+msgid ""
+"[`attributes`](../attribute.md), [raw identifiers](../compatibility/"
+"raw_identifiers.md) and [destructuring](../flow_control/match/destructuring."
+"md)"
+msgstr ""
+"[`attributes`](../attribute.md), [raw identifiers](../compatibility/"
+"raw_identifiers.md) e [destructuring](../flow_control/match/destructuring."
+"md)"
+
+#: src/custom_types/enum.md:3
+msgid ""
+"The `enum` keyword allows the creation of a type which may be one of a few "
+"different variants. Any variant which is valid as a `struct` is also valid "
+"in an `enum`."
+msgstr ""
+"A palavra-chave `enum` permite a criação de um tipo que pode ser um de umas poucas"
+"diferentes variantes. Qualquer variante que seja válida como `struct` também é válida"
+"em um `enum`."
+
+#: src/custom_types/enum.md:8
+msgid ""
+"// Create an `enum` to classify a web event. Note how both\n"
+"// names and type information together specify the variant:\n"
+"// `PageLoad != PageUnload` and `KeyPress(char) != Paste(String)`.\n"
+"// Each is different and independent.\n"
+msgstr ""
+"// Crie um `enum` para classificar um evento web. Observe como ambos os\n"
+"// nomes e os tipos juntos especificam a variante:\n"
+"// `PageLoad != PageUnload` e `KeyPress(char) != Paste(String)`.\n"
+"// Cada um é diferente e independente.\n"
+
+#: src/custom_types/enum.md:13
+msgid "// An `enum` variant may either be `unit-like`,\n"
+msgstr "// Uma variante `enum` pode ser `cuasi-unitaria`,\n"
+
+#: src/custom_types/enum.md:16
+msgid "// like tuple structs,\n"
+msgstr "// como estruturas de tuplas"
+
+#: src/custom_types/enum.md:19
+msgid "// or c-like structures.\n"
+msgstr "// ou estruturas estilo C.\n"
+
+#: src/custom_types/enum.md:22
+msgid ""
+"// A function which takes a `WebEvent` enum as an argument and\n"
+"// returns nothing.\n"
+msgstr ""
+"// Uma função que recebe um enum 'WebEvent` como argumento e \n"
+"// não retorna nada.\n"
+
+#: src/custom_types/enum.md:27
+msgid "\"page loaded\""
+msgstr "\"página cargada\""
+
+#: src/custom_types/enum.md:28
+msgid "\"page unloaded\""
+msgstr "\"página descargada \""
+
+#: src/custom_types/enum.md:29
+msgid "// Destructure `c` from inside the `enum` variant.\n"
+msgstr "// Desestruturação `c` desde dentro de a variante `enum`.\n"
+
+#: src/custom_types/enum.md:30
+msgid "\"pressed '{}'.\""
+msgstr "\"pressionou '{}'.\""
+
+#: src/custom_types/enum.md:31
+msgid "\"pasted \\\"{}\\\".\""
+msgstr "\"colou \\\"{}\\\".\""
+
+
+#: src/custom_types/enum.md:32
+msgid "// Destructure `Click` into `x` and `y`.\n"
+msgstr "// Desestruturação de `Click` em `x` e `y`.\n"
+
+#: src/custom_types/enum.md:34
+msgid "\"clicked at x={}, y={}.\""
+msgstr "\"click em x={}, e={}.\""
+
+
+#: src/custom_types/enum.md:40
+msgid "'x'"
+msgstr "'x'"
+
+#: src/custom_types/enum.md:41
+msgid "// `to_owned()` creates an owned `String` from a string slice.\n"
+msgstr "// `to_owned()` cria um `String` que é dono de uma slice de string.\n"
+
+
+#: src/custom_types/enum.md:42
+msgid "\"my text\""
+msgstr "\"meu texto\""
+
+
+#: src/custom_types/enum.md:56
+msgid "Type aliases"
+msgstr "Aliases de tipos"
+
+#: src/custom_types/enum.md:58
+msgid ""
+"If you use a type alias, you can refer to each enum variant via its alias. "
+"This might be useful if the enum's name is too long or too generic, and you "
+"want to rename it."
+msgstr ""
+"Se usar um alias de tipo, pode consultar cada variante de enum através de seu alias."
+"Isto poderia ser útil se o nome do enum for longo demais ou genérico demais, "
+"e você quiser renomeá-lo."
+
+#: src/custom_types/enum.md:67
+msgid "// Creates a type alias\n"
+msgstr "// Criar um alias de tipo\n"
+
+#: src/custom_types/enum.md:72
+msgid ""
+"// We can refer to each variant via its alias, not its long and "
+"inconvenient\n"
+"    // name.\n"
+msgstr ""
+"// Podemos nos referir a cada variante através de seu alias, e não seu nome longo e"
+"inconveniente \n"
+"   // nome. \n"
+
+#: src/custom_types/enum.md:78
+msgid ""
+"The most common place you'll see this is in `impl` blocks using the `Self` "
+"alias."
+msgstr ""
+"O lugar mais comum que verá isto é em os blocos de `impl` usando o alias `Self` "
+"."
+
+#: src/custom_types/enum.md:96
+msgid ""
+"To learn more about enums and type aliases, you can read the [stabilization "
+"report](https://github.com/rust-lang/rust/pull/61682/"
+"#issuecomment-502472847) from when this feature was stabilized into Rust."
+msgstr ""
+"Para obter mais informações sobre enums e alias de tipo, pode ler o [relatório "
+"estabilización](https://github.com/rust-lang/rust/pull/61682/"
+"#issuecomment-502472847) de quando este feature se estabilizou em Rust."
+
+#: src/custom_types/enum.md:102
+msgid ""
+"[`match`](../flow_control/match.md), [`fn`](../fn.md), and [`String`](../std/"
+"str.md), [\"Type alias enum variants\" RFC](https://rust-lang.github.io/"
+"rfcs/2338-type-alias-enum-variants.html)"
+msgstr ""
+"[`match`](../flow_control/match.md), [`fn`](../fn.md), e [`String`](../std/"
+"str.md), [\"Type alias enum variants\" RFC](https://rust-lang.github.io/"
+"rfcs/2338-type-alias-enum-variants.html)"
+
+#: src/custom_types/enum/enum_use.md:3
+msgid "The `use` declaration can be used so manual scoping isn't needed:"
+msgstr "A declaração `use` pode-se usar de tal forma que não sejam necessários escopos manuais:"
+
+#: src/custom_types/enum/enum_use.md:20
+msgid ""
+"// Explicitly `use` each name so they are available without\n"
+"    // manual scoping.\n"
+msgstr ""
+"// Explicitamente `use` (usa) cada nome para que estejam disponíveis sem \n "
+"    // escopo manual. \n"
+
+#: src/custom_types/enum/enum_use.md:23
+msgid "// Automatically `use` each name inside `Role`.\n"
+msgstr "// Faz `use` automaticamente para cada nome dentro de `Role`.\n"
+
+#: src/custom_types/enum/enum_use.md:26
+msgid "// Equivalent to `Stage::Beginner`.\n"
+msgstr "// Equivalente a `Stage::Beginner`.\n"
+
+#: src/custom_types/enum/enum_use.md:28
+msgid "// Equivalent to `Role::Student`.\n"
+msgstr "// Equivalente a `Role::Student`.\n"
+
+#: src/custom_types/enum/enum_use.md:32
+msgid "// Note the lack of scoping because of the explicit `use` above.\n"
+msgstr "// Note a ausência de escopo por causa do `use` explícito acima.\n"
+
+#: src/custom_types/enum/enum_use.md:33
+msgid "\"Beginners are starting their learning journey!\""
+msgstr "\"Iniciantes estão começando sua jornada de aprendizado!\""
+
+#: src/custom_types/enum/enum_use.md:34
+msgid "\"Advanced learners are mastering their subjects...\""
+msgstr "\"Os estudantes avançados estão dominando sus matérias...\""
+
+#: src/custom_types/enum/enum_use.md:38
+msgid "// Note again the lack of scoping.\n"
+msgstr "// Notamos outra vez a falta de escopos.\n"
+
+#: src/custom_types/enum/enum_use.md:39
+msgid "\"Students are acquiring knowledge!\""
+msgstr "\"Estudantes estão adquirindo conhecimento!\""
+
+#: src/custom_types/enum/enum_use.md:40
+msgid "\"Teachers are spreading knowledge!\""
+msgstr "\"Teachers are spreading knowledge!\""
+
+#: src/custom_types/enum/enum_use.md:47
+msgid "[`match`](../../flow_control/match.md) and [`use`](../../mod/use.md)"
+msgstr "[`match`](../../flow_control/match.md) e [`use`](../../mod/use.md)"
+
+#: src/custom_types/enum/c_like.md:3
+msgid "`enum` can also be used as C-like enums."
+msgstr "`enum` pode also be usado as C-like enums."
+
+#: src/custom_types/enum/c_like.md:8
+msgid "// enum with implicit discriminator (starts at 0)\n"
+msgstr ""
+"// enum com implícita discriminator (starts at 0)\n"
+
+#: src/custom_types/enum/c_like.md:15
+msgid "// enum with explicit discriminator\n"
+msgstr ""
+"// enum com explícita discriminator\n"
+
+#: src/custom_types/enum/c_like.md:24
+msgid "// `enums` can be cast as integers.\n"
+msgstr ""
+"// `enums` pode be cast as inteiros.\n"
+
+#: src/custom_types/enum/c_like.md:25
+msgid "\"zero is {}\""
+msgstr "\"zero is {}\""
+
+#: src/custom_types/enum/c_like.md:26
+msgid "\"one is {}\""
+msgstr "\"one is {}\""
+
+#: src/custom_types/enum/c_like.md:28
+msgid "\"roses are #{:06x}\""
+msgstr "\"roses are #{:06x}\""
+
+#: src/custom_types/enum/c_like.md:29
+msgid "\"violets are #{:06x}\""
+msgstr "\"violets are #{:06x}\""
+
+#: src/custom_types/enum/c_like.md:35
+msgid "[casting](../../types/cast.md)"
+msgstr "[casting](../../types/cast.md)"
+
+#: src/custom_types/enum/testcase_linked_list.md:3
+msgid "A common way to implement a linked-list is via `enums`:"
+msgstr "UM common way to implement um linked-list is via `enums`:"
+
+#: src/custom_types/enum/testcase_linked_list.md:9
+msgid ""
+"// Cons: Tuple struct that wraps an element and a pointer to the next node\n"
+msgstr ""
+"// Cons: Tuple struct aquele wraps um element e um pointer to o próximo node\n"
+
+#: src/custom_types/enum/testcase_linked_list.md:11
+msgid "// Nil: A node that signifies the end of the linked list\n"
+msgstr ""
+"// Nil: UM node aquele signifies o end of o linked list\n"
+
+#: src/custom_types/enum/testcase_linked_list.md:14
+msgid "// Methods can be attached to an enum\n"
+msgstr ""
+"// Métodos pode be attached to um enum\n"
+
+#: src/custom_types/enum/testcase_linked_list.md:17
+msgid "// Create an empty list\n"
+msgstr ""
+"// Cria um vazio list\n"
+
+#: src/custom_types/enum/testcase_linked_list.md:19
+msgid "// `Nil` has type `List`\n"
+msgstr ""
+"// `Nil` has tipo `List`\n"
+
+#: src/custom_types/enum/testcase_linked_list.md:23
+msgid ""
+"// Consume a list, and return the same list with a new element at its front\n"
+msgstr ""
+"// Consume um list, e retorna o mesmo list com um novo element at its front\n"
+
+#: src/custom_types/enum/testcase_linked_list.md:25
+msgid "// `Cons` also has type List\n"
+msgstr ""
+"// `Cons` also has tipo List\n"
+
+#: src/custom_types/enum/testcase_linked_list.md:29
+msgid "// Return the length of the list\n"
+msgstr ""
+"// Retorna o length of o list\n"
+
+#: src/custom_types/enum/testcase_linked_list.md:31
+msgid ""
+"// `self` has to be matched, because the behavior of this method\n"
+"        // depends on the variant of `self`\n"
+"        // `self` has type `&List`, and `*self` has type `List`, matching on "
+"a\n"
+"        // concrete type `T` is preferred over a match on a reference `&T`\n"
+"        // after Rust 2018 you can use self here and tail (with no ref) "
+"below as well,\n"
+"        // rust will infer &s and ref tail. \n"
+"        // See https://doc.rust-lang.org/edition-guide/rust-2018/ownership-"
+"and-lifetimes/default-match-bindings.html\n"
+msgstr ""
+"// `self` has to be matched, porque o behavior of este método\n"
+"        // depends on o variant of `self`\n"
+"        // `self` has tipo `&List`, e `*self` has tipo `List`, matching on um\n"
+"        // concrete tipo `T` is preferred over um match on um reference `&T`\n"
+"        // after Rust 2018 you pode use self here e tail (com no ref) abaixo as well,\n"
+"        // rust vai infer &s e ref tail. \n"
+"        // See https://doc.rust-lang.org/edition-guide/rust-2018/ownership-and-lifetimes/default-match-bindings.html\n"
+
+#: src/custom_types/enum/testcase_linked_list.md:39
+msgid ""
+"// Can't take ownership of the tail, because `self` is borrowed;\n"
+"            // instead take a reference to the tail\n"
+msgstr ""
+"// Pode't take ownership of o tail, porque `self` is emprestadas;\n"
+"            // instead take um reference to o tail\n"
+
+#: src/custom_types/enum/testcase_linked_list.md:42
+msgid "// Base Case: An empty list has zero length\n"
+msgstr ""
+"// Base Case: Um vazio list has zero length\n"
+
+#: src/custom_types/enum/testcase_linked_list.md:47
+msgid "// Return representation of the list as a (heap allocated) string\n"
+msgstr ""
+"// Retorna representation of o list as um (heap allocated) string\n"
+
+#: src/custom_types/enum/testcase_linked_list.md:51
+msgid ""
+"// `format!` is similar to `print!`, but returns a heap\n"
+"                // allocated string instead of printing to the console\n"
+msgstr ""
+"// `format!` is similar to `print!`, but returns a heap\n"
+"                // allocated string instead of printing to the console\n"
+
+#: src/custom_types/enum/testcase_linked_list.md:53 src/generics/impl.md:44
+msgid "\"{}, {}\""
+msgstr "\"{}, {}\""
+
+#: src/custom_types/enum/testcase_linked_list.md:56
+msgid "\"Nil\""
+msgstr "\"Nil\""
+
+#: src/custom_types/enum/testcase_linked_list.md:63
+msgid "// Create an empty linked list\n"
+msgstr ""
+"// Cria um vazio linked list\n"
+
+#: src/custom_types/enum/testcase_linked_list.md:66
+msgid "// Prepend some elements\n"
+msgstr ""
+"// Prepend some elements\n"
+
+#: src/custom_types/enum/testcase_linked_list.md:71
+msgid "// Show the final state of the list\n"
+msgstr ""
+"// Show o final state of o list\n"
+
+#: src/custom_types/enum/testcase_linked_list.md:72
+msgid "\"linked list has length: {}\""
+msgstr "\"linked list has length: {}\""
+
+#: src/custom_types/enum/testcase_linked_list.md:79
+msgid "[`Box`](../../std/box.md) and [methods](../../fn/methods.md)"
+msgstr "[`Box`](../../std/box.md) e [methods](../../fn/methods.md)"
+
+#: src/custom_types/constants.md:3
+msgid ""
+"Rust has two different types of constants which can be declared in any scope "
+"including global. Both require explicit type annotation:"
+msgstr "Rust has two diferente tipos of constants which pode be declared in any scope including global. Both require explícita tipo anotação:"
+
+#: src/custom_types/constants.md:6
+msgid "`const`: An unchangeable value (the common case)."
+msgstr "`const`: Um unchangeable valor (o common case)."
+
+#: src/custom_types/constants.md:7
+msgid ""
+"`static`: A possibly mutable variable with [`'static`](../scope/lifetime/"
+"static_lifetime.md) lifetime. The static lifetime is inferred and does not "
+"have to be specified. Accessing or modifying a mutable static variable is "
+"[`unsafe`](../unsafe.md)."
+msgstr "`static`: UM possibly mutável variável com [`'static`](../scope/lifetime/static_lifetime.md) lifetime. O static lifetime is inferred e does not have to be specified. Accessing ou modifying um mutável static variável is [`unsafe`](../unsafe.md)."
+
+#: src/custom_types/constants.md:12
+msgid "// Globals are declared outside all other scopes.\n"
+msgstr ""
+"// Globals are declared fora all other scopes.\n"
+
+#: src/custom_types/constants.md:13
+msgid "\"Rust\""
+msgstr "\"Rust\""
+
+#: src/custom_types/constants.md:17
+msgid "// Access constant in some function\n"
+msgstr ""
+"// Access constant in some função\n"
+
+#: src/custom_types/constants.md:24
+msgid "// Access constant in the main thread\n"
+msgstr ""
+"// Access constant in o main thread\n"
+
+#: src/custom_types/constants.md:25
+msgid "\"This is {}\""
+msgstr "\"Este is {}\""
+
+#: src/custom_types/constants.md:26
+msgid "\"The threshold is {}\""
+msgstr "\"O threshold is {}\""
+
+#: src/custom_types/constants.md:27
+msgid "\"{} is {}\""
+msgstr "\"{} is {}\""
+
+#: src/custom_types/constants.md:27
+msgid "\"big\""
+msgstr "\"big\""
+
+#: src/custom_types/constants.md:27
+msgid "\"small\""
+msgstr "\"small\""
+
+#: src/custom_types/constants.md:29
+msgid "// Error! Cannot modify a `const`.\n"
+msgstr ""
+"// Erro! Não pode modify um `const`.\n"
+
+#: src/custom_types/constants.md:31 src/variable_bindings/scope.md:22
+#: src/variable_bindings/declare.md:27 src/variable_bindings/freeze.md:16
+#: src/types/cast.md:19 src/types/cast.md:28 src/flow_control/for.md:95
+#: src/scope/borrow.md:41 src/scope/borrow/mut.md:52 src/std/vec.md:32
+#: src/std/vec.md:45 src/std/hash/hashset.md:48
+msgid "// FIXME ^ Comment out this line\n"
+msgstr ""
+"// FIXME ^ Comenta out este line\n"
+
+#: src/custom_types/constants.md:37
+msgid ""
+"[The `const`/`static` RFC](https://github.com/rust-lang/rfcs/blob/master/"
+"text/0246-const-vs-static.md), [`'static` lifetime](../scope/lifetime/"
+"static_lifetime.md)"
+msgstr "[The `const`/`static` RFC](https://github.com/rust-lang/rfcs/blob/master/text/0246-const-vs-static.md), [`'static` lifetime](../scope/lifetime/static_lifetime.md)"
+
+#: src/variable_bindings.md:3
+msgid ""
+"Rust provides type safety via static typing. Variable bindings can be type "
+"annotated when declared. However, in most cases, the compiler will be able "
+"to infer the type of the variable from the context, heavily reducing the "
+"annotation burden."
+msgstr "Rust provides tipo safety via static typing. Variável bindings pode be tipo annotated when declared. However, in most cases, o compiler vai be able to infer o tipo of o variável do context, heavily reducing o anotação burden."
+
+#: src/variable_bindings.md:8
+msgid ""
+"Values (like literals) can be bound to variables, using the `let` binding."
+msgstr "Valores (like literals) pode be bound to variáveis, usando o `let` binding."
+
+#: src/variable_bindings.md:16
+msgid "// copy `an_integer` into `copied_integer`\n"
+msgstr ""
+"// copy `an_integer` em `copied_integer`\n"
+
+#: src/variable_bindings.md:19
+msgid "\"An integer: {:?}\""
+msgstr "\"Um inteiro: {:?}\""
+
+#: src/variable_bindings.md:20
+msgid "\"A boolean: {:?}\""
+msgstr "\"UM booleano: {:?}\""
+
+#: src/variable_bindings.md:21
+msgid "\"Meet the unit value: {:?}\""
+msgstr "\"Meet o unit valor: {:?}\""
+
+#: src/variable_bindings.md:23
+msgid ""
+"// The compiler warns about unused variable bindings; these warnings can\n"
+"    // be silenced by prefixing the variable name with an underscore\n"
+msgstr ""
+"// O compiler warns about unused variável bindings; estes warnings pode\n"
+"    // be silenced by prefixing o variável name com um underscore\n"
+
+#: src/variable_bindings.md:28
+msgid ""
+"// FIXME ^ Prefix with an underscore to suppress the warning\n"
+"    // Please note that warnings may not be shown in a browser\n"
+msgstr ""
+"// FIXME ^ Prefix com um underscore to suppress o warning\n"
+"    // Please note aquele warnings may not be shown in um browser\n"
+
+#: src/variable_bindings/mut.md:3
+msgid ""
+"Variable bindings are immutable by default, but this can be overridden using "
+"the `mut` modifier."
+msgstr "Variável bindings are imutável by default, but este pode be overridden usando o `mut` modifier."
+
+#: src/variable_bindings/mut.md:11
+msgid "\"Before mutation: {}\""
+msgstr "\"Before mutation: {}\""
+
+#: src/variable_bindings/mut.md:13
+msgid "// Ok\n"
+msgstr ""
+"// Ok\n"
+
+#: src/variable_bindings/mut.md:16
+msgid "\"After mutation: {}\""
+msgstr "\"After mutation: {}\""
+
+#: src/variable_bindings/mut.md:18
+msgid "// Error! Cannot assign a new value to an immutable variable\n"
+msgstr ""
+"// Erro! Não pode assign um novo valor to um imutável variável\n"
+
+#: src/variable_bindings/mut.md:23
+msgid "The compiler will throw a detailed diagnostic about mutability errors."
+msgstr "O compiler vai throw um detailed diagnostic about mutability erros."
+
+#: src/variable_bindings/scope.md:3
+msgid ""
+"Variable bindings have a scope, and are constrained to live in a _block_. A "
+"block is a collection of statements enclosed by braces `{}`."
+msgstr "Variável bindings have um scope, e are constrained to live in um _block_. UM block is um collection of statements enclosed by braces `{}`."
+
+#: src/variable_bindings/scope.md:8
+msgid "// This binding lives in the main function\n"
+msgstr ""
+"// Este binding lives in o main função\n"
+
+#: src/variable_bindings/scope.md:11
+msgid "// This is a block, and has a smaller scope than the main function\n"
+msgstr ""
+"// Este is um block, e has um smaller scope than o main função\n"
+
+#: src/variable_bindings/scope.md:13
+msgid "// This binding only exists in this block\n"
+msgstr ""
+"// Este binding only exists in este block\n"
+
+#: src/variable_bindings/scope.md:16
+msgid "\"inner short: {}\""
+msgstr "\"inner short: {}\""
+
+#: src/variable_bindings/scope.md:18
+msgid "// End of the block\n"
+msgstr ""
+"// End of o block\n"
+
+#: src/variable_bindings/scope.md:20
+msgid "// Error! `short_lived_binding` doesn't exist in this scope\n"
+msgstr ""
+"// Erro! `short_lived_binding` doesn't exist in este scope\n"
+
+#: src/variable_bindings/scope.md:21
+msgid "\"outer short: {}\""
+msgstr "\"outer short: {}\""
+
+#: src/variable_bindings/scope.md:24
+msgid "\"outer long: {}\""
+msgstr "\"outer long: {}\""
+
+#: src/variable_bindings/scope.md:28
+msgid ""
+"Also, [variable shadowing](https://en.wikipedia.org/wiki/Variable_shadowing) "
+"is allowed."
+msgstr "Also, [variable shadowing](https://en.wikipedia.org/wiki/Variable_shadowing) is allowed."
+
+#: src/variable_bindings/scope.md:35
+msgid "\"before being shadowed: {}\""
+msgstr "\"before being shadowed: {}\""
+
+#: src/variable_bindings/scope.md:37
+msgid "// This binding *shadows* the outer one\n"
+msgstr ""
+"// Este binding *shadows* o outer one\n"
+
+#: src/variable_bindings/scope.md:38
+msgid "\"abc\""
+msgstr "\"abc\""
+
+#: src/variable_bindings/scope.md:40
+msgid "\"shadowed in inner block: {}\""
+msgstr "\"shadowed in inner block: {}\""
+
+#: src/variable_bindings/scope.md:42
+msgid "\"outside inner block: {}\""
+msgstr "\"fora inner block: {}\""
+
+#: src/variable_bindings/scope.md:44
+msgid "// This binding *shadows* the previous binding\n"
+msgstr ""
+"// Este binding *shadows* o anterior binding\n"
+
+#: src/variable_bindings/scope.md:46
+msgid "\"shadowed in outer block: {}\""
+msgstr "\"shadowed in outer block: {}\""
+
+#: src/variable_bindings/declare.md:3
+msgid ""
+"It is possible to declare variable bindings first and initialize them later, "
+"but all variable bindings must be initialized before they are used: the "
+"compiler forbids use of uninitialized variable bindings, as it would lead to "
+"undefined behavior."
+msgstr "It is possible to declare variable bindings first and initialize them later, but all variable bindings must be initialized before they are used: the compiler forbids use of uninitialized variable bindings, as it would lead to undefined behavior."
+
+#: src/variable_bindings/declare.md:5
+msgid ""
+"It is not common to declare a variable binding and initialize it later in "
+"the function. It is more difficult for a reader to find the initialization "
+"when initialization is separated from declaration. It is common to declare "
+"and initialize a variable binding near where the variable will be used."
+msgstr "It is not common to declare uma variável binding e initialize it later in a função. It is more difficult para um reader to find o initialization when initialization is separated de declaration. It is common to declare e initialize uma variável binding near where o variável vai be usado."
+
+#: src/variable_bindings/declare.md:11
+msgid "// Declare a variable binding\n"
+msgstr ""
+"// Declare uma variável binding\n"
+
+#: src/variable_bindings/declare.md:17
+msgid "// Initialize the binding\n"
+msgstr ""
+"// Initialize o binding\n"
+
+#: src/variable_bindings/declare.md:21
+msgid "\"a binding: {}\""
+msgstr "\"um binding: {}\""
+
+#: src/variable_bindings/declare.md:25
+msgid "// Error! Use of uninitialized binding\n"
+msgstr ""
+"// Erro! Usa of uninitialized binding\n"
+
+#: src/variable_bindings/declare.md:26 src/variable_bindings/declare.md:31
+msgid "\"another binding: {}\""
+msgstr "\"another binding: {}\""
+
+#: src/variable_bindings/freeze.md:3
+msgid ""
+"When data is bound by the same name immutably, it also _freezes_. _Frozen_ "
+"data can't be modified until the immutable binding goes out of scope:"
+msgstr "When data is bound by the same name immutably, it also _freezes_. _Frozen_ data can't be modified until the immutable binding goes out of scope:"
+
+#: src/variable_bindings/freeze.md:11
+msgid "// Shadowing by immutable `_mutable_integer`\n"
+msgstr ""
+"// Shadowing by imutável `_mutable_integer`\n"
+
+#: src/variable_bindings/freeze.md:14
+msgid "// Error! `_mutable_integer` is frozen in this scope\n"
+msgstr ""
+"// Erro! `_mutable_integer` is frozen in este scope\n"
+
+#: src/variable_bindings/freeze.md:18
+msgid "// `_mutable_integer` goes out of scope\n"
+msgstr ""
+"// `_mutable_integer` goes out of scope\n"
+
+#: src/variable_bindings/freeze.md:21
+msgid "// Ok! `_mutable_integer` is not frozen in this scope\n"
+msgstr ""
+"// Ok! `_mutable_integer` is not frozen in este scope\n"
+
+#: src/types.md:3
+msgid ""
+"Rust provides several mechanisms to change or define the type of primitive "
+"and user defined types. The following sections cover:"
+msgstr "Rust provides several mechanisms to change ou define o tipo of primitive e user defined tipos. O following sections cover:"
+
+#: src/types.md:6
+msgid "[Casting](types/cast.md) between primitive types"
+msgstr "[Casting](types/cast.md) between primitive tipos"
+
+#: src/types.md:7
+msgid "Specifying the desired type of [literals](types/literals.md)"
+msgstr "Specifying o desired tipo of [literals](types/literals.md)"
+
+#: src/types.md:8
+msgid "Using [type inference](types/inference.md)"
+msgstr "Usando [type inference](types/inference.md)"
+
+#: src/types.md:9
+msgid "[Aliasing](types/alias.md) types"
+msgstr "[Aliasing](types/alias.md) tipos"
+
+#: src/types/cast.md:3
+msgid ""
+"Rust provides no implicit type conversion (coercion) between primitive "
+"types. But, explicit type conversion (casting) can be performed using the "
+"`as` keyword."
+msgstr "Rust provides no implícita tipo conversion (coercion) between primitive tipos. But, explícita tipo conversion (casting) pode be performed usando o `as` keyword."
+
+#: src/types/cast.md:6
+msgid ""
+"Rules for converting between integral types follow C conventions generally, "
+"except in cases where C has undefined behavior. The behavior of all casts "
+"between integral types is well defined in Rust."
+msgstr "Rules para converting between integral tipos follow C conventions generally, except in cases where C has undefined behavior. O behavior of all casts between integral tipos is well defined in Rust."
+
+#: src/types/cast.md:11
+msgid "// Suppress all warnings from casts which overflow.\n"
+msgstr ""
+"// Suppress all warnings de casts which overflow.\n"
+
+#: src/types/cast.md:17
+msgid "// Error! No implicit conversion\n"
+msgstr ""
+"// Erro! No implícita conversion\n"
+
+#: src/types/cast.md:21
+msgid "// Explicit conversion\n"
+msgstr ""
+"// Explícita conversion\n"
+
+#: src/types/cast.md:25
+msgid ""
+"// Error! There are limitations in conversion rules.\n"
+"    // A float cannot be directly converted to a char.\n"
+msgstr ""
+"// Erro! There are limitations in conversion rules.\n"
+"    // UM float não pode be directly converted to um char.\n"
+
+#: src/types/cast.md:30
+msgid "\"Casting: {} -> {} -> {}\""
+msgstr "\"Casting: {} -> {} -> {}\""
+
+#: src/types/cast.md:32
+msgid ""
+"// when casting any value to an unsigned type, T,\n"
+"    // T::MAX + 1 is added or subtracted until the value\n"
+"    // fits into the new type\n"
+msgstr ""
+"// when casting any valor to um unsigned tipo, T,\n"
+"    // T::MAX + 1 is added ou subtracted until o valor\n"
+"    // fits no novo tipo\n"
+
+#: src/types/cast.md:36
+msgid "// 1000 already fits in a u16\n"
+msgstr ""
+"// 1000 already fits in um u16\n"
+
+#: src/types/cast.md:37
+msgid "\"1000 as a u16 is: {}\""
+msgstr "\"1000 as um u16 is: {}\""
+
+#: src/types/cast.md:39
+msgid ""
+"// 1000 - 256 - 256 - 256 = 232\n"
+"    // Under the hood, the first 8 least significant bits (LSB) are kept,\n"
+"    // while the rest towards the most significant bit (MSB) get truncated.\n"
+msgstr ""
+"// 1000 - 256 - 256 - 256 = 232\n"
+"    // Under o hood, o primeiro 8 least significant bits (LSB) are kept,\n"
+"    // while o rest towards o most significant bit (MSB) get truncated.\n"
+
+#: src/types/cast.md:42 src/types/cast.md:61
+msgid "\"1000 as a u8 is : {}\""
+msgstr "\"1000 as um u8 is : {}\""
+
+#: src/types/cast.md:43
+msgid "// -1 + 256 = 255\n"
+msgstr ""
+"// -1 + 256 = 255\n"
+
+#: src/types/cast.md:44
+msgid "\"  -1 as a u8 is : {}\""
+msgstr "\"  -1 as um u8 is : {}\""
+
+#: src/types/cast.md:46
+msgid "// For positive numbers, this is the same as the modulus\n"
+msgstr ""
+"// Para positive números, este is o mesmo as o modulus\n"
+
+#: src/types/cast.md:47
+msgid "\"1000 mod 256 is : {}\""
+msgstr "\"1000 mod 256 is : {}\""
+
+#: src/types/cast.md:49
+msgid ""
+"// When casting to a signed type, the (bitwise) result is the same as\n"
+"    // first casting to the corresponding unsigned type. If the most "
+"significant\n"
+"    // bit of that value is 1, then the value is negative.\n"
+msgstr ""
+"// When casting to um signed tipo, o (bitwise) resultado is o mesmo as\n"
+"    // primeiro casting to o corresponding unsigned tipo. If o most significant\n"
+"    // bit of aquele valor is 1, then o valor is negative.\n"
+
+#: src/types/cast.md:53
+msgid "// Unless it already fits, of course.\n"
+msgstr ""
+"// Unless it already fits, of course.\n"
+
+#: src/types/cast.md:54
+msgid "\" 128 as a i16 is: {}\""
+msgstr "\" 128 as um i16 is: {}\""
+
+#: src/types/cast.md:56
+msgid ""
+"// In boundary case 128 value in 8-bit two's complement representation is "
+"-128\n"
+msgstr ""
+"// In boundary case 128 valor in 8-bit two's complement representation is -128\n"
+
+#: src/types/cast.md:57
+msgid "\" 128 as a i8 is : {}\""
+msgstr "\" 128 as um i8 is : {}\""
+
+#: src/types/cast.md:59
+msgid ""
+"// repeating the example above\n"
+"    // 1000 as u8 -> 232\n"
+msgstr ""
+"// repeating o example acima\n"
+"    // 1000 as u8 -> 232\n"
+
+#: src/types/cast.md:62
+msgid ""
+"// and the value of 232 in 8-bit two's complement representation is -24\n"
+msgstr ""
+"// e o valor of 232 in 8-bit two's complement representation is -24\n"
+
+#: src/types/cast.md:63
+msgid "\" 232 as a i8 is : {}\""
+msgstr "\" 232 as um i8 is : {}\""
+
+#: src/types/cast.md:65
+msgid ""
+"// Since Rust 1.45, the `as` keyword performs a *saturating cast*\n"
+"    // when casting from float to int. If the floating point value exceeds\n"
+"    // the upper bound or is less than the lower bound, the returned value\n"
+"    // will be equal to the bound crossed.\n"
+msgstr ""
+"// Since Rust 1.45, o `as` keyword performs um *saturating cast*\n"
+"    // when casting de float to int. If o floating point valor exceeds\n"
+"    // o upper bound ou is less than o lower bound, o retornado valor\n"
+"    // vai be equal to o bound crossed.\n"
+
+#: src/types/cast.md:70
+msgid "// 300.0 as u8 is 255\n"
+msgstr ""
+"// 300.0 as u8 is 255\n"
+
+#: src/types/cast.md:71 src/types/cast.md:82
+msgid "\" 300.0 as u8 is : {}\""
+msgstr "\" 300.0 as u8 is : {}\""
+
+#: src/types/cast.md:72
+msgid "// -100.0 as u8 is 0\n"
+msgstr ""
+"// -100.0 as u8 is 0\n"
+
+#: src/types/cast.md:73 src/types/cast.md:84
+msgid "\"-100.0 as u8 is : {}\""
+msgstr "\"-100.0 as u8 is : {}\""
+
+#: src/types/cast.md:74 src/types/cast.md:85
+msgid "// nan as u8 is 0\n"
+msgstr ""
+"// nan as u8 is 0\n"
+
+#: src/types/cast.md:75 src/types/cast.md:86
+msgid "\"   nan as u8 is : {}\""
+msgstr "\"   nan as u8 is : {}\""
+
+#: src/types/cast.md:77
+msgid ""
+"// This behavior incurs a small runtime cost and can be avoided\n"
+"    // with unsafe methods, however the results might overflow and\n"
+"    // return **unsound values**. Use these methods wisely:\n"
+msgstr ""
+"// Este behavior incurs um small runtime cost e pode be avoided\n"
+"    // com unsafe métodos, however o resultados might overflow e\n"
+"    // retorna **unsound valores**. Usa estes métodos wisely:\n"
+
+#: src/types/cast.md:81
+msgid "// 300.0 as u8 is 44\n"
+msgstr ""
+"// 300.0 as u8 is 44\n"
+
+#: src/types/cast.md:83
+msgid "// -100.0 as u8 is 156\n"
+msgstr ""
+"// -100.0 as u8 is 156\n"
+
+#: src/types/literals.md:3
+msgid ""
+"Numeric literals can be type annotated by adding the type as a suffix. As an "
+"example, to specify that the literal `42` should have the type `i32`, write "
+"`42i32`."
+msgstr "Numeric literals pode be tipo annotated by adding o tipo as um suffix. As um example, to specify aquele o literal `42` deve have o tipo `i32`, write `42i32`."
+
+#: src/types/literals.md:6
+msgid ""
+"The type of unsuffixed numeric literals will depend on how they are used. If "
+"no constraint exists, the compiler will use `i32` for integers, and `f64` "
+"for floating-point numbers."
+msgstr "O tipo of unsuffixed numeric literals vai depend on how they are usado. If no constraint exists, o compiler vai use `i32` para inteiros, e `f64` para floating-point números."
+
+#: src/types/literals.md:12
+msgid "// Suffixed literals, their types are known at initialization\n"
+msgstr ""
+"// Suffixed literals, their tipos are known at initialization\n"
+
+#: src/types/literals.md:17
+msgid "// Unsuffixed literals, their types depend on how they are used\n"
+msgstr ""
+"// Unsuffixed literals, their tipos depend on how they are usado\n"
+
+#: src/types/literals.md:21
+msgid "// `size_of_val` returns the size of a variable in bytes\n"
+msgstr ""
+"// `size_of_val` retorna o size of uma variável in bytes\n"
+
+#: src/types/literals.md:22
+msgid "\"size of `x` in bytes: {}\""
+msgstr "\"size of `x` in bytes: {}\""
+
+#: src/types/literals.md:23
+msgid "\"size of `y` in bytes: {}\""
+msgstr "\"size of `y` in bytes: {}\""
+
+#: src/types/literals.md:24
+msgid "\"size of `z` in bytes: {}\""
+msgstr "\"size of `z` in bytes: {}\""
+
+#: src/types/literals.md:25
+msgid "\"size of `i` in bytes: {}\""
+msgstr "\"size of `i` in bytes: {}\""
+
+#: src/types/literals.md:26
+msgid "\"size of `f` in bytes: {}\""
+msgstr "\"size of `f` in bytes: {}\""
+
+#: src/types/literals.md:30
+msgid ""
+"There are some concepts used in the previous code that haven't been "
+"explained yet, here's a brief explanation for the impatient readers:"
+msgstr "There are some concepts usado in o anterior code aquele haven't been explained yet, here's um brief explanation para o impatient readers:"
+
+#: src/types/literals.md:33
+msgid ""
+"`std::mem::size_of_val` is a function, but called with its _full path_. Code "
+"can be split in logical units called _modules_. In this case, the "
+"`size_of_val` function is defined in the `mem` module, and the `mem` module "
+"is defined in the `std` _crate_. For more details, see [modules](../mod.md) "
+"and [crates](../crates.md)."
+msgstr "`std::mem::size_of_val` is um função, but chamado com its _full path_. Code pode be split in logical units chamado _modules_. In este case, o `size_of_val` função is defined in o `mem` módulo, e o `mem` módulo is defined in o `std` _crate_. Para more details, see [modules](../mod.md) e [crates](../crates.md)."
+
+#: src/types/inference.md:3
+msgid ""
+"The type inference engine is pretty smart. It does more than looking at the "
+"type of the value expression during an initialization. It also looks at how "
+"the variable is used afterwards to infer its type. Here's an advanced "
+"example of type inference:"
+msgstr "O tipo inference engine is pretty smart. It does more than looking at o tipo of o valor expression during um initialization. It also looks at how o variável is usado afterwards to infer its tipo. Here's um advanced example of tipo inference:"
+
+#: src/types/inference.md:10
+msgid ""
+"// Because of the annotation, the compiler knows that `elem` has type u8.\n"
+msgstr ""
+"// Porque of o anotação, o compiler knows aquele `elem` has tipo u8.\n"
+
+#: src/types/inference.md:13
+msgid "// Create an empty vector (a growable array).\n"
+msgstr ""
+"// Cria um vazio vector (um growable array).\n"
+
+#: src/types/inference.md:15
+msgid ""
+"// At this point the compiler doesn't know the exact type of `vec`, it\n"
+"    // just knows that it's a vector of something (`Vec<_>`).\n"
+msgstr ""
+"// At este point o compiler doesn't know o exact tipo of `vec`, it\n"
+"    // just knows aquele it's um vector of something (`Vec<_>`).\n"
+
+#: src/types/inference.md:18
+msgid "// Insert `elem` in the vector.\n"
+msgstr ""
+"// Insert `elem` in o vector.\n"
+
+#: src/types/inference.md:20
+msgid ""
+"// Aha! Now the compiler knows that `vec` is a vector of `u8`s (`Vec<u8>`)\n"
+"    // TODO ^ Try commenting out the `vec.push(elem)` line\n"
+msgstr ""
+"// Aha! Now o compiler knows aquele `vec` is um vector of `u8`s (`Vec<u8>`)\n"
+"    // TODO ^ Tente commenting out o `vec.push(elem)` line\n"
+
+#: src/types/inference.md:27
+msgid ""
+"No type annotation of variables was needed, the compiler is happy and so is "
+"the programmer!"
+msgstr "No tipo anotação of variáveis was needed, o compiler is happy e so is o programmer!"
+
+#: src/types/alias.md:3
+msgid ""
+"The `type` statement can be used to give a new name to an existing type. "
+"Types must have `UpperCamelCase` names, or the compiler will raise a "
+"warning. The exception to this rule are the primitive types: `usize`, `f32`, "
+"etc."
+msgstr "O `type` statement pode be usado to give um novo name to um existing tipo. Tipos deve have `UpperCamelCase` names, ou o compiler vai raise um warning. O exception to este rule are o primitive tipos: `usize`, `f32`, etc."
+
+#: src/types/alias.md:8
+msgid "// `NanoSecond`, `Inch`, and `U64` are new names for `u64`.\n"
+msgstr ""
+"// `NanoSecond`, `Inch`, e `U64` are novo names para `u64`.\n"
+
+#: src/types/alias.md:14
+msgid "// `NanoSecond` = `Inch` = `U64` = `u64`.\n"
+msgstr ""
+"// `NanoSecond` = `Inch` = `U64` = `u64`.\n"
+
+#: src/types/alias.md:18
+msgid ""
+"// Note that type aliases *don't* provide any extra type safety, because\n"
+"    // aliases are *not* new types\n"
+msgstr ""
+"// Note aquele tipo aliases *don't* provide any extra tipo safety, porque\n"
+"    // aliases are *not* novo tipos\n"
+
+#: src/types/alias.md:20
+msgid "\"{} nanoseconds + {} inches = {} unit?\""
+msgstr "\"{} nanoseconds + {} inches = {} unit?\""
+
+#: src/types/alias.md:27
+msgid ""
+"The main use of aliases is to reduce boilerplate; for example the `io::"
+"Result<T>` type is an alias for the `Result<T, io::Error>` type."
+msgstr "O main use of aliases is to reduce boilerplate; para example o `io::Result<T>` tipo is um alias para o `Result<T, io::Error>` tipo."
+
+#: src/types/alias.md:32
+msgid "[Attributes](../attribute.md)"
+msgstr "[Attributes](../attribute.md)"
+
+#: src/conversion.md:3
+msgid ""
+"Primitive types can be converted to each other through [casting](types/cast."
+"md)."
+msgstr "Primitive tipos pode be converted to each other through [casting](types/cast.md)."
+
+#: src/conversion.md:5
+msgid ""
+"Rust addresses conversion between custom types (i.e., `struct` and `enum`) "
+"by the use of [traits](trait.md). The generic conversions will use the "
+"[`From`](https://doc.rust-lang.org/std/convert/trait.From.html) and [`Into`]"
+"(https://doc.rust-lang.org/std/convert/trait.Into.html) traits. However "
+"there are more specific ones for the more common cases, in particular when "
+"converting to and from `String`s."
+msgstr "Rust addresses conversion between custom tipos (i.e., `struct` e `enum`) by o use of [traits](trait.md). O generic conversions vai use o [`From`](https://doc.rust-lang.org/std/convert/trait.From.html) e [`Into`](https://doc.rust-lang.org/std/convert/trait.Into.html) traits. However there are more specific ones para o more common cases, in particular when converting to e de `String`s."
+
+#: src/conversion/from_into.md:3
+msgid ""
+"The [`From`](https://doc.rust-lang.org/std/convert/trait.From.html) and "
+"[`Into`](https://doc.rust-lang.org/std/convert/trait.Into.html) traits are "
+"inherently linked, and this is actually part of its implementation. If you "
+"are able to convert type A from type B, then it should be easy to believe "
+"that we should be able to convert type B to type A."
+msgstr "O [`From`](https://doc.rust-lang.org/std/convert/trait.From.html) e [`Into`](https://doc.rust-lang.org/std/convert/trait.Into.html) traits are inherently linked, e este is actually part of its implementation. If you are able to convert tipo UM de tipo B, then it deve be easy to believe aquele we deve be able to convert tipo B to tipo UM."
+
+#: src/conversion/from_into.md:7
+msgid "`From`"
+msgstr "`From`"
+
+#: src/conversion/from_into.md:9
+msgid ""
+"The [`From`](https://doc.rust-lang.org/std/convert/trait.From.html) trait "
+"allows for a type to define how to create itself from another type, hence "
+"providing a very simple mechanism for converting between several types. "
+"There are numerous implementations of this trait within the standard library "
+"for conversion of primitive and common types."
+msgstr "O [`From`](https://doc.rust-lang.org/std/convert/trait.From.html) trait allows para um tipo to define how to create itself de another tipo, hence providing um very simple mechanism para converting between several tipos. There are numerous implementations of este trait within o standard library para conversion of primitive e common tipos."
+
+#: src/conversion/from_into.md:14
+msgid "For example we can easily convert a `str` into a `String`"
+msgstr "Para example we pode easily convert um `str` em um `String`"
+
+#: src/conversion/from_into.md:21
+msgid "We can do something similar for defining a conversion for our own type."
+msgstr "We pode do something similar para defining um conversion para our own tipo."
+
+#: src/conversion/from_into.md:39 src/conversion/from_into.md:68
+#: src/conversion/from_into.md:98
+msgid "\"My number is {:?}\""
+msgstr "\"My número is {:?}\""
+
+#: src/conversion/from_into.md:43
+msgid "`Into`"
+msgstr "`Into`"
+
+#: src/conversion/from_into.md:45
+msgid ""
+"The [`Into`](https://doc.rust-lang.org/std/convert/trait.Into.html) trait is "
+"simply the reciprocal of the `From` trait. It defines how to convert a type "
+"into another type."
+msgstr "O [`Into`](https://doc.rust-lang.org/std/convert/trait.Into.html) trait is simply o reciprocal of o `From` trait. It defines how to convert um tipo em another tipo."
+
+#: src/conversion/from_into.md:48
+msgid ""
+"Calling `into()` typically requires us to specify the result type as the "
+"compiler is unable to determine this most of the time."
+msgstr "Chamaing `into()` typically requires us to specify o resultado tipo as o compiler is unable to determine este most of o time."
+
+#: src/conversion/from_into.md:66
+msgid "// Try removing the type annotation\n"
+msgstr ""
+"// Tente removing o tipo anotação\n"
+
+#: src/conversion/from_into.md:72
+msgid "`From` and `Into` are interchangeable"
+msgstr "`From` e `Into` are interchangeable"
+
+#: src/conversion/from_into.md:74
+msgid ""
+"`From` and `Into` are designed to be complementary. We do not need to "
+"provide an implementation for both traits. If you have implemented the "
+"`From` trait for your type, `Into` will call it when necessary. Note, "
+"however, that the converse is not true: implementing `Into` for your type "
+"will not automatically provide it with an implementation of `From`."
+msgstr "`From` e `Into` are designed to be complementary. We do not need to provide um implementation para both traits. If you have implemented o `From` trait para your tipo, `Into` vai call it when necessary. Note, however, aquele o converse is not true: implementing `Into` para your tipo vai not automatically provide it com um implementation of `From`."
+
+#: src/conversion/from_into.md:86
+msgid "// Define `From`\n"
+msgstr ""
+"// Define `From`\n"
+
+#: src/conversion/from_into.md:96
+msgid "// use `Into`\n"
+msgstr ""
+"// use `Into`\n"
+
+#: src/conversion/try_from_try_into.md:3
+msgid ""
+"Similar to [`From` and `Into`](from_into.html), [`TryFrom`](https://doc.rust-"
+"lang.org/std/convert/trait.TryFrom.html) and [`TryInto`](https://doc.rust-"
+"lang.org/std/convert/trait.TryInto.html) are generic traits for converting "
+"between types. Unlike `From`/`Into`, the `TryFrom`/`TryInto` traits are used "
+"for fallible conversions, and as such, return [`Result`](https://doc.rust-"
+"lang.org/std/result/enum.Result.html)s."
+msgstr "Similar to [`From` and `Into`](from_into.html), [`TryFrom`](https://doc.rust-lang.org/std/convert/trait.TryFrom.html) e [`TryInto`](https://doc.rust-lang.org/std/convert/trait.TryInto.html) are generic traits para converting between tipos. Unlike `From`/`Into`, o `TryFrom`/`TryInto` traits are usado para fallible conversions, e as such, retorna [`Result`](https://doc.rust-lang.org/std/result/enum.Result.html)s."
+
+#: src/conversion/try_from_try_into.md:33
+msgid "// TryFrom\n"
+msgstr ""
+"// TenteFrom\n"
+
+#: src/conversion/try_from_try_into.md:38
+msgid "// TryInto\n"
+msgstr ""
+"// TenteInto\n"
+
+#: src/conversion/string.md:1
+msgid "To and from Strings"
+msgstr "To e de Strings"
+
+#: src/conversion/string.md:3
+msgid "Converting to String"
+msgstr "Converting to String"
+
+#: src/conversion/string.md:5
+msgid ""
+"To convert any type to a `String` is as simple as implementing the "
+"[`ToString`](https://doc.rust-lang.org/std/string/trait.ToString.html) trait "
+"for the type. Rather than doing so directly, you should implement the [`fmt::"
+"Display`](https://doc.rust-lang.org/std/fmt/trait.Display.html) trait which "
+"automatically provides [`ToString`](https://doc.rust-lang.org/std/string/"
+"trait.ToString.html) and also allows printing the type as discussed in the "
+"section on [`print!`](../hello/print.md)."
+msgstr "To convert any tipo to um `String` is as simple as implementing o [`ToString`](https://doc.rust-lang.org/std/string/trait.ToString.html) trait para o tipo. Rather than doing so directly, you deve implement o [`fmt::Display`](https://doc.rust-lang.org/std/fmt/trait.Display.html) trait which automatically provides [`ToString`](https://doc.rust-lang.org/std/string/trait.ToString.html) e also allows printing o tipo as discussed in o section on [`print!`](../hello/print.md)."
+
+#: src/conversion/string.md:19
+msgid "\"Circle of radius {}\""
+msgstr "\"Circle of radius {}\""
+
+#: src/conversion/string.md:29
+msgid "Parsing a String"
+msgstr "Parsing um String"
+
+#: src/conversion/string.md:31
+msgid ""
+"It's useful to convert strings into many types, but one of the more common "
+"string operations is to convert them from string to number. The idiomatic "
+"approach to this is to use the [`parse`](https://doc.rust-lang.org/std/"
+"primitive.str.html#method.parse) function and either to arrange for type "
+"inference or to specify the type to parse using the 'turbofish' syntax. Both "
+"alternatives are shown in the following example."
+msgstr "It's useful to convert strings em many tipos, but one of o more common string operations is to convert them de string to número. O idiomatic approach to este is to use o [`parse`](https://doc.rust-lang.org/std/primitive.str.html#method.parse) função e either to arrange para tipo inference ou to specify o tipo to parse usando o 'turbofish' syntax. Both alternatives are shown in o following example."
+
+#: src/conversion/string.md:37
+msgid ""
+"This will convert the string into the type specified as long as the "
+"[`FromStr`](https://doc.rust-lang.org/std/str/trait.FromStr.html) trait is "
+"implemented for that type. This is implemented for numerous types within the "
+"standard library."
+msgstr "Este vai convert o string no tipo specified as long as o [`FromStr`](https://doc.rust-lang.org/std/str/trait.FromStr.html) trait is implemented para aquele tipo. Este is implemented para numerous tipos within o standard library."
+
+#: src/conversion/string.md:43 src/std_misc/process/wait.md:10
+msgid "\"5\""
+msgstr "\"5\""
+
+#: src/conversion/string.md:44 src/error/result.md:33 src/error/result.md:68
+#: src/error/result/result_map.md:42 src/error/result/result_map.md:75
+#: src/error/result/result_alias.md:36 src/error/result/early_returns.md:36
+#: src/error/result/enter_question_mark.md:34
+#: src/error/result/enter_question_mark.md:67
+msgid "\"10\""
+msgstr "\"10\""
+
+#: src/conversion/string.md:47
+msgid "\"Sum: {:?}\""
+msgstr "\"Sum: {:?}\""
+
+#: src/conversion/string.md:51
+msgid ""
+"To obtain this functionality on a user defined type simply implement the "
+"[`FromStr`](https://doc.rust-lang.org/std/str/trait.FromStr.html) trait for "
+"that type."
+msgstr "To obtain este functionality on um user defined tipo simply implement o [`FromStr`](https://doc.rust-lang.org/std/str/trait.FromStr.html) trait para aquele tipo."
+
+#: src/conversion/string.md:74
+msgid "\"    3 \""
+msgstr "\"    3 \""
+
+#: src/expression.md:3
+msgid "A Rust program is (mostly) made up of a series of statements:"
+msgstr "UM Rust program is (mostly) made up of um series of statements:"
+
+#: src/expression.md:7
+msgid ""
+"// statement\n"
+"    // statement\n"
+"    // statement\n"
+msgstr ""
+"// statement\n"
+"    // statement\n"
+"    // statement\n"
+
+#: src/expression.md:13
+msgid ""
+"There are a few kinds of statements in Rust. The most common two are "
+"declaring a variable binding, and using a `;` with an expression:"
+msgstr "There are um few kinds of statements in Rust. O most common two are declaring uma variável binding, e usando um `;` com um expression:"
+
+#: src/expression.md:18
+msgid "// variable binding\n"
+msgstr ""
+"// variável binding\n"
+
+#: src/expression.md:21
+msgid "// expression;\n"
+msgstr ""
+"// expression;\n"
+
+#: src/expression.md:28
+msgid ""
+"Blocks are expressions too, so they can be used as values in assignments. "
+"The last expression in the block will be assigned to the place expression "
+"such as a local variable. However, if the last expression of the block ends "
+"with a semicolon, the return value will be `()`."
+msgstr "Blocks are expressions too, so they pode be usado as valores in assignments. O último expression in o block vai be assigned to o place expression such as um local variável. However, if o último expression of o block ends com um semicolon, o retorna valor vai be `()`."
+
+#: src/expression.md:41
+msgid "// This expression will be assigned to `y`\n"
+msgstr ""
+"// Este expression vai be assigned to `y`\n"
+
+#: src/expression.md:46
+msgid ""
+"// The semicolon suppresses this expression and `()` is assigned to `z`\n"
+msgstr ""
+"// O semicolon suppresses este expression e `()` is assigned to `z`\n"
+
+#: src/expression.md:50
+msgid "\"x is {:?}\""
+msgstr "\"x is {:?}\""
+
+#: src/expression.md:51
+msgid "\"y is {:?}\""
+msgstr "\"y is {:?}\""
+
+#: src/expression.md:52
+msgid "\"z is {:?}\""
+msgstr "\"z is {:?}\""
+
+#: src/flow_control.md:3
+msgid ""
+"An integral part of any programming language are ways to modify control "
+"flow: `if`/`else`, `for`, and others. Let's talk about them in Rust."
+msgstr "Um integral part of any programming language are ways to modify control flow: `if`/`else`, `for`, e others. Let's talk about them in Rust."
+
+#: src/flow_control/if_else.md:3
+msgid ""
+"Branching with `if`\\-`else` is similar to other languages. Unlike many of "
+"them, the boolean condition doesn't need to be surrounded by parentheses, "
+"and each condition is followed by a block. `if`\\-`else` conditionals are "
+"expressions, and, all branches must return the same type."
+msgstr "Branching com `if`\\-`else` is similar to other languages. Unlike many of them, o booleano condition doesn't need to be surrounded by parentheses, e each condition is followed by um block. `if`\\-`else` conditionals are expressions, e, all branches deve retorna o mesmo tipo."
+
+#: src/flow_control/if_else.md:13
+msgid "\"{} is negative\""
+msgstr "\"{} is negative\""
+
+#: src/flow_control/if_else.md:15
+msgid "\"{} is positive\""
+msgstr "\"{} is positive\""
+
+#: src/flow_control/if_else.md:17
+msgid "\"{} is zero\""
+msgstr "\"{} is zero\""
+
+#: src/flow_control/if_else.md:22
+msgid "\", and is a small number, increase ten-fold\""
+msgstr "\", e is um small número, increase ten-fold\""
+
+#: src/flow_control/if_else.md:24
+msgid "// This expression returns an `i32`.\n"
+msgstr ""
+"// Este expression retorna um `i32`.\n"
+
+#: src/flow_control/if_else.md:27
+msgid "\", and is a big number, halve the number\""
+msgstr "\", e is um big número, halve o número\""
+
+#: src/flow_control/if_else.md:29
+msgid "// This expression must return an `i32` as well.\n"
+msgstr ""
+"// Este expression deve retorna um `i32` as well.\n"
+
+#: src/flow_control/if_else.md:31
+msgid "// TODO ^ Try suppressing this expression with a semicolon.\n"
+msgstr ""
+"// TODO ^ Tente suppressing este expression com um semicolon.\n"
+
+#: src/flow_control/if_else.md:33
+msgid ""
+"//   ^ Don't forget to put a semicolon here! All `let` bindings need it.\n"
+msgstr ""
+"//   ^ Don't forget to put um semicolon here! All `let` bindings need it.\n"
+
+#: src/flow_control/if_else.md:35 src/flow_control/match.md:35
+msgid "\"{} -> {}\""
+msgstr "\"{} -> {}\""
+
+#: src/flow_control/loop.md:3
+msgid "Rust provides a `loop` keyword to indicate an infinite loop."
+msgstr "Rust provides um `loop` keyword to indicate um infinite loop."
+
+#: src/flow_control/loop.md:5
+msgid ""
+"The `break` statement can be used to exit a loop at anytime, whereas the "
+"`continue` statement can be used to skip the rest of the iteration and start "
+"a new one."
+msgstr "O `break` statement pode be usado to exit um loop at anytime, whereas o `continue` statement pode be usado to skip o rest of o iteration e start um novo one."
+
+#: src/flow_control/loop.md:13
+msgid "\"Let's count until infinity!\""
+msgstr "\"Let's count until infinity!\""
+
+#: src/flow_control/loop.md:15
+msgid "// Infinite loop\n"
+msgstr ""
+"// Infinite loop\n"
+
+#: src/flow_control/loop.md:20
+msgid "\"three\""
+msgstr "\"three\""
+
+#: src/flow_control/loop.md:22
+msgid "// Skip the rest of this iteration\n"
+msgstr ""
+"// Skip o rest of este iteration\n"
+
+#: src/flow_control/loop.md:29
+msgid "\"OK, that's enough\""
+msgstr "\"OK, aquele's enough\""
+
+#: src/flow_control/loop.md:31
+msgid "// Exit this loop\n"
+msgstr ""
+"// Exit este loop\n"
+
+#: src/flow_control/loop/nested.md:3
+msgid ""
+"It's possible to `break` or `continue` outer loops when dealing with nested "
+"loops. In these cases, the loops must be annotated with some `'label`, and "
+"the label must be passed to the `break`/`continue` statement."
+msgstr "It's possible to `break` ou `continue` outer loops when dealing com nested loops. In estes cases, o loops deve be annotated com some `'label`, e o label deve be passed to o `break`/`continue` statement."
+
+#: src/flow_control/loop/nested.md:12
+msgid "\"Entered the outer loop\""
+msgstr "\"Entered o outer loop\""
+
+#: src/flow_control/loop/nested.md:15
+msgid "\"Entered the inner loop\""
+msgstr "\"Entered o inner loop\""
+
+#: src/flow_control/loop/nested.md:17
+msgid ""
+"// This would break only the inner loop\n"
+"            //break;\n"
+msgstr ""
+"// Este would break only o inner loop\n"
+"            //break;\n"
+
+#: src/flow_control/loop/nested.md:20
+msgid "// This breaks the outer loop\n"
+msgstr ""
+"// Este breaks o outer loop\n"
+
+#: src/flow_control/loop/nested.md:24
+msgid "\"This point will never be reached\""
+msgstr "\"Este point vai never be reached\""
+
+#: src/flow_control/loop/nested.md:27
+msgid "\"Exited the outer loop\""
+msgstr "\"Exited o outer loop\""
+
+#: src/flow_control/loop/return.md:3
+msgid ""
+"One of the uses of a `loop` is to retry an operation until it succeeds. If "
+"the operation returns a value though, you might need to pass it to the rest "
+"of the code: put it after the `break`, and it will be returned by the `loop` "
+"expression."
+msgstr "One of o uses of um `loop` is to retry um operation until it succeeds. If o operation retorna um valor though, you might need to pass it to o rest of o code: put it after o `break`, e it vai be retornado by o `loop` expression."
+
+#: src/flow_control/while.md:3
+msgid ""
+"The `while` keyword can be used to run a loop while a condition is true."
+msgstr "O `while` keyword pode be usado to run um loop while um condition is true."
+
+#: src/flow_control/while.md:5
+msgid ""
+"Let's write the infamous [FizzBuzz](https://en.wikipedia.org/wiki/Fizz_buzz) "
+"using a `while` loop."
+msgstr "Let's write o infamous [FizzBuzz](https://en.wikipedia.org/wiki/Fizz_buzz) usando um `while` loop."
+
+#: src/flow_control/while.md:9
+msgid "// A counter variable\n"
+msgstr ""
+"// UM counter variável\n"
+
+#: src/flow_control/while.md:12
+msgid "// Loop while `n` is less than 101\n"
+msgstr ""
+"// Loop while `n` is less than 101\n"
+
+#: src/flow_control/while.md:15 src/flow_control/for.md:17
+#: src/flow_control/for.md:37 src/fn.md:34
+msgid "\"fizzbuzz\""
+msgstr "\"fizzbuzz\""
+
+#: src/flow_control/while.md:17 src/flow_control/for.md:19
+#: src/flow_control/for.md:39 src/fn.md:36
+msgid "\"fizz\""
+msgstr "\"fizz\""
+
+#: src/flow_control/while.md:19 src/flow_control/for.md:21
+#: src/flow_control/for.md:41 src/fn.md:38
+msgid "\"buzz\""
+msgstr "\"buzz\""
+
+#: src/flow_control/while.md:24
+msgid "// Increment counter\n"
+msgstr ""
+"// Increment counter\n"
+
+#: src/flow_control/for.md:1
+msgid "for loops"
+msgstr "para loops"
+
+#: src/flow_control/for.md:5
+msgid ""
+"The `for in` construct can be used to iterate through an `Iterator`. One of "
+"the easiest ways to create an iterator is to use the range notation `a..b`. "
+"This yields values from `a` (inclusive) to `b` (exclusive) in steps of one."
+msgstr "O `for in` construct pode be usado to iterate through um `Iterator`. One of o easiest ways to create um iterator is to use o range notation `a..b`. Este yields valores de `a` (inclusive) to `b` (exclusive) in steps of one."
+
+#: src/flow_control/for.md:10
+msgid "Let's write FizzBuzz using `for` instead of `while`."
+msgstr "Let's write FizzBuzz usando `for` instead of `while`."
+
+#: src/flow_control/for.md:14 src/flow_control/for.md:34
+msgid "// `n` will take the values: 1, 2, ..., 100 in each iteration\n"
+msgstr ""
+"// `n` vai take o valores: 1, 2, ..., 100 in each iteration\n"
+
+#: src/flow_control/for.md:29
+msgid ""
+"Alternatively, `a..=b` can be used for a range that is inclusive on both "
+"ends. The above can be written as:"
+msgstr "Alternatively, `a..=b` pode be usado para um range aquele is inclusive on both ends. O acima pode be written as:"
+
+#: src/flow_control/for.md:49
+msgid "for and iterators"
+msgstr "para e iterators"
+
+#: src/flow_control/for.md:51
+msgid ""
+"The `for in` construct is able to interact with an `Iterator` in several "
+"ways. As discussed in the section on the [Iterator](../trait/iter.md) trait, "
+"by default the `for` loop will apply the `into_iter` function to the "
+"collection. However, this is not the only means of converting collections "
+"into iterators."
+msgstr "O `for in` construct is able to interact com um `Iterator` in several ways. As discussed in o section on o [Iterator](../trait/iter.md) trait, by default o `for` loop vai apply o `into_iter` função to o collection. However, este is not o only means of converting collections em iterators."
+
+#: src/flow_control/for.md:56
+msgid ""
+"`into_iter`, `iter` and `iter_mut` all handle the conversion of a collection "
+"into an iterator in different ways, by providing different views on the data "
+"within."
+msgstr "`into_iter`, `iter` e `iter_mut` all handle o conversion of um collection em um iterator in diferente ways, by providing diferente views on o data within."
+
+#: src/flow_control/for.md:60
+msgid ""
+"`iter` - This borrows each element of the collection through each iteration. "
+"Thus leaving the collection untouched and available for reuse after the loop."
+msgstr "`iter` - Este empréstimos each element of o collection through each iteration. Thus leaving o collection untouched e available para reuse after o loop."
+
+#: src/flow_control/for.md:65 src/flow_control/for.md:85
+#: src/flow_control/for.md:104
+msgid "\"Frank\""
+msgstr "\"Frank\""
+
+#: src/flow_control/for.md:65 src/flow_control/for.md:69
+#: src/flow_control/for.md:85 src/flow_control/for.md:89
+#: src/flow_control/for.md:104 src/flow_control/for.md:108
+msgid "\"Ferris\""
+msgstr "\"Ferris\""
+
+#: src/flow_control/for.md:69 src/flow_control/for.md:89
+#: src/flow_control/for.md:108
+msgid "\"There is a rustacean among us!\""
+msgstr "\"There is um rustacean among us!\""
+
+#: src/flow_control/for.md:70
+msgid "// TODO ^ Try deleting the & and matching just \"Ferris\"\n"
+msgstr ""
+"// TODO ^ Tente deleting o & e matching just \"Ferris\"\n"
+
+#: src/flow_control/for.md:71 src/flow_control/for.md:90
+msgid "\"Hello {}\""
+msgstr "\"Hello {}\""
+
+#: src/flow_control/for.md:75 src/flow_control/for.md:94
+#: src/flow_control/for.md:113
+msgid "\"names: {:?}\""
+msgstr "\"names: {:?}\""
+
+#: src/flow_control/for.md:79
+msgid ""
+"`into_iter` - This consumes the collection so that on each iteration the "
+"exact data is provided. Once the collection has been consumed it is no "
+"longer available for reuse as it has been 'moved' within the loop."
+msgstr "`into_iter` - Este consumes o collection so aquele on each iteration o exact data is provided. Once o collection has been consumed it is no longer available para reuse as it has been 'moved' within o loop."
+
+#: src/flow_control/for.md:99
+msgid ""
+"`iter_mut` - This mutably borrows each element of the collection, allowing "
+"for the collection to be modified in place."
+msgstr "`iter_mut` - Este mutably empréstimos each element of o collection, allowing para o collection to be modified in place."
+
+#: src/flow_control/for.md:109
+msgid "\"Hello\""
+msgstr "\"Hello\""
+
+#: src/flow_control/for.md:117
+msgid ""
+"In the above snippets note the type of `match` branch, that is the key "
+"difference in the types of iteration. The difference in type then of course "
+"implies differing actions that are able to be performed."
+msgstr "In o acima snippets note o tipo of `match` branch, aquele is o key difference in o tipos of iteration. O difference in tipo then of course implies differing actions aquele are able to be performed."
+
+#: src/flow_control/for.md:123
+msgid "[Iterator](../trait/iter.md)"
+msgstr "[Iterator](../trait/iter.md)"
+
+#: src/flow_control/match.md:3
+msgid ""
+"Rust provides pattern matching via the `match` keyword, which can be used "
+"like a C `switch`. The first matching arm is evaluated and all possible "
+"values must be covered."
+msgstr "Rust provides pattern matching via o `match` keyword, which pode be usado like um C `switch`. O primeiro matching arm is evaluated e all possible valores deve be covered."
+
+#: src/flow_control/match.md:10
+msgid "// TODO ^ Try different values for `number`\n"
+msgstr ""
+"// TODO ^ Tente diferente valores para `number`\n"
+
+#: src/flow_control/match.md:12
+msgid "\"Tell me about {}\""
+msgstr "\"Tell me about {}\""
+
+#: src/flow_control/match.md:14
+msgid "// Match a single value\n"
+msgstr ""
+"// Match um single valor\n"
+
+#: src/flow_control/match.md:15
+msgid "\"One!\""
+msgstr "\"One!\""
+
+#: src/flow_control/match.md:16
+msgid "// Match several values\n"
+msgstr ""
+"// Match several valores\n"
+
+#: src/flow_control/match.md:17
+msgid "\"This is a prime\""
+msgstr "\"Este is um prime\""
+
+#: src/flow_control/match.md:18
+msgid ""
+"// TODO ^ Try adding 13 to the list of prime values\n"
+"        // Match an inclusive range\n"
+msgstr ""
+"// TODO ^ Tente adding 13 to o list of prime valores\n"
+"        // Match um inclusive range\n"
+
+#: src/flow_control/match.md:20
+msgid "\"A teen\""
+msgstr "\"UM teen\""
+
+#: src/flow_control/match.md:21
+msgid "// Handle the rest of cases\n"
+msgstr ""
+"// Handle o rest of cases\n"
+
+#: src/flow_control/match.md:22
+msgid "\"Ain't special\""
+msgstr "\"Ain't special\""
+
+#: src/flow_control/match.md:23
+msgid "// TODO ^ Try commenting out this catch-all arm\n"
+msgstr ""
+"// TODO ^ Tente commenting out este catch-all arm\n"
+
+#: src/flow_control/match.md:27
+msgid "// Match is an expression too\n"
+msgstr ""
+"// Match is um expression too\n"
+
+#: src/flow_control/match.md:29
+msgid "// The arms of a match must cover all the possible values\n"
+msgstr ""
+"// O arms of um match deve cover all o possible valores\n"
+
+#: src/flow_control/match.md:32
+msgid "// TODO ^ Try commenting out one of these arms\n"
+msgstr ""
+"// TODO ^ Tente commenting out one of estes arms\n"
+
+#: src/flow_control/match/destructuring.md:3
+msgid "A `match` block can destructure items in a variety of ways."
+msgstr "UM `match` block pode destructure items in um variety of ways."
+
+#: src/flow_control/match/destructuring.md:5
+msgid "[Destructuring Tuples](destructuring/destructure_tuple.md)"
+msgstr "[Destructuring Tuples](destructuring/destructure_tuple.md)"
+
+#: src/flow_control/match/destructuring.md:6
+msgid "[Destructuring Arrays and Slices](destructuring/destructure_slice.md)"
+msgstr "[Destructuring Arrays and Slices](destructuring/destructure_slice.md)"
+
+#: src/flow_control/match/destructuring.md:7
+msgid "[Destructuring Enums](destructuring/destructure_enum.md)"
+msgstr "[Destructuring Enums](destructuring/destructure_enum.md)"
+
+#: src/flow_control/match/destructuring.md:8
+msgid "[Destructuring Pointers](destructuring/destructure_pointers.md)"
+msgstr "[Destructuring Pointers](destructuring/destructure_pointers.md)"
+
+#: src/flow_control/match/destructuring.md:9
+msgid "[Destructuring Structures](destructuring/destructure_structures.md)"
+msgstr "[Destructuring Structures](destructuring/destructure_structures.md)"
+
+#: src/flow_control/match/destructuring/destructure_tuple.md:3
+msgid "Tuples can be destructured in a `match` as follows:"
+msgstr "Tuples pode be destructured in um `match` as follows:"
+
+#: src/flow_control/match/destructuring/destructure_tuple.md:8
+msgid "// TODO ^ Try different values for `triple`\n"
+msgstr ""
+"// TODO ^ Tente diferente valores para `triple`\n"
+
+#: src/flow_control/match/destructuring/destructure_tuple.md:10
+msgid "\"Tell me about {:?}\""
+msgstr "\"Tell me about {:?}\""
+
+#: src/flow_control/match/destructuring/destructure_tuple.md:11
+msgid "// Match can be used to destructure a tuple\n"
+msgstr ""
+"// Match pode be usado to destructure um tuple\n"
+
+#: src/flow_control/match/destructuring/destructure_tuple.md:13
+msgid "// Destructure the second and third elements\n"
+msgstr ""
+"// Destructure o segundo e third elements\n"
+
+#: src/flow_control/match/destructuring/destructure_tuple.md:14
+msgid "\"First is `0`, `y` is {:?}, and `z` is {:?}\""
+msgstr "\"Primeiro is `0`, `y` is {:?}, e `z` is {:?}\""
+
+#: src/flow_control/match/destructuring/destructure_tuple.md:15
+msgid "\"First is `1` and the rest doesn't matter\""
+msgstr "\"Primeiro is `1` e o rest doesn't matter\""
+
+#: src/flow_control/match/destructuring/destructure_tuple.md:16
+msgid "\"last is `2` and the rest doesn't matter\""
+msgstr "\"último is `2` e o rest doesn't matter\""
+
+#: src/flow_control/match/destructuring/destructure_tuple.md:17
+msgid "\"First is `3`, last is `4`, and the rest doesn't matter\""
+msgstr "\"Primeiro is `3`, último is `4`, e o rest doesn't matter\""
+
+#: src/flow_control/match/destructuring/destructure_tuple.md:18
+msgid "// `..` can be used to ignore the rest of the tuple\n"
+msgstr ""
+"// `..` pode be usado to ignore o rest of o tuple\n"
+
+#: src/flow_control/match/destructuring/destructure_tuple.md:19
+msgid "\"It doesn't matter what they are\""
+msgstr "\"It doesn't matter what they are\""
+
+#: src/flow_control/match/destructuring/destructure_tuple.md:20
+msgid "// `_` means don't bind the value to a variable\n"
+msgstr ""
+"// `_` means don't bind o valor to uma variável\n"
+
+#: src/flow_control/match/destructuring/destructure_tuple.md:27
+msgid "[Tuples](../../../primitives/tuples.md)"
+msgstr "[Tuples](../../../primitives/tuples.md)"
+
+#: src/flow_control/match/destructuring/destructure_slice.md:3
+msgid "Like tuples, arrays and slices can be destructured this way:"
+msgstr "Like tuples, arrays e slices pode be destructured este way:"
+
+#: src/flow_control/match/destructuring/destructure_slice.md:7
+msgid "// Try changing the values in the array, or make it a slice!\n"
+msgstr ""
+"// Tente changing o valores in o array, ou make it um slice!\n"
+
+#: src/flow_control/match/destructuring/destructure_slice.md:11
+msgid ""
+"// Binds the second and the third elements to the respective variables\n"
+msgstr ""
+"// Binds o segundo e o third elements to o respective variáveis\n"
+
+#: src/flow_control/match/destructuring/destructure_slice.md:13
+msgid "\"array[0] = 0, array[1] = {}, array[2] = {}\""
+msgstr "\"array[0] = 0, array[1] = {}, array[2] = {}\""
+
+#: src/flow_control/match/destructuring/destructure_slice.md:15
+msgid "// Single values can be ignored with _\n"
+msgstr ""
+"// Single valores pode be ignored com _\n"
+
+#: src/flow_control/match/destructuring/destructure_slice.md:17
+msgid "\"array[0] = 1, array[2] = {} and array[1] was ignored\""
+msgstr "\"array[0] = 1, array[2] = {} e array[1] was ignored\""
+
+#: src/flow_control/match/destructuring/destructure_slice.md:21
+msgid "// You can also bind some and ignore the rest\n"
+msgstr ""
+"// You pode also bind some e ignore o rest\n"
+
+#: src/flow_control/match/destructuring/destructure_slice.md:23
+msgid "\"array[0] = -1, array[1] = {} and all the other ones were ignored\""
+msgstr "\"array[0] = -1, array[1] = {} e all o other ones were ignored\""
+
+#: src/flow_control/match/destructuring/destructure_slice.md:26
+msgid ""
+"// The code below would not compile\n"
+"        // [-1, second] => ...\n"
+msgstr ""
+"// O code abaixo would not compile\n"
+"        // [-1, segundo] => ...\n"
+
+#: src/flow_control/match/destructuring/destructure_slice.md:29
+msgid ""
+"// Or store them in another array/slice (the type depends on\n"
+"        // that of the value that is being matched against)\n"
+msgstr ""
+"// Or store them in another array/slice (the type depends on\n"
+"        // that of the value that is being matched against)\n"
+
+#: src/flow_control/match/destructuring/destructure_slice.md:32
+msgid "\"array[0] = 3, array[1] = {} and the other elements were {:?}\""
+msgstr "\"array[0] = 3, array[1] = {} e o other elements were {:?}\""
+
+#: src/flow_control/match/destructuring/destructure_slice.md:36
+msgid ""
+"// Combining these patterns, we can, for example, bind the first and\n"
+"        // last values, and store the rest of them in a single array\n"
+msgstr ""
+"// Combining estes patterns, we pode, para example, bind o primeiro e\n"
+"        // último valores, e store o rest of them in um single array\n"
+
+#: src/flow_control/match/destructuring/destructure_slice.md:39
+msgid "\"array[0] = {}, middle = {:?}, array[2] = {}\""
+msgstr "\"array[0] = {}, middle = {:?}, array[2] = {}\""
+
+#: src/flow_control/match/destructuring/destructure_slice.md:48
+msgid ""
+"[Arrays and Slices](../../../primitives/array.md) and [Binding](../binding."
+"md) for `@` sigil"
+msgstr "[Arrays and Slices](../../../primitives/array.md) e [Binding](../binding.md) para `@` sigil"
+
+#: src/flow_control/match/destructuring/destructure_enum.md:3
+msgid "An `enum` is destructured similarly:"
+msgstr "Um `enum` is destructured similarly:"
+
+#: src/flow_control/match/destructuring/destructure_enum.md:6
+msgid ""
+"// `allow` required to silence warnings because only\n"
+"// one variant is used.\n"
+msgstr ""
+"// `allow` required to silence warnings porque only\n"
+"// one variant is usado.\n"
+
+#: src/flow_control/match/destructuring/destructure_enum.md:10
+msgid "// These 3 are specified solely by their name.\n"
+msgstr ""
+"// Estes 3 are specified solely by their name.\n"
+
+#: src/flow_control/match/destructuring/destructure_enum.md:14
+msgid "// These likewise tie `u32` tuples to different names: color models.\n"
+msgstr ""
+"// Estes likewise tie `u32` tuples to diferente names: color models.\n"
+
+#: src/flow_control/match/destructuring/destructure_enum.md:24
+msgid "// TODO ^ Try different variants for `color`\n"
+msgstr ""
+"// TODO ^ Tente diferente variants para `color`\n"
+
+#: src/flow_control/match/destructuring/destructure_enum.md:26
+msgid "\"What color is it?\""
+msgstr "\"What color is it?\""
+
+#: src/flow_control/match/destructuring/destructure_enum.md:27
+msgid "// An `enum` can be destructured using a `match`.\n"
+msgstr ""
+"// Um `enum` pode be destructured usando um `match`.\n"
+
+#: src/flow_control/match/destructuring/destructure_enum.md:29
+msgid "\"The color is Red!\""
+msgstr "\"O color is Red!\""
+
+#: src/flow_control/match/destructuring/destructure_enum.md:30
+msgid "\"The color is Blue!\""
+msgstr "\"O color is Blue!\""
+
+#: src/flow_control/match/destructuring/destructure_enum.md:31
+msgid "\"The color is Green!\""
+msgstr "\"O color is Green!\""
+
+#: src/flow_control/match/destructuring/destructure_enum.md:33
+msgid "\"Red: {}, green: {}, and blue: {}!\""
+msgstr "\"Red: {}, green: {}, e blue: {}!\""
+
+#: src/flow_control/match/destructuring/destructure_enum.md:35
+msgid "\"Hue: {}, saturation: {}, value: {}!\""
+msgstr "\"Hue: {}, saturation: {}, valor: {}!\""
+
+#: src/flow_control/match/destructuring/destructure_enum.md:37
+msgid "\"Hue: {}, saturation: {}, lightness: {}!\""
+msgstr "\"Hue: {}, saturation: {}, lightness: {}!\""
+
+#: src/flow_control/match/destructuring/destructure_enum.md:39
+msgid "\"Cyan: {}, magenta: {}, yellow: {}!\""
+msgstr "\"Cyan: {}, magenta: {}, yellow: {}!\""
+
+#: src/flow_control/match/destructuring/destructure_enum.md:41
+msgid "\"Cyan: {}, magenta: {}, yellow: {}, key (black): {}!\""
+msgstr "\"Cyan: {}, magenta: {}, yellow: {}, key (black): {}!\""
+
+#: src/flow_control/match/destructuring/destructure_enum.md:43
+msgid "// Don't need another arm because all variants have been examined\n"
+msgstr ""
+"// Don't need another arm porque all variants have been examined\n"
+
+#: src/flow_control/match/destructuring/destructure_enum.md:50
+msgid ""
+"[`#[allow(...)]`](../../../attribute/unused.md), [color models](https://en."
+"wikipedia.org/wiki/Color_model) and [`enum`](../../../custom_types/enum.md)"
+msgstr "[`#[allow(...)]`](../../../attribute/unused.md), [color models](https://en.wikipedia.org/wiki/Color_model) e [`enum`](../../../custom_types/enum.md)"
+
+#: src/flow_control/match/destructuring/destructure_pointers.md:3
+msgid ""
+"For pointers, a distinction needs to be made between destructuring and "
+"dereferencing as they are different concepts which are used differently from "
+"languages like C/C++."
+msgstr "Para pointers, um distinction needs to be made between destructuring e dereferencing as they are diferente concepts which are usado differently de languages like C/C++."
+
+#: src/flow_control/match/destructuring/destructure_pointers.md:7
+msgid "Dereferencing uses `*`"
+msgstr "Dereferencing uses `*`"
+
+#: src/flow_control/match/destructuring/destructure_pointers.md:8
+msgid "Destructuring uses `&`, `ref`, and `ref mut`"
+msgstr "Destructuring uses `&`, `ref`, e `ref mut`"
+
+#: src/flow_control/match/destructuring/destructure_pointers.md:12
+msgid ""
+"// Assign a reference of type `i32`. The `&` signifies there\n"
+"    // is a reference being assigned.\n"
+msgstr ""
+"// Assign um reference of tipo `i32`. O `&` signifies there\n"
+"    // is um reference being assigned.\n"
+
+#: src/flow_control/match/destructuring/destructure_pointers.md:17
+msgid ""
+"// If `reference` is pattern matched against `&val`, it results\n"
+"        // in a comparison like:\n"
+"        // `&i32`\n"
+"        // `&val`\n"
+"        // ^ We see that if the matching `&`s are dropped, then the `i32`\n"
+"        // should be assigned to `val`.\n"
+msgstr ""
+"// If `reference` is pattern matched against `&val`, it results\n"
+"        // in a comparison like:\n"
+"        // `&i32`\n"
+"        // `&val`\n"
+"        // ^ We see that if the matching `&`s are dropped, then the `i32`\n"
+"        // should be assigned to `val`.\n"
+
+#: src/flow_control/match/destructuring/destructure_pointers.md:23
+msgid "\"Got a value via destructuring: {:?}\""
+msgstr "\"Got um valor via destructuring: {:?}\""
+
+#: src/flow_control/match/destructuring/destructure_pointers.md:26
+msgid "// To avoid the `&`, you dereference before matching.\n"
+msgstr ""
+"// To avoid o `&`, you dereference before matching.\n"
+
+#: src/flow_control/match/destructuring/destructure_pointers.md:28
+msgid "\"Got a value via dereferencing: {:?}\""
+msgstr "\"Got um valor via dereferencing: {:?}\""
+
+#: src/flow_control/match/destructuring/destructure_pointers.md:31
+msgid ""
+"// What if you don't start with a reference? `reference` was a `&`\n"
+"    // because the right side was already a reference. This is not\n"
+"    // a reference because the right side is not one.\n"
+msgstr ""
+"// What if you don't start com um reference? `reference` was um `&`\n"
+"    // porque o right side was already um reference. Este is not\n"
+"    // um reference porque o right side is not one.\n"
+
+#: src/flow_control/match/destructuring/destructure_pointers.md:36
+msgid ""
+"// Rust provides `ref` for exactly this purpose. It modifies the\n"
+"    // assignment so that a reference is created for the element; this\n"
+"    // reference is assigned.\n"
+msgstr ""
+"// Rust provides `ref` para exactly este purpose. It modifies o\n"
+"    // assignment so aquele um reference is created para o element; este\n"
+"    // reference is assigned.\n"
+
+#: src/flow_control/match/destructuring/destructure_pointers.md:41
+msgid ""
+"// Accordingly, by defining 2 values without references, references\n"
+"    // can be retrieved via `ref` and `ref mut`.\n"
+msgstr ""
+"// Accordingly, by defining 2 valores sem references, references\n"
+"    // pode be retrieved via `ref` e `ref mut`.\n"
+
+#: src/flow_control/match/destructuring/destructure_pointers.md:46
+msgid "// Use `ref` keyword to create a reference.\n"
+msgstr ""
+"// Usa `ref` keyword to create um reference.\n"
+
+#: src/flow_control/match/destructuring/destructure_pointers.md:48
+msgid "\"Got a reference to a value: {:?}\""
+msgstr "\"Got um reference to um valor: {:?}\""
+
+#: src/flow_control/match/destructuring/destructure_pointers.md:51
+msgid "// Use `ref mut` similarly.\n"
+msgstr ""
+"// Usa `ref mut` similarly.\n"
+
+#: src/flow_control/match/destructuring/destructure_pointers.md:54
+msgid ""
+"// Got a reference. Gotta dereference it before we can\n"
+"            // add anything to it.\n"
+msgstr ""
+"// Got um reference. Gotta dereference it before we pode\n"
+"            // add anything to it.\n"
+
+#: src/flow_control/match/destructuring/destructure_pointers.md:57
+msgid "\"We added 10. `mut_value`: {:?}\""
+msgstr "\"We added 10. `mut_value`: {:?}\""
+
+#: src/flow_control/match/destructuring/destructure_pointers.md:65
+msgid "[The ref pattern](../../../scope/borrow/ref.md)"
+msgstr "[The ref pattern](../../../scope/borrow/ref.md)"
+
+#: src/flow_control/match/destructuring/destructure_structures.md:3
+msgid "Similarly, a `struct` can be destructured as shown:"
+msgstr "Similarly, um `struct` pode be destructured as shown:"
+
+#: src/flow_control/match/destructuring/destructure_structures.md:12
+msgid "// Try changing the values in the struct to see what happens\n"
+msgstr ""
+"// Tente changing o valores in o struct to see what happens\n"
+
+#: src/flow_control/match/destructuring/destructure_structures.md:16
+msgid "\"First of x is 1, b = {},  y = {} \""
+msgstr "\"Primeiro of x is 1, b = {},  y = {} \""
+
+#: src/flow_control/match/destructuring/destructure_structures.md:18
+msgid ""
+"// you can destructure structs and rename the variables,\n"
+"        // the order is not important\n"
+msgstr ""
+"// you pode destructure structs e rename o variáveis,\n"
+"        // o order is not important\n"
+
+#: src/flow_control/match/destructuring/destructure_structures.md:20
+msgid "\"y is 2, i = {:?}\""
+msgstr "\"y is 2, i = {:?}\""
+
+#: src/flow_control/match/destructuring/destructure_structures.md:22
+msgid "// and you can also ignore some variables:\n"
+msgstr ""
+"// e you pode also ignore some variáveis:\n"
+
+#: src/flow_control/match/destructuring/destructure_structures.md:23
+msgid "\"y = {}, we don't care about x\""
+msgstr "\"y = {}, we don't care about x\""
+
+#: src/flow_control/match/destructuring/destructure_structures.md:24
+msgid ""
+"// this will give an error: pattern does not mention field `x`\n"
+"        //Foo { y } => println!(\"y = {}\", y),\n"
+msgstr ""
+"// este vai give um erro: pattern does not mention campo `x`\n"
+"        //Foo { y } => println!(\"y = {}\", y),\n"
+
+#: src/flow_control/match/destructuring/destructure_structures.md:30
+msgid "// You do not need a match block to destructure structs:\n"
+msgstr ""
+"// You do not need um match block to destructure structs:\n"
+
+#: src/flow_control/match/destructuring/destructure_structures.md:32
+msgid "\"Outside: x0 = {x0:?}, y0 = {y0}\""
+msgstr "\"Fora: x0 = {x0:?}, y0 = {y0}\""
+
+#: src/flow_control/match/destructuring/destructure_structures.md:34
+msgid "// Destructuring works with nested structs as well:\n"
+msgstr ""
+"// Destructuring works com nested structs as well:\n"
+
+#: src/flow_control/match/destructuring/destructure_structures.md:41
+msgid "\"Nested: nested_x = {nested_x:?}, nested_y = {nested_y:?}\""
+msgstr "\"Nested: nested_x = {nested_x:?}, nested_y = {nested_y:?}\""
+
+#: src/flow_control/match/destructuring/destructure_structures.md:47
+msgid "[Structs](../../../custom_types/structs.md)"
+msgstr "[Structs](../../../custom_types/structs.md)"
+
+#: src/flow_control/match/guard.md:3
+msgid "A `match` _guard_ can be added to filter the arm."
+msgstr "UM `match` _guard_ pode be added to filter o arm."
+
+#: src/flow_control/match/guard.md:14
+msgid "// ^ TODO try different values for `temperature`\n"
+msgstr ""
+"// ^ TODO try diferente valores para `temperature`\n"
+
+#: src/flow_control/match/guard.md:17
+msgid "\"{}C is above 30 Celsius\""
+msgstr "\"{}C is acima 30 Celsius\""
+
+#: src/flow_control/match/guard.md:18
+msgid "// The `if condition` part ^ is a guard\n"
+msgstr ""
+"// O `if condition` part ^ is um guard\n"
+
+#: src/flow_control/match/guard.md:19
+msgid "\"{}C is equal to or below 30 Celsius\""
+msgstr "\"{}C is equal to ou abaixo 30 Celsius\""
+
+#: src/flow_control/match/guard.md:21
+msgid "\"{}F is above 86 Fahrenheit\""
+msgstr "\"{}F is acima 86 Fahrenheit\""
+
+#: src/flow_control/match/guard.md:22
+msgid "\"{}F is equal to or below 86 Fahrenheit\""
+msgstr "\"{}F is equal to ou abaixo 86 Fahrenheit\""
+
+#: src/flow_control/match/guard.md:27
+msgid ""
+"Note that the compiler won't take guard conditions into account when "
+"checking if all patterns are covered by the match expression."
+msgstr "Note aquele o compiler won't take guard conditions em account when checking if all patterns are covered by o match expression."
+
+#: src/flow_control/match/guard.md:35
+msgid "\"Zero\""
+msgstr "\"Zero\""
+
+#: src/flow_control/match/guard.md:36
+msgid "\"Greater than zero\""
+msgstr "\"Greater than zero\""
+
+#: src/flow_control/match/guard.md:37
+msgid ""
+"// _ => unreachable!(\"Should never happen.\"),\n"
+"        // TODO ^ uncomment to fix compilation\n"
+msgstr ""
+"// _ => unreachable!(\"Deve never happen.\"),\n"
+"        // TODO ^ uncomment to fix compilation\n"
+
+#: src/flow_control/match/guard.md:45
+msgid ""
+"[Tuples](../../primitives/tuples.md) [Enums](../../custom_types/enum.md)"
+msgstr "[Tuples](../../primitives/tuples.md) [Enums](../../custom_types/enum.md)"
+
+#: src/flow_control/match/binding.md:3
+msgid ""
+"Indirectly accessing a variable makes it impossible to branch and use that "
+"variable without re-binding. `match` provides the `@` sigil for binding "
+"values to names:"
+msgstr "Indirectly accessing uma variável makes it impossible to branch e use aquele variável sem re-binding. `match` provides o `@` sigil para binding valores to names:"
+
+#: src/flow_control/match/binding.md:8
+msgid "// A function `age` which returns a `u32`.\n"
+msgstr ""
+"// UM função `age` which retorna um `u32`.\n"
+
+#: src/flow_control/match/binding.md:14
+msgid "\"Tell me what type of person you are\""
+msgstr "\"Tell me what tipo of person you are\""
+
+#: src/flow_control/match/binding.md:17
+msgid "\"I haven't celebrated my first birthday yet\""
+msgstr "\"I haven't celebrated my primeiro birthday yet\""
+
+#: src/flow_control/match/binding.md:18
+msgid ""
+"// Could `match` 1 ..= 12 directly but then what age\n"
+"        // would the child be? Instead, bind to `n` for the\n"
+"        // sequence of 1 ..= 12. Now the age can be reported.\n"
+msgstr ""
+"// Could `match` 1 ..= 12 directly but then what age\n"
+"        // would o child be? Instead, bind to `n` para o\n"
+"        // sequence of 1 ..= 12. Now o age pode be reported.\n"
+
+#: src/flow_control/match/binding.md:21
+msgid "\"I'm a child of age {:?}\""
+msgstr "\"I'm um child of age {:?}\""
+
+#: src/flow_control/match/binding.md:22
+msgid "\"I'm a teen of age {:?}\""
+msgstr "\"I'm um teen of age {:?}\""
+
+#: src/flow_control/match/binding.md:23
+msgid "// Nothing bound. Return the result.\n"
+msgstr ""
+"// Nothing bound. Retorna o resultado.\n"
+
+#: src/flow_control/match/binding.md:24
+msgid "\"I'm an old person of age {:?}\""
+msgstr "\"I'm um antigo person of age {:?}\""
+
+#: src/flow_control/match/binding.md:29
+msgid ""
+"You can also use binding to \"destructure\" `enum` variants, such as "
+"`Option`:"
+msgstr "You pode also use binding to \"destructure\" `enum` variants, such as `Option`:"
+
+#: src/flow_control/match/binding.md:38
+msgid ""
+"// Got `Some` variant, match if its value, bound to `n`,\n"
+"        // is equal to 42.\n"
+msgstr ""
+"// Got `Some` variant, match if its value, bound to `n`,\n"
+"        // is equal to 42.\n"
+
+#: src/flow_control/match/binding.md:40
+msgid "\"The Answer: {}!\""
+msgstr "\"O Answer: {}!\""
+
+#: src/flow_control/match/binding.md:41
+msgid "// Match any other number.\n"
+msgstr ""
+"// Match any other número.\n"
+
+#: src/flow_control/match/binding.md:42
+msgid "\"Not interesting... {}\""
+msgstr "\"Not interesting... {}\""
+
+#: src/flow_control/match/binding.md:43
+msgid "// Match anything else (`None` variant).\n"
+msgstr ""
+"// Match anything else (`None` variant).\n"
+
+#: src/flow_control/match/binding.md:51
+msgid ""
+"[`functions`](../../fn.md), [`enums`](../../custom_types/enum.md) and "
+"[`Option`](../../std/option.md)"
+msgstr "[`functions`](../../fn.md), [`enums`](../../custom_types/enum.md) e [`Option`](../../std/option.md)"
+
+#: src/flow_control/if_let.md:3
+msgid ""
+"For some use cases, when matching enums, `match` is awkward. For example:"
+msgstr "Para some use cases, when matching enums, `match` is awkward. Para example:"
+
+#: src/flow_control/if_let.md:6 src/flow_control/while_let.md:7
+#: src/flow_control/while_let.md:35
+msgid "// Make `optional` of type `Option<i32>`\n"
+msgstr ""
+"// Make `optional` of tipo `Option<i32>`\n"
+
+#: src/flow_control/if_let.md:10
+msgid "\"This is a really long string and `{:?}`\""
+msgstr "\"Este is um really long string e `{:?}`\""
+
+#: src/flow_control/if_let.md:12
+msgid ""
+"// ^ Required because `match` is exhaustive. Doesn't it seem\n"
+"    // like wasted space?\n"
+msgstr ""
+"// ^ Required porque `match` is exhaustive. Doesn't it seem\n"
+"    // like wasted space?\n"
+
+#: src/flow_control/if_let.md:18
+msgid ""
+"`if let` is cleaner for this use case and in addition allows various failure "
+"options to be specified:"
+msgstr "`if let` is cleaner para este use case e in addition allows various failure options to be specified:"
+
+#: src/flow_control/if_let.md:23
+msgid "// All have type `Option<i32>`\n"
+msgstr ""
+"// All have tipo `Option<i32>`\n"
+
+#: src/flow_control/if_let.md:28
+msgid ""
+"// The `if let` construct reads: \"if `let` destructures `number` into\n"
+"    // `Some(i)`, evaluate the block (`{}`).\n"
+msgstr ""
+"// O `if let` construct reads: \"if `let` destructures `number` em\n"
+"    // `Some(i)`, evaluate o block (`{}`).\n"
+
+#: src/flow_control/if_let.md:31 src/flow_control/if_let.md:36
+#: src/flow_control/if_let.md:46
+msgid "\"Matched {:?}!\""
+msgstr "\"Matched {:?}!\""
+
+#: src/flow_control/if_let.md:34
+msgid "// If you need to specify a failure, use an else:\n"
+msgstr ""
+"// If you need to specify um failure, use um else:\n"
+
+#: src/flow_control/if_let.md:38
+msgid "// Destructure failed. Change to the failure case.\n"
+msgstr ""
+"// Destructure failed. Change to o failure case.\n"
+
+#: src/flow_control/if_let.md:39 src/flow_control/if_let.md:50
+msgid "\"Didn't match a number. Let's go with a letter!\""
+msgstr "\"Didn't match um número. Let's go com um letter!\""
+
+#: src/flow_control/if_let.md:42
+msgid "// Provide an altered failing condition.\n"
+msgstr ""
+"// Provide um altered failing condition.\n"
+
+#: src/flow_control/if_let.md:47
+msgid ""
+"// Destructure failed. Evaluate an `else if` condition to see if the\n"
+"    // alternate failure branch should be taken:\n"
+msgstr ""
+"// Destructure failed. Evaluate um `else if` condition to see if o\n"
+"    // alternate failure branch deve be taken:\n"
+
+#: src/flow_control/if_let.md:52
+msgid "// The condition evaluated false. This branch is the default:\n"
+msgstr ""
+"// O condition evaluated false. Este branch is o default:\n"
+
+#: src/flow_control/if_let.md:53
+msgid "\"I don't like letters. Let's go with an emoticon :)!\""
+msgstr "\"I don't like letters. Let's go com um emoticon :)!\""
+
+#: src/flow_control/if_let.md:58
+msgid "In the same way, `if let` can be used to match any enum value:"
+msgstr "In o mesmo way, `if let` pode be usado to match any enum valor:"
+
+#: src/flow_control/if_let.md:61
+msgid "// Our example enum\n"
+msgstr ""
+"// Our example enum\n"
+
+#: src/flow_control/if_let.md:69
+msgid "// Create example variables\n"
+msgstr ""
+"// Cria example variáveis\n"
+
+#: src/flow_control/if_let.md:74 src/flow_control/if_let.md:110
+msgid "// Variable a matches Foo::Bar\n"
+msgstr ""
+"// Variável um matches Foo::Bar\n"
+
+#: src/flow_control/if_let.md:76 src/flow_control/if_let.md:113
+msgid "\"a is foobar\""
+msgstr "\"um is foobar\""
+
+#: src/flow_control/if_let.md:79
+msgid ""
+"// Variable b does not match Foo::Bar\n"
+"    // So this will print nothing\n"
+msgstr ""
+"// Variável b does not match Foo::Bar\n"
+"    // So este vai print nothing\n"
+
+#: src/flow_control/if_let.md:82
+msgid "\"b is foobar\""
+msgstr "\"b is foobar\""
+
+#: src/flow_control/if_let.md:85
+msgid ""
+"// Variable c matches Foo::Qux which has a value\n"
+"    // Similar to Some() in the previous example\n"
+msgstr ""
+"// Variável c matches Foo::Qux which has um valor\n"
+"    // Similar to Some() in o anterior example\n"
+
+#: src/flow_control/if_let.md:88
+msgid "\"c is {}\""
+msgstr "\"c is {}\""
+
+#: src/flow_control/if_let.md:91
+msgid "// Binding also works with `if let`\n"
+msgstr ""
+"// Binding also works com `if let`\n"
+
+#: src/flow_control/if_let.md:93
+msgid "\"c is one hundred\""
+msgstr "\"c is one hundred\""
+
+#: src/flow_control/if_let.md:98
+msgid ""
+"Another benefit is that `if let` allows us to match non-parameterized enum "
+"variants. This is true even in cases where the enum doesn't implement or "
+"derive `PartialEq`. In such cases `if Foo::Bar == a` would fail to compile, "
+"because instances of the enum cannot be equated, however `if let` will "
+"continue to work."
+msgstr "Another benefit is aquele `if let` allows us to match non-parameterized enum variants. Este is true even in cases where o enum doesn't implement ou derive `PartialEq`. In such cases `if Foo::Bar == a` would fail to compile, porque instances of o enum não pode be equated, however `if let` vai continue to work."
+
+#: src/flow_control/if_let.md:100
+msgid "Would you like a challenge? Fix the following example to use `if let`:"
+msgstr "Would you like um challenge? Fix o following example to use `if let`:"
+
+#: src/flow_control/if_let.md:103
+msgid ""
+"// This enum purposely neither implements nor derives PartialEq.\n"
+"// That is why comparing Foo::Bar == a fails below.\n"
+msgstr ""
+"// Este enum purposely neither implements nor derives PartialEq.\n"
+"// Aquele is why comparing Foo::Bar == um fails abaixo.\n"
+
+#: src/flow_control/if_let.md:112
+msgid "// ^-- this causes a compile-time error. Use `if let` instead.\n"
+msgstr ""
+"// ^-- este causes um compile-time erro. Usa `if let` instead.\n"
+
+#: src/flow_control/if_let.md:120
+msgid ""
+"[`enum`](../custom_types/enum.md), [`Option`](../std/option.md), and the "
+"[RFC](https://github.com/rust-lang/rfcs/pull/160)"
+msgstr "[`enum`](../custom_types/enum.md), [`Option`](../std/option.md), e o [RFC](https://github.com/rust-lang/rfcs/pull/160)"
+
+#: src/flow_control/let_else.md:3
+msgid "🛈 stable since: rust 1.65"
+msgstr "🛈 stable since: rust 1.65"
+
+#: src/flow_control/let_else.md:5
+msgid ""
+"🛈 you can target specific edition by compiling like this `rustc --"
+"edition=2021 main.rs`"
+msgstr "🛈 you pode target specific edition by compiling like este `rustc --edition=2021 main.rs`"
+
+#: src/flow_control/let_else.md:8
+msgid ""
+"With `let`\\-`else`, a refutable pattern can match and bind variables in the "
+"surrounding scope like a normal `let`, or else diverge (e.g. `break`, "
+"`return`, `panic!`) when the pattern doesn't match."
+msgstr "Com `let`\\-`else`, um refutable pattern pode match e bind variáveis in o surrounding scope like um normal `let`, ou else diverge (e.g. `break`, `return`, `panic!`) when o pattern doesn't match."
+
+#: src/flow_control/let_else.md:16 src/flow_control/let_else.md:39
+#: src/std/str.md:41
+msgid "' '"
+msgstr "' '"
+
+#: src/flow_control/let_else.md:18 src/flow_control/let_else.md:42
+msgid "\"Can't segment count item pair: '{s}'\""
+msgstr "\"Pode't segment count item pair: '{s}'\""
+
+#: src/flow_control/let_else.md:21 src/flow_control/let_else.md:47
+msgid "\"Can't parse integer: '{count_str}'\""
+msgstr "\"Pode't parse inteiro: '{count_str}'\""
+
+#: src/flow_control/let_else.md:27 src/flow_control/let_else.md:52
+msgid "\"3 chairs\""
+msgstr "\"3 chairs\""
+
+#: src/flow_control/let_else.md:27 src/flow_control/let_else.md:52
+msgid "\"chairs\""
+msgstr "\"chairs\""
+
+#: src/flow_control/let_else.md:31
+msgid ""
+"The scope of name bindings is the main thing that makes this different from "
+"`match` or `if let`\\-`else` expressions. You could previously approximate "
+"these patterns with an unfortunate bit of repetition and an outer `let`:"
+msgstr "O scope of name bindings is o main thing aquele makes este diferente de `match` ou `if let`\\-`else` expressions. You could previously approximate estes patterns com um unfortunate bit of repetition e um outer `let`:"
+
+#: src/flow_control/let_else.md:57
+msgid ""
+"[option](../std/option.md), [match](./match.md), [if let](./if_let.md) and "
+"the [let-else RFC](https://rust-lang.github.io/rfcs/3137-let-else.html)."
+msgstr "[option](../std/option.md), [match](./match.md), [if let](./if_let.md) e o [let-else RFC](https://rust-lang.github.io/rfcs/3137-let-else.html)."
+
+#: src/flow_control/while_let.md:3
+msgid ""
+"Similar to `if let`, `while let` can make awkward `match` sequences more "
+"tolerable. Consider the following sequence that increments `i`:"
+msgstr "Similar to `if let`, `while let` pode make awkward `match` sequences more tolerable. Consider o following sequence aquele increments `i`:"
+
+#: src/flow_control/while_let.md:9
+msgid "// Repeatedly try this test.\n"
+msgstr ""
+"// Repeatedly try este test.\n"
+
+#: src/flow_control/while_let.md:13
+msgid "// If `optional` destructures, evaluate the block.\n"
+msgstr ""
+"// If `optional` destructures, evaluate o block.\n"
+
+#: src/flow_control/while_let.md:16 src/flow_control/while_let.md:42
+msgid "\"Greater than 9, quit!\""
+msgstr "\"Greater than 9, quit!\""
+
+#: src/flow_control/while_let.md:19 src/flow_control/while_let.md:45
+msgid "\"`i` is `{:?}`. Try again.\""
+msgstr "\"`i` is `{:?}`. Tente again.\""
+
+#: src/flow_control/while_let.md:22
+msgid "// ^ Requires 3 indentations!\n"
+msgstr ""
+"// ^ Requires 3 indentations!\n"
+
+#: src/flow_control/while_let.md:24
+msgid "// Quit the loop when the destructure fails:\n"
+msgstr ""
+"// Quit o loop when o destructure fails:\n"
+
+#: src/flow_control/while_let.md:26
+msgid "// ^ Why should this be required? There must be a better way!\n"
+msgstr ""
+"// ^ Why deve este be required? There deve be um better way!\n"
+
+#: src/flow_control/while_let.md:31
+msgid "Using `while let` makes this sequence much nicer:"
+msgstr "Usando `while let` makes este sequence much nicer:"
+
+#: src/flow_control/while_let.md:38
+msgid ""
+"// This reads: \"while `let` destructures `optional` into\n"
+"    // `Some(i)`, evaluate the block (`{}`). Else `break`.\n"
+msgstr ""
+"// Este reads: \"while `let` destructures `optional` em\n"
+"    // `Some(i)`, evaluate o block (`{}`). Else `break`.\n"
+
+#: src/flow_control/while_let.md:48
+msgid ""
+"// ^ Less rightward drift and doesn't require\n"
+"        // explicitly handling the failing case.\n"
+msgstr ""
+"// ^ Less rightward drift e doesn't require\n"
+"        // explicitly handling o failing case.\n"
+
+#: src/flow_control/while_let.md:51
+msgid ""
+"// ^ `if let` had additional optional `else`/`else if`\n"
+"    // clauses. `while let` does not have these.\n"
+msgstr ""
+"// ^ `if let` had additional optional `else`/`else if`\n"
+"    // clauses. `while let` does not have estes.\n"
+
+#: src/flow_control/while_let.md:58
+msgid ""
+"[`enum`](../custom_types/enum.md), [`Option`](../std/option.md), and the "
+"[RFC](https://github.com/rust-lang/rfcs/pull/214)"
+msgstr "[`enum`](../custom_types/enum.md), [`Option`](../std/option.md), e o [RFC](https://github.com/rust-lang/rfcs/pull/214)"
+
+#: src/fn.md:3
+msgid ""
+"Functions are declared using the `fn` keyword. Its arguments are type "
+"annotated, just like variables, and, if the function returns a value, the "
+"return type must be specified after an arrow `->`."
+msgstr "Funções are declared usando o `fn` keyword. Its argumentos are tipo annotated, just like variáveis, e, if a função retorna um valor, o retorna tipo deve be specified after um arrow `->`."
+
+#: src/fn.md:7
+msgid ""
+"The final expression in the function will be used as return value. "
+"Alternatively, the `return` statement can be used to return a value earlier "
+"from within the function, even from inside loops or `if` statements."
+msgstr "O final expression in a função vai be usado as retorna valor. Alternatively, o `return` statement pode be usado to retorna um valor earlier de within a função, even de dentro loops ou `if` statements."
+
+#: src/fn.md:11
+msgid "Let's rewrite FizzBuzz using functions!"
+msgstr "Let's rewrite FizzBuzz usando funções!"
+
+#: src/fn.md:14
+msgid ""
+"// Unlike C/C++, there's no restriction on the order of function "
+"definitions\n"
+msgstr ""
+"// Unlike C/C++, there's no restriction on o order of função definitions\n"
+
+#: src/fn.md:16
+msgid "// We can use this function here, and define it somewhere later\n"
+msgstr ""
+"// We pode use este função here, e define it somewhere later\n"
+
+#: src/fn.md:19
+msgid "// Function that returns a boolean value\n"
+msgstr ""
+"// Função aquele retorna um booleano valor\n"
+
+#: src/fn.md:22
+msgid "// Corner case, early return\n"
+msgstr ""
+"// Corner case, early retorna\n"
+
+#: src/fn.md:27
+msgid "// This is an expression, the `return` keyword is not necessary here\n"
+msgstr ""
+"// Este is um expression, o `return` keyword is not necessary here\n"
+
+#: src/fn.md:30
+msgid ""
+"// Functions that \"don't\" return a value, actually return the unit type "
+"`()`\n"
+msgstr ""
+"// Funções aquele \"don't\" retorna um valor, actually retorna o unit tipo `()`\n"
+
+#: src/fn.md:43
+msgid ""
+"// When a function returns `()`, the return type can be omitted from the\n"
+"// signature\n"
+msgstr ""
+"// When um função retorna `()`, o retorna tipo pode be omitted de o\n"
+"// signature\n"
+
+#: src/fn/methods.md:1
+msgid "Associated functions & Methods"
+msgstr "Associated funções & Métodos"
+
+#: src/fn/methods.md:3
+msgid ""
+"Some functions are connected to a particular type. These come in two forms: "
+"associated functions, and methods. Associated functions are functions that "
+"are defined on a type generally, while methods are associated functions that "
+"are called on a particular instance of a type."
+msgstr "Some funções are connected to um particular tipo. Estes come in two forms: associated funções, e métodos. Associated funções are funções aquele are defined on um tipo generally, while métodos are associated funções aquele are chamado on um particular instance of um tipo."
+
+#: src/fn/methods.md:13
+msgid ""
+"// Implementation block, all `Point` associated functions & methods go in "
+"here\n"
+msgstr ""
+"// Implementation block, all `Point` associated funções & métodos go in here\n"
+
+#: src/fn/methods.md:16
+msgid ""
+"// This is an \"associated function\" because this function is associated "
+"with\n"
+"    // a particular type, that is, Point.\n"
+"    //\n"
+"    // Associated functions don't need to be called with an instance.\n"
+"    // These functions are generally used like constructors.\n"
+msgstr ""
+"// Este is um \"associated função\" porque este função is associated com\n"
+"    // um particular tipo, aquele is, Point.\n"
+"    //\n"
+"    // Associated funções don't need to be chamado com um instance.\n"
+"    // Estes funções are generally usado like constructors.\n"
+
+#: src/fn/methods.md:25
+msgid "// Another associated function, taking two arguments:\n"
+msgstr ""
+"// Another associated função, taking two argumentos:\n"
+
+#: src/fn/methods.md:37
+msgid ""
+"// This is a method\n"
+"    // `&self` is sugar for `self: &Self`, where `Self` is the type of the\n"
+"    // caller object. In this case `Self` = `Rectangle`\n"
+msgstr ""
+"// This is a method\n"
+"    // `&self` is sugar for `self: &Self`, where `Self` is the type of the\n"
+"    // caller object. In this case `Self` = `Rectangle`\n"
+
+#: src/fn/methods.md:41
+msgid "// `self` gives access to the struct fields via the dot operator\n"
+msgstr ""
+"// `self` gives access to o struct campos via o dot operator\n"
+
+#: src/fn/methods.md:45
+msgid ""
+"// `abs` is a `f64` method that returns the absolute value of the\n"
+"        // caller\n"
+msgstr ""
+"// `abs` is um `f64` método aquele retorna o absolute valor of o\n"
+"        // caller\n"
+
+#: src/fn/methods.md:57
+msgid ""
+"// This method requires the caller object to be mutable\n"
+"    // `&mut self` desugars to `self: &mut Self`\n"
+msgstr ""
+"// Este método requires o caller object to be mutável\n"
+"    // `&mut self` desugars to `self: &mut Self`\n"
+
+#: src/fn/methods.md:67
+msgid "// `Pair` owns resources: two heap allocated integers\n"
+msgstr ""
+"// `Pair` owns resources: two heap allocated inteiros\n"
+
+#: src/fn/methods.md:72
+msgid ""
+"// This method \"consumes\" the resources of the caller object\n"
+"    // `self` desugars to `self: Self`\n"
+msgstr ""
+"// Este método \"consumes\" o resources of o caller object\n"
+"    // `self` desugars to `self: Self`\n"
+
+#: src/fn/methods.md:75
+msgid "// Destructure `self`\n"
+msgstr ""
+"// Destructure `self`\n"
+
+#: src/fn/methods.md:78
+msgid "\"Destroying Pair({}, {})\""
+msgstr "\"Destroying Pair({}, {})\""
+
+#: src/fn/methods.md:80
+msgid "// `first` and `second` go out of scope and get freed\n"
+msgstr ""
+"// `first` e `second` go out of scope e get freed\n"
+
+#: src/fn/methods.md:86
+msgid "// Associated functions are called using double colons\n"
+msgstr ""
+"// Associated funções are chamado usando double colons\n"
+
+#: src/fn/methods.md:91
+msgid ""
+"// Methods are called using the dot operator\n"
+"    // Note that the first argument `&self` is implicitly passed, i.e.\n"
+"    // `rectangle.perimeter()` === `Rectangle::perimeter(&rectangle)`\n"
+msgstr ""
+"// Métodos are chamado usando o dot operator\n"
+"    // Note aquele o primeiro argumento `&self` is implicitly passed, i.e.\n"
+"    // `rectangle.perimeter()` === `Rectangle::perimeter(&rectangle)`\n"
+
+#: src/fn/methods.md:94
+msgid "\"Rectangle perimeter: {}\""
+msgstr "\"Rectangle perimeter: {}\""
+
+#: src/fn/methods.md:95
+msgid "\"Rectangle area: {}\""
+msgstr "\"Rectangle area: {}\""
+
+#: src/fn/methods.md:102
+msgid ""
+"// Error! `rectangle` is immutable, but this method requires a mutable\n"
+"    // object\n"
+"    //rectangle.translate(1.0, 0.0);\n"
+"    // TODO ^ Try uncommenting this line\n"
+msgstr ""
+"// Erro! `rectangle` is imutável, but este método requires um mutável\n"
+"    // object\n"
+"    //rectangle.translate(1.0, 0.0);\n"
+"    // TODO ^ Tente uncommenting este line\n"
+
+#: src/fn/methods.md:107
+msgid "// Okay! Mutable objects can call mutable methods\n"
+msgstr ""
+"// Okay! Mutável objects pode call mutável métodos\n"
+
+#: src/fn/methods.md:114
+msgid ""
+"// Error! Previous `destroy` call \"consumed\" `pair`\n"
+"    //pair.destroy();\n"
+"    // TODO ^ Try uncommenting this line\n"
+msgstr ""
+"// Erro! Anterior `destroy` call \"consumed\" `pair`\n"
+"    //pair.destroy();\n"
+"    // TODO ^ Tente uncommenting este line\n"
+
+#: src/fn/closures.md:3
+msgid ""
+"Closures are functions that can capture the enclosing environment. For "
+"example, a closure that captures the `x` variable:"
+msgstr "Closures are funções aquele pode capture o enclosing environment. Para example, um closure aquele captures o `x` variável:"
+
+#: src/fn/closures.md:10
+msgid ""
+"The syntax and capabilities of closures make them very convenient for on the "
+"fly usage. Calling a closure is exactly like calling a function. However, "
+"both input and return types _can_ be inferred and input variable names "
+"_must_ be specified."
+msgstr "O syntax e capabilities of closures make them very convenient para on o fly usage. Chamaing um closure is exactly like calling um função. However, both entrada e retorna tipos _can_ be inferred e entrada variável names _must_ be specified."
+
+#: src/fn/closures.md:15
+msgid "Other characteristics of closures include:"
+msgstr "Other characteristics of closures include:"
+
+#: src/fn/closures.md:17
+msgid "using `||` instead of `()` around input variables."
+msgstr "usando `||` instead of `()` around entrada variáveis."
+
+#: src/fn/closures.md:18
+msgid ""
+"optional body delimitation (`{}`) for a single line expression (mandatory "
+"otherwise)."
+msgstr "optional body delimitation (`{}`) para um single line expression (mandatory otherwise)."
+
+#: src/fn/closures.md:19
+msgid "the ability to capture the outer environment variables."
+msgstr "o ability to capture o outer environment variáveis."
+
+#: src/fn/closures.md:25
+msgid ""
+"// A regular function can't refer to variables in the enclosing environment\n"
+"    //fn function(i: i32) -> i32 { i + outer_var }\n"
+"    // TODO: uncomment the line above and see the compiler error. The "
+"compiler\n"
+"    // suggests that we define a closure instead.\n"
+msgstr ""
+"// UM regular função pode't refer to variáveis in o enclosing environment\n"
+"    //fn função(i: i32) -> i32 { i + outer_var }\n"
+"    // TODO: uncomment o line acima e see o compiler erro. O compiler\n"
+"    // suggests aquele we define um closure instead.\n"
+
+#: src/fn/closures.md:30
+msgid ""
+"// Closures are anonymous, here we are binding them to references.\n"
+"    // Annotation is identical to function annotation but is optional\n"
+"    // as are the `{}` wrapping the body. These nameless functions\n"
+"    // are assigned to appropriately named variables.\n"
+msgstr ""
+"// Closures are anonymous, here we are binding them to references.\n"
+"    // Anotação is identical ta função anotação but is optional\n"
+"    // as are o `{}` wrapping o body. Estes nameless funções\n"
+"    // are assigned to appropriately named variáveis.\n"
+
+#: src/fn/closures.md:37
+msgid "// Call the closures.\n"
+msgstr ""
+"// Chama o closures.\n"
+
+#: src/fn/closures.md:38
+msgid "\"closure_annotated: {}\""
+msgstr "\"closure_annotated: {}\""
+
+#: src/fn/closures.md:39
+msgid "\"closure_inferred: {}\""
+msgstr "\"closure_inferred: {}\""
+
+#: src/fn/closures.md:40
+msgid ""
+"// Once closure's type has been inferred, it cannot be inferred again with "
+"another type.\n"
+"    //println!(\"cannot reuse closure_inferred with another type: {}\", "
+"closure_inferred(42i64));\n"
+"    // TODO: uncomment the line above and see the compiler error.\n"
+msgstr ""
+"// Once closure's tipo has been inferred, it não pode be inferred again com another tipo.\n"
+"    //println!(\"não pode reuse closure_inferred com another tipo: {}\", closure_inferred(42i64));\n"
+"    // TODO: uncomment o line acima e see o compiler erro.\n"
+
+#: src/fn/closures.md:44
+msgid ""
+"// A closure taking no arguments which returns an `i32`.\n"
+"    // The return type is inferred.\n"
+msgstr ""
+"// UM closure taking no argumentos which retorna um `i32`.\n"
+"    // O retorna tipo is inferred.\n"
+
+#: src/fn/closures.md:47
+msgid "\"closure returning one: {}\""
+msgstr "\"closure returning one: {}\""
+
+#: src/fn/closures/capture.md:3
+msgid ""
+"Closures are inherently flexible and will do what the functionality requires "
+"to make the closure work without annotation. This allows capturing to "
+"flexibly adapt to the use case, sometimes moving and sometimes borrowing. "
+"Closures can capture variables:"
+msgstr "Closures are inherently flexible e vai do what o functionality requires to make o closure work sem anotação. Este allows capturing to flexibly adapt to o use case, sometimes moving e sometimes borrowing. Closures pode capture variáveis:"
+
+#: src/fn/closures/capture.md:8
+msgid "by reference: `&T`"
+msgstr "by reference: `&T`"
+
+#: src/fn/closures/capture.md:9
+msgid "by mutable reference: `&mut T`"
+msgstr "by mutável reference: `&mut T`"
+
+#: src/fn/closures/capture.md:10
+msgid "by value: `T`"
+msgstr "by valor: `T`"
+
+#: src/fn/closures/capture.md:12
+msgid ""
+"They preferentially capture variables by reference and only go lower when "
+"required."
+msgstr "They preferentially capture variáveis by reference e only go lower when required."
+
+#: src/fn/closures/capture.md:19
+msgid "\"green\""
+msgstr "\"green\""
+
+#: src/fn/closures/capture.md:21
+msgid ""
+"// A closure to print `color` which immediately borrows (`&`) `color` and\n"
+"    // stores the borrow and closure in the `print` variable. It will "
+"remain\n"
+"    // borrowed until `print` is used the last time. \n"
+"    //\n"
+"    // `println!` only requires arguments by immutable reference so it "
+"doesn't\n"
+"    // impose anything more restrictive.\n"
+msgstr ""
+"// UM closure to print `color` which immediately empréstimos (`&`) `color` e\n"
+"    // stores o emprestar e closure in o `print` variável. It vai remain\n"
+"    // emprestadas until `print` is usado o último time. \n"
+"    //\n"
+"    // `println!` only requires argumentos by imutável reference so it doesn't\n"
+"    // impose anything more restrictive.\n"
+
+#: src/fn/closures/capture.md:27
+msgid "\"`color`: {}\""
+msgstr "\"`color`: {}\""
+
+#: src/fn/closures/capture.md:29
+msgid "// Call the closure using the borrow.\n"
+msgstr ""
+"// Chama o closure usando o emprestar.\n"
+
+#: src/fn/closures/capture.md:32
+msgid ""
+"// `color` can be borrowed immutably again, because the closure only holds\n"
+"    // an immutable reference to `color`. \n"
+msgstr ""
+"// `color` pode be emprestadas immutably again, porque o closure only holds\n"
+"    // um imutável reference to `color`. \n"
+
+#: src/fn/closures/capture.md:37
+msgid "// A move or reborrow is allowed after the final use of `print`\n"
+msgstr ""
+"// UM move ou reborrow is allowed after o final use of `print`\n"
+
+#: src/fn/closures/capture.md:42
+msgid ""
+"// A closure to increment `count` could take either `&mut count` or `count`\n"
+"    // but `&mut count` is less restrictive so it takes that. Immediately\n"
+"    // borrows `count`.\n"
+"    //\n"
+"    // A `mut` is required on `inc` because a `&mut` is stored inside. "
+"Thus,\n"
+"    // calling the closure mutates `count` which requires a `mut`.\n"
+msgstr ""
+"// UM closure to increment `count` could take either `&mut count` ou `count`\n"
+"    // but `&mut count` is less restrictive so it takes aquele. Immediately\n"
+"    // empréstimos `count`.\n"
+"    //\n"
+"    // UM `mut` is required on `inc` porque um `&mut` is stored dentro. Thus,\n"
+"    // calling o closure mutates `count` which requires um `mut`.\n"
+
+#: src/fn/closures/capture.md:50
+msgid "\"`count`: {}\""
+msgstr "\"`count`: {}\""
+
+#: src/fn/closures/capture.md:53
+msgid "// Call the closure using a mutable borrow.\n"
+msgstr ""
+"// Chama o closure usando um mutável emprestar.\n"
+
+#: src/fn/closures/capture.md:56
+msgid ""
+"// The closure still mutably borrows `count` because it is called later.\n"
+"    // An attempt to reborrow will lead to an error.\n"
+"    // let _reborrow = &count; \n"
+"    // ^ TODO: try uncommenting this line.\n"
+msgstr ""
+"// O closure still mutably empréstimos `count` porque it is chamado later.\n"
+"    // Um attempt to reborrow vai lead to um erro.\n"
+"    // let _reborrow = &count; \n"
+"    // ^ TODO: try uncommenting este line.\n"
+
+#: src/fn/closures/capture.md:62
+msgid ""
+"// The closure no longer needs to borrow `&mut count`. Therefore, it is\n"
+"    // possible to reborrow without an error\n"
+msgstr ""
+"// O closure no longer needs to emprestar `&mut count`. Therefore, it is\n"
+"    // possible to reborrow sem um erro\n"
+
+#: src/fn/closures/capture.md:67
+msgid "// A non-copy type.\n"
+msgstr ""
+"// UM non-copy tipo.\n"
+
+#: src/fn/closures/capture.md:70
+msgid ""
+"// `mem::drop` requires `T` so this must take by value. A copy type\n"
+"    // would copy into the closure leaving the original untouched.\n"
+"    // A non-copy must move and so `movable` immediately moves into\n"
+"    // the closure.\n"
+msgstr ""
+"// `mem::drop` requires `T` so este deve take by valor. UM copy tipo\n"
+"    // would copy no closure leaving o original untouched.\n"
+"    // UM non-copy deve move e so `movable` immediately moves em\n"
+"    // o closure.\n"
+
+#: src/fn/closures/capture.md:75
+msgid "\"`movable`: {:?}\""
+msgstr "\"`movable`: {:?}\""
+
+#: src/fn/closures/capture.md:79
+msgid "// `consume` consumes the variable so this can only be called once.\n"
+msgstr ""
+"// `consume` consumes o variável so este pode only be chamado once.\n"
+
+#: src/fn/closures/capture.md:81
+msgid ""
+"// consume();\n"
+"    // ^ TODO: Try uncommenting this line.\n"
+msgstr ""
+"// consume();\n"
+"    // ^ TODO: Tente uncommenting este line.\n"
+
+#: src/fn/closures/capture.md:86
+msgid ""
+"Using `move` before vertical pipes forces closure to take ownership of "
+"captured variables:"
+msgstr "Usando `move` before vertical pipes forces closure to take ownership of captured variáveis:"
+
+#: src/fn/closures/capture.md:91
+msgid "// `Vec` has non-copy semantics.\n"
+msgstr ""
+"// `Vec` has non-copy semantics.\n"
+
+#: src/fn/closures/capture.md:99
+msgid ""
+"// println!(\"There're {} elements in vec\", haystack.len());\n"
+"    // ^ Uncommenting above line will result in compile-time error\n"
+"    // because borrow checker doesn't allow re-using variable after it\n"
+"    // has been moved.\n"
+msgstr ""
+"// println!(\"There're {} elements in vec\", haystack.len());\n"
+"    // ^ Remova o comentário deing acima line vai resultado in compile-time erro\n"
+"    // porque emprestar checker doesn't allow re-usando variável after it\n"
+"    // has been moved.\n"
+
+#: src/fn/closures/capture.md:104
+msgid ""
+"// Removing `move` from closure's signature will cause closure\n"
+"    // to borrow _haystack_ variable immutably, hence _haystack_ is still\n"
+"    // available and uncommenting above line will not cause an error.\n"
+msgstr ""
+"// Removing `move` de closure's signature vai cause closure\n"
+"    // to emprestar _haystack_ variável immutably, hence _haystack_ is still\n"
+"    // available e uncommenting acima line vai not cause um erro.\n"
+
+#: src/fn/closures/capture.md:112
+msgid ""
+"[`Box`](../../std/box.md) and [`std::mem::drop`](https://doc.rust-lang.org/"
+"std/mem/fn.drop.html)"
+msgstr "[`Box`](../../std/box.md) e [`std::mem::drop`](https://doc.rust-lang.org/std/mem/fn.drop.html)"
+
+#: src/fn/closures/input_parameters.md:3
+msgid ""
+"While Rust chooses how to capture variables on the fly mostly without type "
+"annotation, this ambiguity is not allowed when writing functions. When "
+"taking a closure as an input parameter, the closure's complete type must be "
+"annotated using one of a few `traits`, and they're determined by what the "
+"closure does with captured value. In order of decreasing restriction, they "
+"are:"
+msgstr "While Rust chooses how to capture variáveis on o fly mostly sem tipo anotação, este ambiguity is not allowed when writing funções. When taking um closure as um entrada parâmetro, o closure's complete tipo deve be annotated usando one of um few `traits`, e they're determined by what o closure does com captured valor. In order of decreasing restriction, they are:"
+
+#: src/fn/closures/input_parameters.md:10
+msgid "`Fn`: the closure uses the captured value by reference (`&T`)"
+msgstr "`Fn`: o closure uses o captured valor by reference (`&T`)"
+
+#: src/fn/closures/input_parameters.md:11
+msgid ""
+"`FnMut`: the closure uses the captured value by mutable reference (`&mut T`)"
+msgstr "`FnMut`: o closure uses o captured valor by mutável reference (`&mut T`)"
+
+#: src/fn/closures/input_parameters.md:12
+msgid "`FnOnce`: the closure uses the captured value by value (`T`)"
+msgstr "`FnOnce`: o closure uses o captured valor by valor (`T`)"
+
+#: src/fn/closures/input_parameters.md:14
+msgid ""
+"On a variable-by-variable basis, the compiler will capture variables in the "
+"least restrictive manner possible."
+msgstr "On uma variável-by-variável basis, o compiler vai capture variáveis in o least restrictive manner possible."
+
+#: src/fn/closures/input_parameters.md:17
+msgid ""
+"For instance, consider a parameter annotated as `FnOnce`. This specifies "
+"that the closure _may_ capture by `&T`, `&mut T`, or `T`, but the compiler "
+"will ultimately choose based on how the captured variables are used in the "
+"closure."
+msgstr "Para instance, consider um parâmetro annotated as `FnOnce`. Este specifies aquele o closure _may_ capture by `&T`, `&mut T`, ou `T`, but o compiler vai ultimately choose based on how o captured variáveis are usado in o closure."
+
+#: src/fn/closures/input_parameters.md:22
+msgid ""
+"This is because if a move is possible, then any type of borrow should also "
+"be possible. Note that the reverse is not true. If the parameter is "
+"annotated as `Fn`, then capturing variables by `&mut T` or `T` are not "
+"allowed. However, `&T` is allowed."
+msgstr "This is because if a move is possible, then any type of borrow should also be possible. Note that the reverse is not true. If the parameter is annotated as `Fn`, then capturing variables by `&mut T` or `T` are not allowed. However, `&T` is allowed."
+
+#: src/fn/closures/input_parameters.md:27
+msgid ""
+"In the following example, try swapping the usage of `Fn`, `FnMut`, and "
+"`FnOnce` to see what happens:"
+msgstr "In o following example, try swapping o usage of `Fn`, `FnMut`, e `FnOnce` to see what happens:"
+
+#: src/fn/closures/input_parameters.md:31
+msgid ""
+"// A function which takes a closure as an argument and calls it.\n"
+"// <F> denotes that F is a \"Generic type parameter\"\n"
+msgstr ""
+"// UM função which takes um closure as um argumento e calls it.\n"
+"// <F> denotes aquele F is um \"Generic tipo parâmetro\"\n"
+
+#: src/fn/closures/input_parameters.md:34
+msgid "// The closure takes no input and returns nothing.\n"
+msgstr ""
+"// O closure takes na entrada e retorna nothing.\n"
+
+#: src/fn/closures/input_parameters.md:36
+msgid "// ^ TODO: Try changing this to `Fn` or `FnMut`.\n"
+msgstr ""
+"// ^ TODO: Tente changing este to `Fn` ou `FnMut`.\n"
+
+#: src/fn/closures/input_parameters.md:40
+msgid "// A function which takes a closure and returns an `i32`.\n"
+msgstr ""
+"// UM função which takes um closure e retorna um `i32`.\n"
+
+#: src/fn/closures/input_parameters.md:43
+msgid "// The closure takes an `i32` and returns an `i32`.\n"
+msgstr ""
+"// O closure takes um `i32` e retorna um `i32`.\n"
+
+#: src/fn/closures/input_parameters.md:53
+msgid ""
+"// A non-copy type.\n"
+"    // `to_owned` creates owned data from borrowed one\n"
+msgstr ""
+"// UM non-copy tipo.\n"
+"    // `to_owned` creates owned data de emprestadas one\n"
+
+#: src/fn/closures/input_parameters.md:55
+msgid "\"goodbye\""
+msgstr "\"goodbye\""
+
+#: src/fn/closures/input_parameters.md:57
+msgid ""
+"// Capture 2 variables: `greeting` by reference and\n"
+"    // `farewell` by value.\n"
+msgstr ""
+"// Capture 2 variáveis: `greeting` by reference e\n"
+"    // `farewell` by valor.\n"
+
+#: src/fn/closures/input_parameters.md:60
+msgid "// `greeting` is by reference: requires `Fn`.\n"
+msgstr ""
+"// `greeting` is by reference: requires `Fn`.\n"
+
+#: src/fn/closures/input_parameters.md:61
+msgid "\"I said {}.\""
+msgstr "\"I said {}.\""
+
+#: src/fn/closures/input_parameters.md:63
+msgid ""
+"// Mutation forces `farewell` to be captured by\n"
+"        // mutable reference. Now requires `FnMut`.\n"
+msgstr ""
+"// Mutation forces `farewell` to be captured by\n"
+"        // mutável reference. Now requires `FnMut`.\n"
+
+#: src/fn/closures/input_parameters.md:65
+msgid "\"!!!\""
+msgstr "\"!!!\""
+
+#: src/fn/closures/input_parameters.md:66
+msgid "\"Then I screamed {}.\""
+msgstr "\"Then I screamed {}.\""
+
+#: src/fn/closures/input_parameters.md:67
+msgid "\"Now I can sleep. zzzzz\""
+msgstr "\"Now I pode sleep. zzzzz\""
+
+#: src/fn/closures/input_parameters.md:69
+msgid ""
+"// Manually calling drop forces `farewell` to\n"
+"        // be captured by value. Now requires `FnOnce`.\n"
+msgstr ""
+"// Manually calling drop forces `farewell` to\n"
+"        // be captured by valor. Now requires `FnOnce`.\n"
+
+#: src/fn/closures/input_parameters.md:74
+msgid "// Call the function which applies the closure.\n"
+msgstr ""
+"// Chama a função which applies o closure.\n"
+
+#: src/fn/closures/input_parameters.md:77
+msgid "// `double` satisfies `apply_to_3`'s trait bound\n"
+msgstr ""
+"// `double` satisfies `apply_to_3`'s trait bound\n"
+
+#: src/fn/closures/input_parameters.md:80
+msgid "\"3 doubled: {}\""
+msgstr "\"3 doubled: {}\""
+
+#: src/fn/closures/input_parameters.md:86
+msgid ""
+"[`std::mem::drop`](https://doc.rust-lang.org/std/mem/fn.drop.html), [`Fn`]"
+"(https://doc.rust-lang.org/std/ops/trait.Fn.html), [`FnMut`](https://doc."
+"rust-lang.org/std/ops/trait.FnMut.html), [Generics](../../generics.md), "
+"[where](../../generics/where.md) and [`FnOnce`](https://doc.rust-lang.org/"
+"std/ops/trait.FnOnce.html)"
+msgstr "[`std::mem::drop`](https://doc.rust-lang.org/std/mem/fn.drop.html), [`Fn`](https://doc.rust-lang.org/std/ops/trait.Fn.html), [`FnMut`](https://doc.rust-lang.org/std/ops/trait.FnMut.html), [Generics](../../generics.md), [where](../../generics/where.md) e [`FnOnce`](https://doc.rust-lang.org/std/ops/trait.FnOnce.html)"
+
+#: src/fn/closures/anonymity.md:3
+msgid ""
+"Closures succinctly capture variables from enclosing scopes. Does this have "
+"any consequences? It surely does. Observe how using a closure as a function "
+"parameter requires [generics](../../generics.md), which is necessary because "
+"of how they are defined:"
+msgstr "Closures succinctly capture variáveis de enclosing scopes. Does este have any consequences? It surely does. Observe how usando um closure as um função parâmetro requires [generics](../../generics.md), which is necessary porque of how they are defined:"
+
+#: src/fn/closures/anonymity.md:9
+msgid "// `F` must be generic.\n"
+msgstr ""
+"// `F` deve be generic.\n"
+
+#: src/fn/closures/anonymity.md:16
+msgid ""
+"When a closure is defined, the compiler implicitly creates a new anonymous "
+"structure to store the captured variables inside, meanwhile implementing the "
+"functionality via one of the `traits`: `Fn`, `FnMut`, or `FnOnce` for this "
+"unknown type. This type is assigned to the variable which is stored until "
+"calling."
+msgstr "When um closure is defined, o compiler implicitly creates um novo anonymous estrutura to store o captured variáveis dentro, meanwhile implementing o functionality via one of o `traits`: `Fn`, `FnMut`, ou `FnOnce` para este unknown tipo. Este tipo is assigned to o variável which is stored until calling."
+
+#: src/fn/closures/anonymity.md:22
+msgid ""
+"Since this new type is of unknown type, any usage in a function will require "
+"generics. However, an unbounded type parameter `<T>` would still be "
+"ambiguous and not be allowed. Thus, bounding by one of the `traits`: `Fn`, "
+"`FnMut`, or `FnOnce` (which it implements) is sufficient to specify its type."
+msgstr "Since este novo tipo is of unknown tipo, any usage in um função vai require generics. However, um unbounded tipo parâmetro `<T>` would still be ambiguous e not be allowed. Thus, bounding by one of o `traits`: `Fn`, `FnMut`, ou `FnOnce` (which it implements) is sufficient to specify its tipo."
+
+#: src/fn/closures/anonymity.md:28
+msgid ""
+"// `F` must implement `Fn` for a closure which takes no\n"
+"// inputs and returns nothing - exactly what is required\n"
+"// for `print`.\n"
+msgstr ""
+"// `F` deve implement `Fn` para um closure which takes no\n"
+"// inputs e retorna nothing - exactly what is required\n"
+"// para `print`.\n"
+
+#: src/fn/closures/anonymity.md:39
+msgid ""
+"// Capture `x` into an anonymous type and implement\n"
+"    // `Fn` for it. Store it in `print`.\n"
+msgstr ""
+"// Capture `x` em um anonymous tipo e implement\n"
+"    // `Fn` para it. Store it in `print`.\n"
+
+#: src/fn/closures/anonymity.md:49
+msgid ""
+"[A thorough analysis](https://huonw.github.io/blog/2015/05/finding-closure-"
+"in-rust/), [`Fn`](https://doc.rust-lang.org/std/ops/trait.Fn.html), [`FnMut`]"
+"(https://doc.rust-lang.org/std/ops/trait.FnMut.html), and [`FnOnce`](https://"
+"doc.rust-lang.org/std/ops/trait.FnOnce.html)"
+msgstr "[A thorough analysis](https://huonw.github.io/blog/2015/05/finding-closure-in-rust/), [`Fn`](https://doc.rust-lang.org/std/ops/trait.Fn.html), [`FnMut`](https://doc.rust-lang.org/std/ops/trait.FnMut.html), e [`FnOnce`](https://doc.rust-lang.org/std/ops/trait.FnOnce.html)"
+
+#: src/fn/closures/input_functions.md:3
+msgid ""
+"Since closures may be used as arguments, you might wonder if the same can be "
+"said about functions. And indeed they can! If you declare a function that "
+"takes a closure as parameter, then any function that satisfies the trait "
+"bound of that closure can be passed as a parameter."
+msgstr "Since closures may be usado as argumentos, you might wonder if o mesmo pode be said about funções. E indeed they pode! If you declare um função aquele takes um closure as parâmetro, then any função aquele satisfies o trait bound of aquele closure pode be passed as um parâmetro."
+
+#: src/fn/closures/input_functions.md:9
+msgid ""
+"// Define a function which takes a generic `F` argument\n"
+"// bounded by `Fn`, and calls it\n"
+msgstr ""
+"// Define um função which takes um generic `F` argumento\n"
+"// bounded by `Fn`, e calls it\n"
+
+#: src/fn/closures/input_functions.md:14
+msgid "// Define a wrapper function satisfying the `Fn` bound\n"
+msgstr ""
+"// Define um wrapper função satisfying o `Fn` bound\n"
+
+#: src/fn/closures/input_functions.md:17
+msgid "\"I'm a function!\""
+msgstr "\"I'm um função!\""
+
+#: src/fn/closures/input_functions.md:21
+msgid "// Define a closure satisfying the `Fn` bound\n"
+msgstr ""
+"// Define um closure satisfying o `Fn` bound\n"
+
+#: src/fn/closures/input_functions.md:22
+msgid "\"I'm a closure!\""
+msgstr "\"I'm um closure!\""
+
+#: src/fn/closures/input_functions.md:29
+msgid ""
+"As an additional note, the `Fn`, `FnMut`, and `FnOnce` `traits` dictate how "
+"a closure captures variables from the enclosing scope."
+msgstr "As um additional note, o `Fn`, `FnMut`, e `FnOnce` `traits` dictate how um closure captures variáveis do enclosing scope."
+
+#: src/fn/closures/input_functions.md:34
+msgid ""
+"[`Fn`](https://doc.rust-lang.org/std/ops/trait.Fn.html), [`FnMut`](https://"
+"doc.rust-lang.org/std/ops/trait.FnMut.html), and [`FnOnce`](https://doc.rust-"
+"lang.org/std/ops/trait.FnOnce.html)"
+msgstr "[`Fn`](https://doc.rust-lang.org/std/ops/trait.Fn.html), [`FnMut`](https://doc.rust-lang.org/std/ops/trait.FnMut.html), e [`FnOnce`](https://doc.rust-lang.org/std/ops/trait.FnOnce.html)"
+
+#: src/fn/closures/output_parameters.md:3
+msgid ""
+"Closures as input parameters are possible, so returning closures as output "
+"parameters should also be possible. However, anonymous closure types are, by "
+"definition, unknown, so we have to use `impl Trait` to return them."
+msgstr "Closures as entrada parâmetros are possible, so returning closures as saída parâmetros deve also be possible. However, anonymous closure tipos are, by definition, unknown, so we have to use `impl Trait` to retorna them."
+
+#: src/fn/closures/output_parameters.md:8
+msgid "The valid traits for returning a closure are:"
+msgstr "O válido traits para returning um closure are:"
+
+#: src/fn/closures/output_parameters.md:10
+msgid "`Fn`"
+msgstr "`Fn`"
+
+#: src/fn/closures/output_parameters.md:11
+msgid "`FnMut`"
+msgstr "`FnMut`"
+
+#: src/fn/closures/output_parameters.md:12
+msgid "`FnOnce`"
+msgstr "`FnOnce`"
+
+#: src/fn/closures/output_parameters.md:14
+msgid ""
+"Beyond this, the `move` keyword must be used, which signals that all "
+"captures occur by value. This is required because any captures by reference "
+"would be dropped as soon as the function exited, leaving invalid references "
+"in the closure."
+msgstr "Beyond este, o `move` keyword deve be usado, which signals aquele all captures occur by valor. Este is required porque any captures by reference would be dropped as soon as a função exited, leaving inválido references in o closure."
+
+#: src/fn/closures/output_parameters.md:21
+msgid "\"Fn\""
+msgstr "\"Fn\""
+
+#: src/fn/closures/output_parameters.md:23
+#: src/fn/closures/output_parameters.md:29
+#: src/fn/closures/output_parameters.md:35
+msgid "\"This is a: {}\""
+msgstr "\"Este is um: {}\""
+
+#: src/fn/closures/output_parameters.md:27
+msgid "\"FnMut\""
+msgstr "\"FnMut\""
+
+#: src/fn/closures/output_parameters.md:33
+msgid "\"FnOnce\""
+msgstr "\"FnOnce\""
+
+#: src/fn/closures/output_parameters.md:51
+msgid ""
+"[`Fn`](https://doc.rust-lang.org/std/ops/trait.Fn.html), [`FnMut`](https://"
+"doc.rust-lang.org/std/ops/trait.FnMut.html), [Generics](../../generics.md) "
+"and [impl Trait](../../trait/impl_trait.md)."
+msgstr "[`Fn`](https://doc.rust-lang.org/std/ops/trait.Fn.html), [`FnMut`](https://doc.rust-lang.org/std/ops/trait.FnMut.html), [Generics](../../generics.md) e [impl Trait](../../trait/impl_trait.md)."
+
+#: src/fn/closures/closure_examples.md:3
+msgid ""
+"This section contains a few examples of using closures from the `std` "
+"library."
+msgstr "Este section contains um few examples of usando closures do `std` library."
+
+#: src/fn/closures/closure_examples/iter_any.md:3
+msgid ""
+"`Iterator::any` is a function which when passed an iterator, will return "
+"`true` if any element satisfies the predicate. Otherwise `false`. Its "
+"signature:"
+msgstr "`Iterator::any` is um função which when passed um iterator, vai retorna `true` if any element satisfies o predicate. Otherwise `false`. Its signature:"
+
+#: src/fn/closures/closure_examples/iter_any.md:9
+#: src/fn/closures/closure_examples/iter_find.md:9
+msgid "// The type being iterated over.\n"
+msgstr ""
+"// O tipo being iterated over.\n"
+
+#: src/fn/closures/closure_examples/iter_any.md:12
+msgid ""
+"// `any` takes `&mut self` meaning the caller may be borrowed\n"
+"    // and modified, but not consumed.\n"
+msgstr ""
+"// `any` takes `&mut self` meaning o caller may be emprestadas\n"
+"    // e modified, but not consumed.\n"
+
+#: src/fn/closures/closure_examples/iter_any.md:15
+msgid ""
+"// `FnMut` meaning any captured variable may at most be\n"
+"        // modified, not consumed. `Self::Item` states it takes\n"
+"        // arguments to the closure by value.\n"
+msgstr ""
+"// `FnMut` meaning any captured variável may at most be\n"
+"        // modified, not consumed. `Self::Item` states it takes\n"
+"        // argumentos to o closure by valor.\n"
+
+#: src/fn/closures/closure_examples/iter_any.md:27
+msgid "// `iter()` for vecs yields `&i32`. Destructure to `i32`.\n"
+msgstr ""
+"// `iter()` para vecs yields `&i32`. Destructure to `i32`.\n"
+
+#: src/fn/closures/closure_examples/iter_any.md:28
+msgid "\"2 in vec1: {}\""
+msgstr "\"2 in vec1: {}\""
+
+#: src/fn/closures/closure_examples/iter_any.md:29
+msgid "// `into_iter()` for vecs yields `i32`. No destructuring required.\n"
+msgstr ""
+"// `into_iter()` para vecs yields `i32`. No destructuring required.\n"
+
+#: src/fn/closures/closure_examples/iter_any.md:30
+msgid "\"2 in vec2: {}\""
+msgstr "\"2 in vec2: {}\""
+
+#: src/fn/closures/closure_examples/iter_any.md:32
+msgid ""
+"// `iter()` only borrows `vec1` and its elements, so they can be used again\n"
+msgstr ""
+"// `iter()` only empréstimos `vec1` e its elements, so they pode be usado again\n"
+
+#: src/fn/closures/closure_examples/iter_any.md:33
+msgid "\"vec1 len: {}\""
+msgstr "\"vec1 len: {}\""
+
+#: src/fn/closures/closure_examples/iter_any.md:34
+msgid "\"First element of vec1 is: {}\""
+msgstr "\"Primeiro element of vec1 is: {}\""
+
+#: src/fn/closures/closure_examples/iter_any.md:35
+msgid ""
+"// `into_iter()` does move `vec2` and its elements, so they cannot be used "
+"again\n"
+"    // println!(\"First element of vec2 is: {}\", vec2[0]);\n"
+"    // println!(\"vec2 len: {}\", vec2.len());\n"
+"    // TODO: uncomment two lines above and see compiler errors.\n"
+msgstr ""
+"// `into_iter()` does move `vec2` e its elements, so they não pode be usado again\n"
+"    // println!(\"Primeiro element of vec2 is: {}\", vec2[0]);\n"
+"    // println!(\"vec2 len: {}\", vec2.len());\n"
+"    // TODO: uncomment two lines acima e see compiler erros.\n"
+
+#: src/fn/closures/closure_examples/iter_any.md:43
+msgid "// `iter()` for arrays yields `&i32`.\n"
+msgstr ""
+"// `iter()` para arrays yields `&i32`.\n"
+
+#: src/fn/closures/closure_examples/iter_any.md:44
+msgid "\"2 in array1: {}\""
+msgstr "\"2 in array1: {}\""
+
+#: src/fn/closures/closure_examples/iter_any.md:45
+msgid "// `into_iter()` for arrays yields `i32`.\n"
+msgstr ""
+"// `into_iter()` para arrays yields `i32`.\n"
+
+#: src/fn/closures/closure_examples/iter_any.md:46
+msgid "\"2 in array2: {}\""
+msgstr "\"2 in array2: {}\""
+
+#: src/fn/closures/closure_examples/iter_any.md:52
+msgid ""
+"[`std::iter::Iterator::any`](https://doc.rust-lang.org/std/iter/trait."
+"Iterator.html#method.any)"
+msgstr "[`std::iter::Iterator::any`](https://doc.rust-lang.org/std/iter/trait.Iterator.html#method.any)"
+
+#: src/fn/closures/closure_examples/iter_find.md:3
+msgid ""
+"`Iterator::find` is a function which iterates over an iterator and searches "
+"for the first value which satisfies some condition. If none of the values "
+"satisfy the condition, it returns `None`. Its signature:"
+msgstr "`Iterator::find` is um função which iterates over um iterator e searches para o primeiro valor which satisfies some condition. If none of o valores satisfy o condition, it retorna `None`. Its signature:"
+
+#: src/fn/closures/closure_examples/iter_find.md:12
+msgid ""
+"// `find` takes `&mut self` meaning the caller may be borrowed\n"
+"    // and modified, but not consumed.\n"
+msgstr ""
+"// `find` takes `&mut self` meaning o caller may be emprestadas\n"
+"    // e modified, but not consumed.\n"
+
+#: src/fn/closures/closure_examples/iter_find.md:15
+msgid ""
+"// `FnMut` meaning any captured variable may at most be\n"
+"        // modified, not consumed. `&Self::Item` states it takes\n"
+"        // arguments to the closure by reference.\n"
+msgstr ""
+"// `FnMut` meaning any captured variável may at most be\n"
+"        // modified, not consumed. `&Self::Item` states it takes\n"
+"        // argumentos to o closure by reference.\n"
+
+#: src/fn/closures/closure_examples/iter_find.md:27
+msgid "// `iter()` for vecs yields `&i32`.\n"
+msgstr ""
+"// `iter()` para vecs yields `&i32`.\n"
+
+#: src/fn/closures/closure_examples/iter_find.md:29
+msgid "// `into_iter()` for vecs yields `i32`.\n"
+msgstr ""
+"// `into_iter()` para vecs yields `i32`.\n"
+
+#: src/fn/closures/closure_examples/iter_find.md:32
+msgid ""
+"// `iter()` for vecs yields `&i32`, and we want to reference one of its\n"
+"    // items, so we have to destructure `&&i32` to `i32`\n"
+msgstr ""
+"// `iter()` para vecs yields `&i32`, e we want to reference one of its\n"
+"    // items, so we have to destructure `&&i32` to `i32`\n"
+
+#: src/fn/closures/closure_examples/iter_find.md:34
+msgid "\"Find 2 in vec1: {:?}\""
+msgstr "\"Find 2 in vec1: {:?}\""
+
+#: src/fn/closures/closure_examples/iter_find.md:35
+msgid ""
+"// `into_iter()` for vecs yields `i32`, and we want to reference one of\n"
+"    // its items, so we have to destructure `&i32` to `i32`\n"
+msgstr ""
+"// `into_iter()` para vecs yields `i32`, e we want to reference one of\n"
+"    // its items, so we have to destructure `&i32` to `i32`\n"
+
+#: src/fn/closures/closure_examples/iter_find.md:37
+msgid "\"Find 2 in vec2: {:?}\""
+msgstr "\"Find 2 in vec2: {:?}\""
+
+#: src/fn/closures/closure_examples/iter_find.md:42
+msgid "// `iter()` for arrays yields `&&i32`\n"
+msgstr ""
+"// `iter()` para arrays yields `&&i32`\n"
+
+#: src/fn/closures/closure_examples/iter_find.md:43
+msgid "\"Find 2 in array1: {:?}\""
+msgstr "\"Find 2 in array1: {:?}\""
+
+#: src/fn/closures/closure_examples/iter_find.md:44
+msgid "// `into_iter()` for arrays yields `&i32`\n"
+msgstr ""
+"// `into_iter()` para arrays yields `&i32`\n"
+
+#: src/fn/closures/closure_examples/iter_find.md:45
+msgid "\"Find 2 in array2: {:?}\""
+msgstr "\"Find 2 in array2: {:?}\""
+
+#: src/fn/closures/closure_examples/iter_find.md:49
+msgid ""
+"`Iterator::find` gives you a reference to the item. But if you want the "
+"_index_ of the item, use `Iterator::position`."
+msgstr "`Iterator::find` gives you um reference to o item. But if you want o _index_ of o item, use `Iterator::position`."
+
+#: src/fn/closures/closure_examples/iter_find.md:56
+msgid ""
+"// `iter()` for vecs yields `&i32` and `position()` does not take a "
+"reference, so\n"
+"    // we have to destructure `&i32` to `i32`\n"
+msgstr ""
+"// `iter()` para vecs yields `&i32` e `position()` does not take um reference, so\n"
+"    // we have to destructure `&i32` to `i32`\n"
+
+#: src/fn/closures/closure_examples/iter_find.md:61
+msgid ""
+"// `into_iter()` for vecs yields `i32` and `position()` does not take a "
+"reference, so\n"
+"    // we do not have to destructure    \n"
+msgstr ""
+"// `into_iter()` for vecs yields `i32` and `position()` does not take a reference, so\n"
+"    // we do not have to destructure    \n"
+
+#: src/fn/closures/closure_examples/iter_find.md:70
+msgid ""
+"[`std::iter::Iterator::find`](https://doc.rust-lang.org/std/iter/trait."
+"Iterator.html#method.find)"
+msgstr "[`std::iter::Iterator::find`](https://doc.rust-lang.org/std/iter/trait.Iterator.html#method.find)"
+
+#: src/fn/closures/closure_examples/iter_find.md:72
+msgid ""
+"[`std::iter::Iterator::find_map`](https://doc.rust-lang.org/std/iter/trait."
+"Iterator.html#method.find_map)"
+msgstr "[`std::iter::Iterator::find_map`](https://doc.rust-lang.org/std/iter/trait.Iterator.html#method.find_map)"
+
+#: src/fn/closures/closure_examples/iter_find.md:74
+msgid ""
+"[`std::iter::Iterator::position`](https://doc.rust-lang.org/std/iter/trait."
+"Iterator.html#method.position)"
+msgstr "[`std::iter::Iterator::position`](https://doc.rust-lang.org/std/iter/trait.Iterator.html#method.position)"
+
+#: src/fn/closures/closure_examples/iter_find.md:76
+msgid ""
+"[`std::iter::Iterator::rposition`](https://doc.rust-lang.org/std/iter/trait."
+"Iterator.html#method.rposition)"
+msgstr "[`std::iter::Iterator::rposition`](https://doc.rust-lang.org/std/iter/trait.Iterator.html#method.rposition)"
+
+#: src/fn/hof.md:3
+msgid ""
+"Rust provides Higher Order Functions (HOF). These are functions that take "
+"one or more functions and/or produce a more useful function. HOFs and lazy "
+"iterators give Rust its functional flavor."
+msgstr "Rust provides Higher Order Funções (HOF). Estes are funções aquele take one ou more funções e/ou produce um more useful função. HOFs e lazy iterators give Rust its functional flavor."
+
+#: src/fn/hof.md:13
+msgid "\"Find the sum of all the numbers with odd squares under 1000\""
+msgstr "\"Find o sum of all o números com odd squares under 1000\""
+
+#: src/fn/hof.md:16
+msgid ""
+"// Imperative approach\n"
+"    // Declare accumulator variable\n"
+msgstr ""
+"// Imperative approach\n"
+"    // Declare accumulator variável\n"
+
+#: src/fn/hof.md:19
+msgid "// Iterate: 0, 1, 2, ... to infinity\n"
+msgstr ""
+"// Iterate: 0, 1, 2, ... to infinity\n"
+
+#: src/fn/hof.md:21
+msgid "// Square the number\n"
+msgstr ""
+"// Square o número\n"
+
+#: src/fn/hof.md:25
+msgid "// Break loop if exceeded the upper limit\n"
+msgstr ""
+"// Break loop if exceeded o upper limit\n"
+
+#: src/fn/hof.md:28
+msgid "// Accumulate value, if it's odd\n"
+msgstr ""
+"// Accumulate valor, if it's odd\n"
+
+#: src/fn/hof.md:32
+msgid "\"imperative style: {}\""
+msgstr "\"imperative style: {}\""
+
+#: src/fn/hof.md:34
+msgid "// Functional approach\n"
+msgstr ""
+"// Functional approach\n"
+
+#: src/fn/hof.md:36
+msgid "// All natural numbers squared\n"
+msgstr ""
+"// All natural números squared\n"
+
+#: src/fn/hof.md:37
+msgid "// Below upper limit\n"
+msgstr ""
+"// Abaixo upper limit\n"
+
+#: src/fn/hof.md:38
+msgid "// That are odd\n"
+msgstr ""
+"// Aquele are odd\n"
+
+#: src/fn/hof.md:39
+msgid "// Sum them\n"
+msgstr ""
+"// Sum them\n"
+
+#: src/fn/hof.md:40
+msgid "\"functional style: {}\""
+msgstr "\"functional style: {}\""
+
+#: src/fn/hof.md:44
+msgid ""
+"[Option](https://doc.rust-lang.org/core/option/enum.Option.html) and "
+"[Iterator](https://doc.rust-lang.org/core/iter/trait.Iterator.html) "
+"implement their fair share of HOFs."
+msgstr "[Option](https://doc.rust-lang.org/core/option/enum.Option.html) e [Iterator](https://doc.rust-lang.org/core/iter/trait.Iterator.html) implement their fair share of HOFs."
+
+#: src/fn/diverging.md:3
+msgid ""
+"Diverging functions never return. They are marked using `!`, which is an "
+"empty type."
+msgstr "Diverging funções never retorna. They are marked usando `!`, which is um vazio tipo."
+
+#: src/fn/diverging.md:7 src/fn/diverging.md:35
+msgid "\"This call never returns.\""
+msgstr "\"Este call never retorna.\""
+
+#: src/fn/diverging.md:11
+msgid ""
+"As opposed to all the other types, this one cannot be instantiated, because "
+"the set of all possible values this type can have is empty. Note that, it is "
+"different from the `()` type, which has exactly one possible value."
+msgstr "As opposed to all o other tipos, este one não pode be instantiated, porque o set of all possible valores este tipo pode have is vazio. Note aquele, it is diferente do `()` tipo, which has exactly one possible valor."
+
+#: src/fn/diverging.md:15
+msgid ""
+"For example, this function returns as usual, although there is no "
+"information in the return value."
+msgstr "Para example, este função retorna as usual, although there is no information in o retorna valor."
+
+#: src/fn/diverging.md:25
+msgid "\"This function returns and you can see this line.\""
+msgstr "\"Este função retorna e you pode see este line.\""
+
+#: src/fn/diverging.md:29
+msgid ""
+"As opposed to this function, which will never return the control back to the "
+"caller."
+msgstr "As opposed to este função, which vai never retorna o control back to o caller."
+
+#: src/fn/diverging.md:36
+msgid "\"You will never see this line!\""
+msgstr "\"You vai never see este line!\""
+
+#: src/fn/diverging.md:40
+msgid ""
+"Although this might seem like an abstract concept, it is actually very "
+"useful and often handy. The main advantage of this type is that it can be "
+"cast to any other type, making it versatile in situations where an exact "
+"type is required, such as in match branches. This flexibility allows us to "
+"write code like this:"
+msgstr "Although este might seem like um abstract concept, it is actually very useful e often handy. O main advantage of este tipo is aquele it pode be cast to any other tipo, making it versatile in situations where um exact tipo is required, such as in match branches. Este flexibility allows us to write code like este:"
+
+#: src/fn/diverging.md:50
+msgid ""
+"// Notice that the return type of this match expression must be u32\n"
+"            // because of the type of the \"addition\" variable.\n"
+msgstr ""
+"// Notice aquele o retorna tipo of este match expression deve be u32\n"
+"            // porque of o tipo of o \"addition\" variável.\n"
+
+#: src/fn/diverging.md:53
+msgid "// The \"i\" variable is of type u32, which is perfectly fine.\n"
+msgstr ""
+"// O \"i\" variável is of tipo u32, which is perfectly fine.\n"
+
+#: src/fn/diverging.md:55
+msgid ""
+"// On the other hand, the \"continue\" expression does not return\n"
+"                // u32, but it is still fine, because it never returns and "
+"therefore\n"
+"                // does not violate the type requirements of the match "
+"expression.\n"
+msgstr ""
+"// On o other hand, o \"continue\" expression does not retorna\n"
+"                // u32, but it is still fine, porque it never retorna e therefore\n"
+"                // does not violate o tipo requirements of o match expression.\n"
+
+#: src/fn/diverging.md:64
+msgid "\"Sum of odd numbers up to 9 (excluding): {}\""
+msgstr "\"Sum of odd números up to 9 (excluding): {}\""
+
+#: src/fn/diverging.md:68
+msgid ""
+"It is also the return type of functions that loop forever (e.g. `loop {}`) "
+"like network servers or functions that terminate the process (e.g. `exit()`)."
+msgstr "It is also o retorna tipo of funções aquele loop forever (e.g. `loop {}`) like network servers ou funções aquele terminate o process (e.g. `exit()`)."
+
+#: src/mod.md:3
+msgid ""
+"Rust provides a powerful module system that can be used to hierarchically "
+"split code in logical units (modules), and manage visibility (public/"
+"private) between them."
+msgstr "Rust provides um powerful módulo system aquele pode be usado to hierarchically split code in logical units (módulos), e manage visibility (público/privado) between them."
+
+#: src/mod.md:7
+msgid ""
+"A module is a collection of items: functions, structs, traits, `impl` "
+"blocks, and even other modules."
+msgstr "UM módulo is um collection of items: funções, structs, traits, `impl` blocks, e even other módulos."
+
+#: src/mod/visibility.md:3
+msgid ""
+"By default, the items in a module have private visibility, but this can be "
+"overridden with the `pub` modifier. Only the public items of a module can be "
+"accessed from outside the module scope."
+msgstr "By default, o items in um módulo have privado visibility, but este pode be overridden com o `pub` modifier. Only o público items of um módulo pode be accessed de fora o módulo scope."
+
+#: src/mod/visibility.md:8
+msgid "// A module named `my_mod`\n"
+msgstr ""
+"// UM módulo named `my_mod`\n"
+
+#: src/mod/visibility.md:10
+msgid "// Items in modules default to private visibility.\n"
+msgstr ""
+"// Items in módulos default to privado visibility.\n"
+
+#: src/mod/visibility.md:12
+msgid "\"called `my_mod::private_function()`\""
+msgstr "\"chamado `my_mod::private_function()`\""
+
+#: src/mod/visibility.md:15
+msgid "// Use the `pub` modifier to override default visibility.\n"
+msgstr ""
+"// Usa o `pub` modifier to override default visibility.\n"
+
+#: src/mod/visibility.md:17
+msgid "\"called `my_mod::function()`\""
+msgstr "\"chamado `my_mod::function()`\""
+
+#: src/mod/visibility.md:20
+msgid ""
+"// Items can access other items in the same module,\n"
+"    // even when private.\n"
+msgstr ""
+"// Items pode access other items in o mesmo módulo,\n"
+"    // even when privado.\n"
+
+#: src/mod/visibility.md:23
+msgid "\"called `my_mod::indirect_access()`, that\\n> \""
+msgstr "\"chamado `my_mod::indirect_access()`, aquele\\n> \""
+
+#: src/mod/visibility.md:27
+msgid "// Modules can also be nested\n"
+msgstr ""
+"// Módulos pode also be nested\n"
+
+#: src/mod/visibility.md:30
+msgid "\"called `my_mod::nested::function()`\""
+msgstr "\"chamado `my_mod::nested::function()`\""
+
+#: src/mod/visibility.md:35
+msgid "\"called `my_mod::nested::private_function()`\""
+msgstr "\"chamado `my_mod::nested::private_function()`\""
+
+#: src/mod/visibility.md:38
+msgid ""
+"// Functions declared using `pub(in path)` syntax are only visible\n"
+"        // within the given path. `path` must be a parent or ancestor "
+"module\n"
+msgstr ""
+"// Funções declared usando `pub(in path)` syntax are only visible\n"
+"        // within o given path. `path` deve be um parent ou ancestor módulo\n"
+
+#: src/mod/visibility.md:41
+msgid "\"called `my_mod::nested::public_function_in_my_mod()`, that\\n> \""
+msgstr "\"chamado `my_mod::nested::public_function_in_my_mod()`, aquele\\n> \""
+
+#: src/mod/visibility.md:45
+msgid ""
+"// Functions declared using `pub(self)` syntax are only visible within\n"
+"        // the current module, which is the same as leaving them private\n"
+msgstr ""
+"// Funções declared usando `pub(self)` syntax are only visible within\n"
+"        // o current módulo, which is o mesmo as leaving them privado\n"
+
+#: src/mod/visibility.md:48
+msgid "\"called `my_mod::nested::public_function_in_nested()`\""
+msgstr "\"chamado `my_mod::nested::public_function_in_nested()`\""
+
+#: src/mod/visibility.md:51
+msgid ""
+"// Functions declared using `pub(super)` syntax are only visible within\n"
+"        // the parent module\n"
+msgstr ""
+"// Funções declared usando `pub(super)` syntax are only visible within\n"
+"        // o parent módulo\n"
+
+#: src/mod/visibility.md:54
+msgid "\"called `my_mod::nested::public_function_in_super_mod()`\""
+msgstr "\"chamado `my_mod::nested::public_function_in_super_mod()`\""
+
+#: src/mod/visibility.md:59
+msgid "\"called `my_mod::call_public_function_in_my_mod()`, that\\n> \""
+msgstr "\"chamado `my_mod::call_public_function_in_my_mod()`, aquele\\n> \""
+
+#: src/mod/visibility.md:61
+msgid "\"> \""
+msgstr "\"> \""
+
+#: src/mod/visibility.md:65
+msgid "// pub(crate) makes functions visible only within the current crate\n"
+msgstr ""
+"// pub(crate) makes funções visible only within o current crate\n"
+
+#: src/mod/visibility.md:67
+msgid "\"called `my_mod::public_function_in_crate()`\""
+msgstr "\"chamado `my_mod::public_function_in_crate()`\""
+
+#: src/mod/visibility.md:70
+msgid "// Nested modules follow the same rules for visibility\n"
+msgstr ""
+"// Nested módulos follow o mesmo rules para visibility\n"
+
+#: src/mod/visibility.md:74
+msgid "\"called `my_mod::private_nested::function()`\""
+msgstr "\"chamado `my_mod::private_nested::function()`\""
+
+#: src/mod/visibility.md:77
+msgid ""
+"// Private parent items will still restrict the visibility of a child item,\n"
+"        // even if it is declared as visible within a bigger scope.\n"
+msgstr ""
+"// Privado parent items vai still restrict o visibility of um child item,\n"
+"        // even if it is declared as visible within um bigger scope.\n"
+
+#: src/mod/visibility.md:81
+msgid "\"called `my_mod::private_nested::restricted_function()`\""
+msgstr "\"chamado `my_mod::private_nested::restricted_function()`\""
+
+#: src/mod/visibility.md:87 src/mod/use.md:25 src/mod/super.md:8
+#: src/mod/split.md:24
+msgid "\"called `function()`\""
+msgstr "\"chamado `function()`\""
+
+#: src/mod/visibility.md:91
+msgid ""
+"// Modules allow disambiguation between items that have the same name.\n"
+msgstr ""
+"// Módulos allow disambiguation between items aquele have o mesmo name.\n"
+
+#: src/mod/visibility.md:95
+msgid ""
+"// Public items, including those inside nested modules, can be\n"
+"    // accessed from outside the parent module.\n"
+msgstr ""
+"// Público items, including aqueles dentro nested módulos, pode be\n"
+"    // accessed de fora o parent módulo.\n"
+
+#: src/mod/visibility.md:101
+msgid "// pub(crate) items can be called from anywhere in the same crate\n"
+msgstr ""
+"// pub(crate) items pode be chamado de anywhere in o mesmo crate\n"
+
+#: src/mod/visibility.md:104
+msgid ""
+"// pub(in path) items can only be called from within the module specified\n"
+"    // Error! function `public_function_in_my_mod` is private\n"
+"    //my_mod::nested::public_function_in_my_mod();\n"
+"    // TODO ^ Try uncommenting this line\n"
+msgstr ""
+"// pub(in path) items pode only be chamado de within o módulo specified\n"
+"    // Erro! função `public_function_in_my_mod` is privado\n"
+"    //my_mod::nested::public_function_in_my_mod();\n"
+"    // TODO ^ Tente uncommenting este line\n"
+
+#: src/mod/visibility.md:109
+msgid ""
+"// Private items of a module cannot be directly accessed, even if\n"
+"    // nested in a public module:\n"
+msgstr ""
+"// Privado items of um módulo não pode be directly accessed, even if\n"
+"    // nested in um público módulo:\n"
+
+#: src/mod/visibility.md:112
+msgid ""
+"// Error! `private_function` is private\n"
+"    //my_mod::private_function();\n"
+"    // TODO ^ Try uncommenting this line\n"
+msgstr ""
+"// Erro! `private_function` is privado\n"
+"    //my_mod::private_function();\n"
+"    // TODO ^ Tente uncommenting este line\n"
+
+#: src/mod/visibility.md:116
+msgid ""
+"// Error! `private_function` is private\n"
+"    //my_mod::nested::private_function();\n"
+"    // TODO ^ Try uncommenting this line\n"
+msgstr ""
+"// Erro! `private_function` is privado\n"
+"    //my_mod::nested::private_function();\n"
+"    // TODO ^ Tente uncommenting este line\n"
+
+#: src/mod/visibility.md:120
+msgid ""
+"// Error! `private_nested` is a private module\n"
+"    //my_mod::private_nested::function();\n"
+"    // TODO ^ Try uncommenting this line\n"
+msgstr ""
+"// Erro! `private_nested` is um privado módulo\n"
+"    //my_mod::private_nested::função();\n"
+"    // TODO ^ Tente uncommenting este line\n"
+
+#: src/mod/visibility.md:124
+msgid ""
+"// Error! `private_nested` is a private module\n"
+"    //my_mod::private_nested::restricted_function();\n"
+"    // TODO ^ Try uncommenting this line\n"
+msgstr ""
+"// Erro! `private_nested` is um privado módulo\n"
+"    //my_mod::private_nested::restricted_function();\n"
+"    // TODO ^ Tente uncommenting este line\n"
+
+#: src/mod/struct_visibility.md:3
+msgid ""
+"Structs have an extra level of visibility with their fields. The visibility "
+"defaults to private, and can be overridden with the `pub` modifier. This "
+"visibility only matters when a struct is accessed from outside the module "
+"where it is defined, and has the goal of hiding information (encapsulation)."
+msgstr "Structs have um extra level of visibility com their campos. O visibility defaults to privado, e pode be overridden com o `pub` modifier. Este visibility only matters when um struct is accessed de fora o módulo where it is defined, e has o goal of hiding information (encapsulation)."
+
+#: src/mod/struct_visibility.md:10
+msgid "// A public struct with a public field of generic type `T`\n"
+msgstr ""
+"// UM público struct com um público campo of generic tipo `T`\n"
+
+#: src/mod/struct_visibility.md:15
+msgid "// A public struct with a private field of generic type `T`\n"
+msgstr ""
+"// UM público struct com um privado campo of generic tipo `T`\n"
+
+#: src/mod/struct_visibility.md:21
+msgid "// A public constructor method\n"
+msgstr ""
+"// UM público constructor método\n"
+
+#: src/mod/struct_visibility.md:31
+msgid "// Public structs with public fields can be constructed as usual\n"
+msgstr ""
+"// Público structs com público campos pode be constructed as usual\n"
+
+#: src/mod/struct_visibility.md:32
+msgid "\"public information\""
+msgstr "\"público information\""
+
+#: src/mod/struct_visibility.md:34
+msgid "// and their fields can be normally accessed.\n"
+msgstr ""
+"// e their campos pode be normally accessed.\n"
+
+#: src/mod/struct_visibility.md:35
+msgid "\"The open box contains: {}\""
+msgstr "\"O open box contains: {}\""
+
+#: src/mod/struct_visibility.md:37
+msgid ""
+"// Public structs with private fields cannot be constructed using field "
+"names.\n"
+"    // Error! `ClosedBox` has private fields\n"
+"    //let closed_box = my::ClosedBox { contents: \"classified "
+"information\" };\n"
+"    // TODO ^ Try uncommenting this line\n"
+msgstr ""
+"// Público structs com privado campos não pode be constructed usando campo names.\n"
+"    // Erro! `ClosedBox` has privado campos\n"
+"    //let closed_box = my::FechadBox { contents: \"classified information\" };\n"
+"    // TODO ^ Tente uncommenting este line\n"
+
+#: src/mod/struct_visibility.md:42
+msgid ""
+"// However, structs with private fields can be created using\n"
+"    // public constructors\n"
+msgstr ""
+"// However, structs com privado campos pode be created usando\n"
+"    // público constructors\n"
+
+#: src/mod/struct_visibility.md:44
+msgid "\"classified information\""
+msgstr "\"classified information\""
+
+#: src/mod/struct_visibility.md:46
+msgid ""
+"// and the private fields of a public struct cannot be accessed.\n"
+"    // Error! The `contents` field is private\n"
+"    //println!(\"The closed box contains: {}\", _closed_box.contents);\n"
+"    // TODO ^ Try uncommenting this line\n"
+msgstr ""
+"// e o privado campos of um público struct não pode be accessed.\n"
+"    // Erro! O `contents` campo is privado\n"
+"    //println!(\"O closed box contains: {}\", _closed_box.contents);\n"
+"    // TODO ^ Tente uncommenting este line\n"
+
+#: src/mod/struct_visibility.md:55
+msgid "[generics](../generics.md) and [methods](../fn/methods.md)"
+msgstr "[generics](../generics.md) e [methods](../fn/methods.md)"
+
+#: src/mod/use.md:3
+msgid ""
+"The `use` declaration can be used to bind a full path to a new name, for "
+"easier access. It is often used like this:"
+msgstr "O `use` declaration pode be usado to bind um full path to um novo name, para easier access. It is often usado like este:"
+
+#: src/mod/use.md:18
+msgid "You can use the `as` keyword to bind imports to a different name:"
+msgstr "You pode use o `as` keyword to bind imports to um diferente name:"
+
+#: src/mod/use.md:21
+msgid "// Bind the `deeply::nested::function` path to `other_function`.\n"
+msgstr ""
+"// Bind o `deeply::nested::function` path to `other_function`.\n"
+
+#: src/mod/use.md:31
+msgid "\"called `deeply::nested::function()`\""
+msgstr "\"chamado `deeply::nested::function()`\""
+
+#: src/mod/use.md:37
+msgid "// Easier access to `deeply::nested::function`\n"
+msgstr ""
+"// Easier access to `deeply::nested::function`\n"
+
+#: src/mod/use.md:40
+msgid "\"Entering block\""
+msgstr "\"Entering block\""
+
+#: src/mod/use.md:42
+msgid ""
+"// This is equivalent to `use deeply::nested::function as function`.\n"
+"        // This `function()` will shadow the outer one.\n"
+msgstr ""
+"// Este is equivalent to `use deeply::nested::function as function`.\n"
+"        // Este `function()` vai shadow o outer one.\n"
+
+#: src/mod/use.md:46
+msgid ""
+"// `use` bindings have a local scope. In this case, the\n"
+"        // shadowing of `function()` is only in this block.\n"
+msgstr ""
+"// `use` bindings have a local scope. In this case, the\n"
+"        // shadowing of `function()` is only in this block.\n"
+
+#: src/mod/use.md:50
+msgid "\"Leaving block\""
+msgstr "\"Leaving block\""
+
+#: src/mod/super.md:3
+msgid ""
+"The `super` and `self` keywords can be used in the path to remove ambiguity "
+"when accessing items and to prevent unnecessary hardcoding of paths."
+msgstr "O `super` e `self` keywords pode be usado in o path to remove ambiguity when accessing items e to prevent unnecessary hardcoding of paths."
+
+#: src/mod/super.md:13
+msgid "\"called `cool::function()`\""
+msgstr "\"chamado `cool::function()`\""
+
+#: src/mod/super.md:19 src/mod/split.md:49
+msgid "\"called `my::function()`\""
+msgstr "\"chamado `my::function()`\""
+
+#: src/mod/super.md:24
+msgid "\"called `my::cool::function()`\""
+msgstr "\"chamado `my::cool::function()`\""
+
+#: src/mod/super.md:29
+msgid "// Let's access all the functions named `function` from this scope!\n"
+msgstr ""
+"// Let's access all o funções named `function` de este scope!\n"
+
+#: src/mod/super.md:30
+msgid "\"called `my::indirect_call()`, that\\n> \""
+msgstr "\"chamado `my::indirect_call()`, aquele\\n> \""
+
+#: src/mod/super.md:32
+msgid ""
+"// The `self` keyword refers to the current module scope - in this case "
+"`my`.\n"
+"        // Calling `self::function()` and calling `function()` directly both "
+"give\n"
+"        // the same result, because they refer to the same function.\n"
+msgstr ""
+"// O `self` keyword refers to o current módulo scope - in este case `my`.\n"
+"        // Chamaing `self::function()` e calling `function()` directly both give\n"
+"        // o mesmo resultado, porque they refer to o mesma função.\n"
+
+#: src/mod/super.md:38
+msgid "// We can also use `self` to access another module inside `my`:\n"
+msgstr ""
+"// We pode also use `self` to access another módulo dentro `my`:\n"
+
+#: src/mod/super.md:41
+msgid ""
+"// The `super` keyword refers to the parent scope (outside the `my` "
+"module).\n"
+msgstr ""
+"// O `super` keyword refers to o parent scope (fora o `my` módulo).\n"
+
+#: src/mod/super.md:44
+msgid ""
+"// This will bind to the `cool::function` in the *crate* scope.\n"
+"        // In this case the crate scope is the outermost scope.\n"
+msgstr ""
+"// This will bind to the `cool::function` in the *crate* scope.\n"
+"        // In this case the crate scope is the outermost scope.\n"
+
+#: src/mod/split.md:3
+msgid ""
+"Modules can be mapped to a file/directory hierarchy. Let's break down the "
+"[visibility example](visibility.md) in files:"
+msgstr "Módulos pode be mapped to um arquivo/directory hierarchy. Let's break down o [visibility example](visibility.md) in arquivos:"
+
+#: src/mod/split.md:16
+msgid "In `split.rs`:"
+msgstr "In `split.rs`:"
+
+#: src/mod/split.md:19
+msgid ""
+"// This declaration will look for a file named `my.rs` and will\n"
+"// insert its contents inside a module named `my` under this scope\n"
+msgstr ""
+"// Este declaration vai look para um arquivo named `my.rs` e vai\n"
+"// insert its contents dentro um módulo named `my` under este scope\n"
+
+#: src/mod/split.md:39
+msgid "In `my.rs`:"
+msgstr "In `my.rs`:"
+
+#: src/mod/split.md:42
+msgid ""
+"// Similarly `mod inaccessible` and `mod nested` will locate the `nested."
+"rs`\n"
+"// and `inaccessible.rs` files and insert them here under their respective\n"
+"// modules\n"
+msgstr ""
+"// Similarly `mod inaccessible` e `mod nested` vai locate o `nested.rs`\n"
+"// e `inaccessible.rs` arquivos e insert them here under their respective\n"
+"// módulos\n"
+
+#: src/mod/split.md:53
+msgid "\"called `my::private_function()`\""
+msgstr "\"chamado `my::private_function()`\""
+
+#: src/mod/split.md:57
+msgid "\"called `my::indirect_access()`, that\\n> \""
+msgstr "\"chamado `my::indirect_access()`, aquele\\n> \""
+
+#: src/mod/split.md:63
+msgid "In `my/nested.rs`:"
+msgstr "In `my/nested.rs`:"
+
+#: src/mod/split.md:67
+msgid "\"called `my::nested::function()`\""
+msgstr "\"chamado `my::nested::function()`\""
+
+#: src/mod/split.md:72
+msgid "\"called `my::nested::private_function()`\""
+msgstr "\"chamado `my::nested::private_function()`\""
+
+#: src/mod/split.md:76
+msgid "In `my/inaccessible.rs`:"
+msgstr "In `my/inaccessible.rs`:"
+
+#: src/mod/split.md:81
+msgid "\"called `my::inaccessible::public_function()`\""
+msgstr "\"chamado `my::inaccessible::public_function()`\""
+
+#: src/mod/split.md:85
+msgid "Let's check that things still work as before:"
+msgstr "Let's check aquele things still work as before:"
+
+#: src/crates.md:3
+msgid ""
+"A crate is a compilation unit in Rust. Whenever `rustc some_file.rs` is "
+"called, `some_file.rs` is treated as the _crate file_. If `some_file.rs` has "
+"`mod` declarations in it, then the contents of the module files would be "
+"inserted in places where `mod` declarations in the crate file are found, "
+"_before_ running the compiler over it. In other words, modules do _not_ get "
+"compiled individually, only crates get compiled."
+msgstr "A crate is a compilation unit in Rust. Whenever `rustc some_file.rs` is called, `some_file.rs` is treated as the _crate file_. If `some_file.rs` has `mod` declarations in it, then the contents of the module files would be inserted in places where `mod` declarations in the crate file are found, _before_ running the compiler over it. In other words, modules do _not_ get compiled individually, only crates get compiled."
+
+#: src/crates.md:10
+msgid ""
+"A crate can be compiled into a binary or into a library. By default, `rustc` "
+"will produce a binary from a crate. This behavior can be overridden by "
+"passing the `--crate-type` flag to `lib`."
+msgstr "UM crate pode be compiled em um binary ou em um library. By default, `rustc` vai produce um binary de um crate. Este behavior pode be overridden by passing o `--crate-type` flag to `lib`."
+
+#: src/crates/lib.md:3
+msgid "Let's create a library, and then see how to link it to another crate."
+msgstr "Let's create a library, and then see how to link it to another crate."
+
+#: src/crates/lib.md:5
+msgid "In `rary.rs`:"
+msgstr "In `rary.rs`:"
+
+#: src/crates/lib.md:9 src/attribute/crate.md:19
+msgid "\"called rary's `public_function()`\""
+msgstr "\"chamado rary's `public_function()`\""
+
+#: src/crates/lib.md:13 src/attribute/crate.md:23
+msgid "\"called rary's `private_function()`\""
+msgstr "\"chamado rary's `private_function()`\""
+
+#: src/crates/lib.md:17 src/attribute/crate.md:27
+msgid "\"called rary's `indirect_access()`, that\\n> \""
+msgstr "\"chamado rary's `indirect_access()`, aquele\\n> \""
+
+#: src/crates/lib.md:29
+msgid ""
+"Libraries get prefixed with \"lib\", and by default they get named after "
+"their crate file, but this default name can be overridden by passing the `--"
+"crate-name` option to `rustc` or by using the [`crate_name` attribute](../"
+"attribute/crate.md)."
+msgstr "Libraries get prefixed com \"lib\", e by default they get named after their crate arquivo, but este default name pode be overridden by passing o `--crate-name` option to `rustc` ou by usando o [`crate_name` attribute](../attribute/crate.md)."
+
+#: src/crates/using_lib.md:3
+msgid ""
+"To link a crate to this new library you may use `rustc`'s `--extern` flag. "
+"All of its items will then be imported under a module named the same as the "
+"library. This module generally behaves the same way as any other module."
+msgstr "To link um crate to este novo library you may use `rustc`'s `--extern` flag. All of its items vai then be imported under um módulo named o mesmo as o library. Este módulo generally behaves o mesmo way as any other módulo."
+
+#: src/crates/using_lib.md:8
+msgid ""
+"// extern crate rary; // May be required for Rust 2015 edition or earlier\n"
+msgstr ""
+"// extern crate rary; // May be required para Rust 2015 edition ou earlier\n"
+
+#: src/crates/using_lib.md:13
+msgid ""
+"// Error! `private_function` is private\n"
+"    //rary::private_function();\n"
+msgstr ""
+"// Erro! `private_function` is privado\n"
+"    //rary::private_function();\n"
+
+#: src/cargo.md:3
+msgid ""
+"`cargo` is the official Rust package management tool. It has lots of really "
+"useful features to improve code quality and developer velocity! These include"
+msgstr "`cargo` is o official Rust package management tool. It has lots of really useful features to improve code quality e developer velocity! Estes include"
+
+#: src/cargo.md:6
+msgid ""
+"Dependency management and integration with [crates.io](https://crates.io) "
+"(the official Rust package registry)"
+msgstr "Dependency management e integration com [crates.io](https://crates.io) (o official Rust package registry)"
+
+#: src/cargo.md:8
+msgid "Awareness of unit tests"
+msgstr "Awareness of unit tests"
+
+#: src/cargo.md:9
+msgid "Awareness of benchmarks"
+msgstr "Awareness of benchmarks"
+
+#: src/cargo.md:11
+msgid ""
+"This chapter will go through some quick basics, but you can find the "
+"comprehensive docs in [The Cargo Book](https://doc.rust-lang.org/cargo/)."
+msgstr "Este chapter vai go through some quick basics, but you pode find o comprehensive docs in [The Cargo Book](https://doc.rust-lang.org/cargo/)."
+
+#: src/cargo/deps.md:3
+msgid ""
+"Most programs have dependencies on some libraries. If you have ever managed "
+"dependencies by hand, you know how much of a pain this can be. Luckily, the "
+"Rust ecosystem comes standard with `cargo`! `cargo` can manage dependencies "
+"for a project."
+msgstr "Most programs have dependencies on some libraries. If you have ever managed dependencies by hand, you know how much of um pain este pode be. Luckily, o Rust ecosystem comes standard com `cargo`! `cargo` pode manage dependencies para um project."
+
+#: src/cargo/deps.md:8
+msgid "To create a new Rust project,"
+msgstr "To create um novo Rust project,"
+
+#: src/cargo/deps.md:11
+msgid "# A binary\n"
+msgstr ""
+"# UM binary\n"
+
+#: src/cargo/deps.md:13
+msgid "# A library\n"
+msgstr ""
+"# UM library\n"
+
+#: src/cargo/deps.md:18
+msgid ""
+"For the rest of this chapter, let's assume we are making a binary, rather "
+"than a library, but all of the concepts are the same."
+msgstr "Para o rest of este chapter, let's assume we are making um binary, rather than um library, but all of o concepts are o mesmo."
+
+#: src/cargo/deps.md:21
+msgid "After the above commands, you should see a file hierarchy like this:"
+msgstr "After o acima commands, you deve see um arquivo hierarchy like este:"
+
+#: src/cargo/deps.md:35
+msgid ""
+"The `main.rs` is the root source file for your new `foo` project -- nothing "
+"new there. The `Cargo.toml` is the config file for `cargo` for this project. "
+"If you look inside it, you should see something like this:"
+msgstr "O `main.rs` is o root source arquivo para your novo `foo` project -- nothing novo there. O `Cargo.toml` is o config arquivo para `cargo` para este project. If you look dentro it, you deve see something like este:"
+
+#: src/cargo/deps.md:39
+msgid ""
+"```toml\n"
+"[package]\n"
+"name = \"foo\"\n"
+"version = \"0.1.0\"\n"
+"authors = [\"mark\"]\n"
+"\n"
+"[dependencies]\n"
+"```"
+msgstr ""
+"```toml\n"
+"[package]\n"
+"name = \"foo\"\n"
+"version = \"0.1.0\"\n"
+"authors = [\"mark\"]\n"
+"\n"
+"[dependencies]\n"
+"```"
+
+#: src/cargo/deps.md:48
+msgid ""
+"The `name` field under `[package]` determines the name of the project. This "
+"is used by `crates.io` if you publish the crate (more later). It is also the "
+"name of the output binary when you compile."
+msgstr "O `name` campo under `[package]` determines o name of o project. Este is usado by `crates.io` if you publish o crate (more later). It is also o name of a saída binary when you compile."
+
+#: src/cargo/deps.md:52
+msgid ""
+"The `version` field is a crate version number using [Semantic Versioning]"
+"(http://semver.org/)."
+msgstr "O `version` campo is um crate version número usando [Semantic Versioning](http://semver.org/)."
+
+#: src/cargo/deps.md:55
+msgid ""
+"The `authors` field is a list of authors used when publishing the crate."
+msgstr "O `authors` campo is um list of authors usado when publishing o crate."
+
+#: src/cargo/deps.md:57
+msgid ""
+"The `[dependencies]` section lets you add dependencies for your project."
+msgstr "O `[dependencies]` section lets you add dependencies para your project."
+
+#: src/cargo/deps.md:59
+msgid ""
+"For example, suppose that we want our program to have a great CLI. You can "
+"find lots of great packages on [crates.io](https://crates.io) (the official "
+"Rust package registry). One popular choice is [clap](https://crates.io/"
+"crates/clap). As of this writing, the most recent published version of "
+"`clap` is `2.27.1`. To add a dependency to our program, we can simply add "
+"the following to our `Cargo.toml` under `[dependencies]`: `clap = "
+"\"2.27.1\"`. And that's it! You can start using `clap` in your program."
+msgstr "Para example, suppose aquele we want our program to have um great CLI. You pode find lots of great packages on [crates.io](https://crates.io) (o official Rust package registry). One popular choice is [clap](https://crates.io/crates/clap). As of este writing, o most recent published version of `clap` is `2.27.1`. To add um dependency to our program, we pode simply add o following to our `Cargo.toml` under `[dependencies]`: `clap = \"2.27.1\"`. E aquele's it! You pode start usando `clap` in your program."
+
+#: src/cargo/deps.md:67
+msgid ""
+"`cargo` also supports [other types of dependencies](https://doc.rust-lang."
+"org/cargo/reference/specifying-dependencies.html). Here is just a small "
+"sampling:"
+msgstr "`cargo` also supports [other types of dependencies](https://doc.rust-lang.org/cargo/reference/specifying-dependencies.html). Here is just um small sampling:"
+
+#: src/cargo/deps.md:70
+msgid ""
+"```toml\n"
+"[package]\n"
+"name = \"foo\"\n"
+"version = \"0.1.0\"\n"
+"authors = [\"mark\"]\n"
+"\n"
+"[dependencies]\n"
+"clap = \"2.27.1\" # from crates.io\n"
+"rand = { git = \"https://github.com/rust-lang-nursery/rand\" } # from online "
+"repo\n"
+"bar = { path = \"../bar\" } # from a path in the local filesystem\n"
+"```"
+msgstr ""
+"```toml\n"
+"[package]\n"
+"name = \"foo\"\n"
+"version = \"0.1.0\"\n"
+"authors = [\"mark\"]\n"
+"\n"
+"[dependencies]\n"
+"clap = \"2.27.1\" # from crates.io\n"
+"rand = { git = \"https://github.com/rust-lang-nursery/rand\" } # from online repo\n"
+"bar = { path = \"../bar\" } # from a path in the local filesystem\n"
+"```"
+
+#: src/cargo/deps.md:82
+msgid ""
+"`cargo` is more than a dependency manager. All of the available "
+"configuration options are listed in the [format specification](https://doc."
+"rust-lang.org/cargo/reference/manifest.html) of `Cargo.toml`."
+msgstr "`cargo` is more than a dependency manager. All of the available configuration options are listed in the [format specification](https://doc.rust-lang.org/cargo/reference/manifest.html) of `Cargo.toml`."
+
+#: src/cargo/deps.md:86
+msgid ""
+"To build our project we can execute `cargo build` anywhere in the project "
+"directory (including subdirectories!). We can also do `cargo run` to build "
+"and run. Notice that these commands will resolve all dependencies, download "
+"crates if needed, and build everything, including your crate. (Note that it "
+"only rebuilds what it has not already built, similar to `make`)."
+msgstr "To build our project we pode execute `cargo build` anywhere in o project directory (including subdirectories!). We pode also do `cargo run` to build e run. Notice aquele estes commands vai resolve all dependencies, download crates if needed, e build everything, including your crate. (Note aquele it only rebuilds what it has not already built, similar to `make`)."
+
+#: src/cargo/deps.md:92
+msgid "Voila! That's all there is to it!"
+msgstr "Voila! Aquele's all there is to it!"
+
+#: src/cargo/conventions.md:3
+msgid "In the previous chapter, we saw the following directory hierarchy:"
+msgstr "In o anterior chapter, we saw o following directory hierarchy:"
+
+#: src/cargo/conventions.md:12
+msgid ""
+"Suppose that we wanted to have two binaries in the same project, though. "
+"What then?"
+msgstr "Suppose aquele we wanted to have two binaries in o mesmo project, though. What then?"
+
+#: src/cargo/conventions.md:15
+msgid ""
+"It turns out that `cargo` supports this. The default binary name is `main`, "
+"as we saw before, but you can add additional binaries by placing them in a "
+"`bin/` directory:"
+msgstr "It turns out aquele `cargo` supports este. O default binary name is `main`, as we saw before, but you pode add additional binaries by placing them in um `bin/` directory:"
+
+#: src/cargo/conventions.md:28
+msgid ""
+"To tell `cargo` to only compile or run this binary, we just pass `cargo` the "
+"`--bin my_other_bin` flag, where `my_other_bin` is the name of the binary we "
+"want to work with."
+msgstr "To tell `cargo` to only compile ou run este binary, we just pass `cargo` o `--bin my_other_bin` flag, where `my_other_bin` is o name of o binary we want to work com."
+
+#: src/cargo/conventions.md:32
+msgid ""
+"In addition to extra binaries, `cargo` supports [more features](https://doc."
+"rust-lang.org/cargo/guide/project-layout.html) such as benchmarks, tests, "
+"and examples."
+msgstr "In addition to extra binaries, `cargo` supports [more features](https://doc.rust-lang.org/cargo/guide/project-layout.html) such as benchmarks, tests, e examples."
+
+#: src/cargo/conventions.md:35
+msgid "In the next chapter, we will look more closely at tests."
+msgstr "In o próximo chapter, we vai look more closely at tests."
+
+#: src/cargo/test.md:3
+msgid ""
+"As we know testing is integral to any piece of software! Rust has first-"
+"class support for unit and integration testing ([see this chapter](https://"
+"doc.rust-lang.org/book/ch11-00-testing.html) in TRPL)."
+msgstr "As we know testing is integral to any piece of software! Rust has primeiro-class support para unit e integration testing ([see this chapter](https://doc.rust-lang.org/book/ch11-00-testing.html) in TRPL)."
+
+#: src/cargo/test.md:7
+msgid ""
+"From the testing chapters linked above, we see how to write unit tests and "
+"integration tests. Organizationally, we can place unit tests in the modules "
+"they test and integration tests in their own `tests/` directory:"
+msgstr "De o testing chapters linked acima, we see how to write unit tests e integration tests. Organizationally, we pode place unit tests in o módulos they test e integration tests in their own `tests/` directory:"
+
+#: src/cargo/test.md:22
+msgid ""
+"Each file in `tests` is a separate [integration test](https://doc.rust-lang."
+"org/book/ch11-03-test-organization.html#integration-tests), i.e. a test that "
+"is meant to test your library as if it were being called from a dependent "
+"crate."
+msgstr "Each arquivo in `tests` is um separate [integration test](https://doc.rust-lang.org/book/ch11-03-test-organization.html#integration-tests), i.e. um test aquele is meant to test your library as if it were being chamado de um dependent crate."
+
+#: src/cargo/test.md:27
+msgid ""
+"The [Testing](../testing.md) chapter elaborates on the three different "
+"testing styles: [Unit](../testing/unit_testing.md), [Doc](../testing/"
+"doc_testing.md), and [Integration](../testing/integration_testing.md)."
+msgstr "O [Testing](../testing.md) chapter elaborates on o three diferente testing styles: [Unit](../testing/unit_testing.md), [Doc](../testing/doc_testing.md), e [Integration](../testing/integration_testing.md)."
+
+#: src/cargo/test.md:30
+msgid "`cargo` naturally provides an easy way to run all of your tests!"
+msgstr "`cargo` naturally provides um easy way to run all of your tests!"
+
+#: src/cargo/test.md:36
+msgid "You should see output like this:"
+msgstr "You deve see saída like este:"
+
+#: src/cargo/test.md:38
+msgid ""
+"```shell\n"
+"$ cargo test\n"
+"   Compiling blah v0.1.0 (file:///nobackup/blah)\n"
+"    Finished dev [unoptimized + debuginfo] target(s) in 0.89 secs\n"
+"     Running target/debug/deps/blah-d3b32b97275ec472\n"
+"\n"
+"running 4 tests\n"
+"test test_bar ... ok\n"
+"test test_baz ... ok\n"
+"test test_foo_bar ... ok\n"
+"test test_foo ... ok\n"
+"\n"
+"test result: ok. 4 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out\n"
+"```"
+msgstr ""
+"```shell\n"
+"$ cargo test\n"
+"   Compiling blah v0.1.0 (file:///nobackup/blah)\n"
+"    Finished dev [unoptimized + debuginfo] target(s) in 0.89 secs\n"
+"     Running target/debug/deps/blah-d3b32b97275ec472\n"
+"\n"
+"running 4 tests\n"
+"test test_bar ... ok\n"
+"test test_baz ... ok\n"
+"test test_foo_bar ... ok\n"
+"test test_foo ... ok\n"
+"\n"
+"test result: ok. 4 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out\n"
+"```"
+
+#: src/cargo/test.md:53
+msgid "You can also run tests whose name matches a pattern:"
+msgstr "You pode also run tests whose name matches um pattern:"
+
+#: src/cargo/test.md:59
+msgid ""
+"```shell\n"
+"$ cargo test test_foo\n"
+"   Compiling blah v0.1.0 (file:///nobackup/blah)\n"
+"    Finished dev [unoptimized + debuginfo] target(s) in 0.35 secs\n"
+"     Running target/debug/deps/blah-d3b32b97275ec472\n"
+"\n"
+"running 2 tests\n"
+"test test_foo ... ok\n"
+"test test_foo_bar ... ok\n"
+"\n"
+"test result: ok. 2 passed; 0 failed; 0 ignored; 0 measured; 2 filtered out\n"
+"```"
+msgstr ""
+"```shell\n"
+"$ cargo test test_foo\n"
+"   Compiling blah v0.1.0 (file:///nobackup/blah)\n"
+"    Finished dev [unoptimized + debuginfo] target(s) in 0.35 secs\n"
+"     Running target/debug/deps/blah-d3b32b97275ec472\n"
+"\n"
+"running 2 tests\n"
+"test test_foo ... ok\n"
+"test test_foo_bar ... ok\n"
+"\n"
+"test result: ok. 2 passed; 0 failed; 0 ignored; 0 measured; 2 filtered out\n"
+"```"
+
+#: src/cargo/test.md:72
+msgid ""
+"One word of caution: Cargo may run multiple tests concurrently, so make sure "
+"that they don't race with each other."
+msgstr "One word of caution: Cargo may run multiple tests concurrently, so make sure aquele they don't race com each other."
+
+#: src/cargo/test.md:75
+msgid ""
+"One example of this concurrency causing issues is if two tests output to a "
+"file, such as below:"
+msgstr "One example of este concurrency causing issues is if two tests saída to um arquivo, such as abaixo:"
+
+#: src/cargo/test.md:81
+msgid "// Import the necessary modules\n"
+msgstr ""
+"// Importa o necessary módulos\n"
+
+#: src/cargo/test.md:85
+msgid "// This test writes to a file\n"
+msgstr ""
+"// Este test writes to um arquivo\n"
+
+#: src/cargo/test.md:88 src/cargo/test.md:105
+msgid "// Opens the file ferris.txt or creates one if it doesn't exist.\n"
+msgstr ""
+"// Abres o arquivo ferris.txt ou creates one if it doesn't exist.\n"
+
+#: src/cargo/test.md:92 src/cargo/test.md:109
+msgid "\"ferris.txt\""
+msgstr "\"ferris.txt\""
+
+#: src/cargo/test.md:93 src/cargo/test.md:110
+msgid "\"Failed to open ferris.txt\""
+msgstr "\"Failed to open ferris.txt\""
+
+#: src/cargo/test.md:95
+msgid "// Print \"Ferris\" 5 times.\n"
+msgstr ""
+"// Imprime \"Ferris\" 5 times.\n"
+
+#: src/cargo/test.md:97
+msgid "\"Ferris\\n\""
+msgstr "\"Ferris\\n\""
+
+#: src/cargo/test.md:98 src/cargo/test.md:115
+msgid "\"Could not write to ferris.txt\""
+msgstr "\"Could not write to ferris.txt\""
+
+#: src/cargo/test.md:102
+msgid "// This test tries to write to the same file\n"
+msgstr ""
+"// Este test tries to write to o mesmo arquivo\n"
+
+#: src/cargo/test.md:112
+msgid "// Print \"Corro\" 5 times.\n"
+msgstr ""
+"// Imprime \"Corro\" 5 times.\n"
+
+#: src/cargo/test.md:114
+msgid "\"Corro\\n\""
+msgstr "\"Corro\\n\""
+
+#: src/cargo/test.md:121
+msgid "Although the intent is to get the following:"
+msgstr "Although o intent is to get o following:"
+
+#: src/cargo/test.md:137
+msgid "What actually gets put into `ferris.txt` is this:"
+msgstr "What actually gets put em `ferris.txt` is este:"
+
+#: src/cargo/build_scripts.md:3
+msgid ""
+"Sometimes a normal build from `cargo` is not enough. Perhaps your crate "
+"needs some pre-requisites before `cargo` will successfully compile, things "
+"like code generation, or some native code that needs to be compiled. To "
+"solve this problem we have build scripts that Cargo can run."
+msgstr "Sometimes um normal build de `cargo` is not enough. Perhaps your crate needs some pre-requisites before `cargo` vai successfully compile, things like code generation, ou some native code aquele needs to be compiled. To solve este problem we have build scripts aquele Cargo pode run."
+
+#: src/cargo/build_scripts.md:8
+msgid ""
+"To add a build script to your package it can either be specified in the "
+"`Cargo.toml` as follows:"
+msgstr "To add a build script to your package it can either be specified in the `Cargo.toml` as follows:"
+
+#: src/cargo/build_scripts.md:11
+msgid ""
+"```toml\n"
+"[package]\n"
+"...\n"
+"build = \"build.rs\"\n"
+"```"
+msgstr ""
+"```toml\n"
+"[package]\n"
+"...\n"
+"build = \"build.rs\"\n"
+"```"
+
+#: src/cargo/build_scripts.md:17
+msgid ""
+"Otherwise Cargo will look for a `build.rs` file in the project directory by "
+"default."
+msgstr "Otherwise Cargo vai look para um `build.rs` arquivo in o project directory by default."
+
+#: src/cargo/build_scripts.md:20
+msgid "How to use a build script"
+msgstr "How to use um build script"
+
+#: src/cargo/build_scripts.md:22
+msgid ""
+"The build script is simply another Rust file that will be compiled and "
+"invoked prior to compiling anything else in the package. Hence it can be "
+"used to fulfill pre-requisites of your crate."
+msgstr "O build script is simply another Rust arquivo aquele vai be compiled e invoked prior to compiling anything else in o package. Hence it pode be usado to fulfill pre-requisites of your crate."
+
+#: src/cargo/build_scripts.md:26
+msgid ""
+"Cargo provides the script with inputs via environment variables [specified "
+"here](https://doc.rust-lang.org/cargo/reference/environment-variables."
+"html#environment-variables-cargo-sets-for-build-scripts) that can be used."
+msgstr "Cargo provides o script com inputs via environment variáveis [specified here](https://doc.rust-lang.org/cargo/reference/environment-variables.html#environment-variables-cargo-sets-for-build-scripts) aquele pode be usado."
+
+#: src/cargo/build_scripts.md:29
+msgid ""
+"The script provides output via stdout. All lines printed are written to "
+"`target/debug/build/<pkg>/output`. Further, lines prefixed with `cargo:` "
+"will be interpreted by Cargo directly and hence can be used to define "
+"parameters for the package's compilation."
+msgstr "O script provides saída via stdout. All lines printed are written to `target/debug/build/<pkg>/output`. Further, lines prefixed com `cargo:` vai be interpreted by Cargo directly e hence pode be usado to define parâmetros para o package's compilation."
+
+#: src/cargo/build_scripts.md:34
+msgid ""
+"For further specification and examples have a read of the [Cargo "
+"specification](https://doc.rust-lang.org/cargo/reference/build-scripts.html)."
+msgstr "Para further specification e examples have um read of o [Cargo specification](https://doc.rust-lang.org/cargo/reference/build-scripts.html)."
+
+#: src/attribute.md:3
+msgid ""
+"An attribute is metadata applied to some module, crate or item. This "
+"metadata can be used to/for:"
+msgstr "Um attribute is metadata applied to some módulo, crate ou item. Este metadata pode be usado to/para:"
+
+#: src/attribute.md:8
+msgid "[conditional compilation of code](attribute/cfg.md)"
+msgstr "[conditional compilation of code](attribute/cfg.md)"
+
+#: src/attribute.md:9
+msgid ""
+"[set crate name, version and type (binary or library)](attribute/crate.md)"
+msgstr "[set crate name, version and type (binary or library)](attribute/crate.md)"
+
+#: src/attribute.md:10
+msgid ""
+"disable [lints](https://en.wikipedia.org/wiki/Lint_%28software%29) (warnings)"
+msgstr "disable [lints](https://en.wikipedia.org/wiki/Lint_%28software%29) (warnings)"
+
+#: src/attribute.md:11
+msgid "enable compiler features (macros, glob imports, etc.)"
+msgstr "enable compiler features (macros, glob imports, etc.)"
+
+#: src/attribute.md:12
+msgid "link to a foreign library"
+msgstr "link to um foreign library"
+
+#: src/attribute.md:13
+msgid "mark functions as unit tests"
+msgstr "mark funções as unit tests"
+
+#: src/attribute.md:14
+msgid "mark functions that will be part of a benchmark"
+msgstr "mark funções aquele vai be part of um benchmark"
+
+#: src/attribute.md:15
+msgid ""
+"[attribute like macros](https://doc.rust-lang.org/book/ch19-06-macros."
+"html#attribute-like-macros)"
+msgstr "[attribute like macros](https://doc.rust-lang.org/book/ch19-06-macros.html#attribute-like-macros)"
+
+#: src/attribute.md:17
+msgid ""
+"Attributes look like `#[outer_attribute]` or `#![inner_attribute]`, with the "
+"difference between them being where they apply."
+msgstr "Attributes look like `#[outer_attribute]` ou `#![inner_attribute]`, com o difference between them being where they apply."
+
+#: src/attribute.md:20
+msgid ""
+"`#[outer_attribute]` applies to the [item](https://doc.rust-lang.org/stable/"
+"reference/items.html) immediately following it. Some examples of items are: "
+"a function, a module declaration, a constant, a structure, an enum. Here is "
+"an example where attribute `#[derive(Debug)]` applies to the struct "
+"`Rectangle`:"
+msgstr "`#[outer_attribute]` applies to o [item](https://doc.rust-lang.org/stable/reference/items.html) immediately following it. Some examples of items are: um função, um módulo declaration, um constant, uma estrutura, um enum. Here is um example where attribute `#[derive(Debug)]` applies to o struct `Rectangle`:"
+
+#: src/attribute.md:34
+msgid ""
+"`#![inner_attribute]` applies to the enclosing [item](https://doc.rust-lang."
+"org/stable/reference/items.html) (typically a module or a crate). In other "
+"words, this attribute is interpreted as applying to the entire scope in "
+"which it's placed. Here is an example where `#![allow(unused_variables)]` "
+"applies to the whole crate (if placed in `main.rs`):"
+msgstr "`#![inner_attribute]` applies to o enclosing [item](https://doc.rust-lang.org/stable/reference/items.html) (typically um módulo ou um crate). In other words, este attribute is interpreted as applying to o entire scope in which it's placed. Here is um example where `#![allow(unused_variables)]` applies to o whole crate (if placed in `main.rs`):"
+
+#: src/attribute.md:44
+msgid "// This would normally warn about an unused variable.\n"
+msgstr ""
+"// Este would normally warn about um unused variável.\n"
+
+#: src/attribute.md:48
+msgid "Attributes can take arguments with different syntaxes:"
+msgstr "Attributes pode take argumentos com diferente syntaxes:"
+
+#: src/attribute.md:50
+msgid "`#[attribute = \"value\"]`"
+msgstr "`#[attribute = \"value\"]`"
+
+#: src/attribute.md:51
+msgid "`#[attribute(key = \"value\")]`"
+msgstr "`#[attribute(key = \"value\")]`"
+
+#: src/attribute.md:52
+msgid "`#[attribute(value)]`"
+msgstr "`#[attribute(value)]`"
+
+#: src/attribute.md:54
+msgid ""
+"Attributes can have multiple values and can be separated over multiple "
+"lines, too:"
+msgstr "Attributes pode have multiple valores e pode be separated over multiple lines, too:"
+
+#: src/attribute/unused.md:3
+msgid ""
+"The compiler provides a `dead_code` [_lint_](https://en.wikipedia.org/wiki/"
+"Lint_%28software%29) that will warn about unused functions. An _attribute_ "
+"can be used to disable the lint."
+msgstr "O compiler provides um `dead_code` [_lint_](https://en.wikipedia.org/wiki/Lint_%28software%29) aquele vai warn about unused funções. Um _attribute_ pode be usado to disable o lint."
+
+#: src/attribute/unused.md:9
+msgid ""
+"// `#[allow(dead_code)]` is an attribute that disables the `dead_code` lint\n"
+msgstr ""
+"// `#[allow(dead_code)]` is um attribute aquele disables o `dead_code` lint\n"
+
+#: src/attribute/unused.md:14
+msgid "// FIXME ^ Add an attribute to suppress the warning\n"
+msgstr ""
+"// FIXME ^ Adiciona um attribute to suppress o warning\n"
+
+#: src/attribute/unused.md:22
+msgid ""
+"Note that in real programs, you should eliminate dead code. In these "
+"examples we'll allow dead code in some places because of the interactive "
+"nature of the examples."
+msgstr "Note aquele in real programs, you deve eliminate dead code. In estes examples we'll allow dead code in some places porque of o interactive nature of o examples."
+
+#: src/attribute/crate.md:3
+msgid ""
+"The `crate_type` attribute can be used to tell the compiler whether a crate "
+"is a binary or a library (and even which type of library), and the "
+"`crate_name` attribute can be used to set the name of the crate."
+msgstr "O `crate_type` attribute pode be usado to tell o compiler whether um crate is um binary ou um library (e even which tipo of library), e o `crate_name` attribute pode be usado to set o name of o crate."
+
+#: src/attribute/crate.md:7
+msgid ""
+"However, it is important to note that both the `crate_type` and `crate_name` "
+"attributes have **no** effect whatsoever when using Cargo, the Rust package "
+"manager. Since Cargo is used for the majority of Rust projects, this means "
+"real-world uses of `crate_type` and `crate_name` are relatively limited."
+msgstr "However, it is important to note aquele both o `crate_type` e `crate_name` attributes have **no** effect whatsoever when usando Cargo, o Rust package manager. Since Cargo is usado para o majority of Rust projects, este means real-world uses of `crate_type` e `crate_name` are relatively limited."
+
+#: src/attribute/crate.md:13
+msgid "// This crate is a library\n"
+msgstr ""
+"// Este crate is um library\n"
+
+#: src/attribute/crate.md:14
+msgid "\"lib\""
+msgstr "\"lib\""
+
+#: src/attribute/crate.md:14
+msgid "// The library is named \"rary\"\n"
+msgstr ""
+"// O library is named \"rary\"\n"
+
+#: src/attribute/crate.md:16
+msgid "\"rary\""
+msgstr "\"rary\""
+
+#: src/attribute/crate.md:33
+msgid ""
+"When the `crate_type` attribute is used, we no longer need to pass the `--"
+"crate-type` flag to `rustc`."
+msgstr "When the `crate_type` attribute is used, we no longer need to pass the `--crate-type` flag to `rustc`."
+
+#: src/attribute/cfg.md:3
+msgid ""
+"Configuration conditional checks are possible through two different "
+"operators:"
+msgstr "Configuration conditional checks are possible through two diferente operators:"
+
+#: src/attribute/cfg.md:5
+msgid "the `cfg` attribute: `#[cfg(...)]` in attribute position"
+msgstr "o `cfg` attribute: `#[cfg(...)]` in attribute position"
+
+#: src/attribute/cfg.md:6
+msgid "the `cfg!` macro: `cfg!(...)` in boolean expressions"
+msgstr "o `cfg!` macro: `cfg!(...)` in booleano expressions"
+
+#: src/attribute/cfg.md:8
+msgid ""
+"While the former enables conditional compilation, the latter conditionally "
+"evaluates to `true` or `false` literals allowing for checks at run-time. "
+"Both utilize identical argument syntax."
+msgstr "While o former enables conditional compilation, o latter conditionally evaluates to `true` ou `false` literals allowing para checks at run-time. Both utilize identical argumento syntax."
+
+#: src/attribute/cfg.md:12
+msgid ""
+"`cfg!`, unlike `#[cfg]`, does not remove any code and only evaluates to true "
+"or false. For example, all blocks in an if/else expression need to be valid "
+"when `cfg!` is used for the condition, regardless of what `cfg!` is "
+"evaluating."
+msgstr "`cfg!`, unlike `#[cfg]`, does not remove any code e only evaluates to true ou false. Para example, all blocks in um if/else expression need to be válido when `cfg!` is usado para o condition, regardless of what `cfg!` is evaluating."
+
+#: src/attribute/cfg.md:15
+msgid "// This function only gets compiled if the target OS is linux\n"
+msgstr ""
+"// Este função only gets compiled if o target OS is linux\n"
+
+#: src/attribute/cfg.md:16 src/attribute/cfg.md:22 src/attribute/cfg.md:31
+msgid "\"linux\""
+msgstr "\"linux\""
+
+#: src/attribute/cfg.md:18
+msgid "\"You are running linux!\""
+msgstr "\"You are running linux!\""
+
+#: src/attribute/cfg.md:20
+msgid ""
+"// And this function only gets compiled if the target OS is *not* linux\n"
+msgstr ""
+"// E este função only gets compiled if o target OS is *not* linux\n"
+
+#: src/attribute/cfg.md:24
+msgid "\"You are *not* running linux!\""
+msgstr "\"You are *not* running linux!\""
+
+#: src/attribute/cfg.md:30
+msgid "\"Are you sure?\""
+msgstr "\"Are you sure?\""
+
+#: src/attribute/cfg.md:32
+msgid "\"Yes. It's definitely linux!\""
+msgstr "\"Yes. It's definitely linux!\""
+
+#: src/attribute/cfg.md:34
+msgid "\"Yes. It's definitely *not* linux!\""
+msgstr "\"Yes. It's definitely *not* linux!\""
+
+#: src/attribute/cfg.md:41
+msgid ""
+"[the reference](https://doc.rust-lang.org/reference/attributes."
+"html#conditional-compilation), [`cfg!`](https://doc.rust-lang.org/std/macro."
+"cfg!.html), and [macros](../macros.md)."
+msgstr "[the reference](https://doc.rust-lang.org/reference/attributes.html#conditional-compilation), [`cfg!`](https://doc.rust-lang.org/std/macro.cfg!.html), e [macros](../macros.md)."
+
+#: src/attribute/cfg/custom.md:3
+msgid ""
+"Some conditionals like `target_os` are implicitly provided by `rustc`, but "
+"custom conditionals must be passed to `rustc` using the `--cfg` flag."
+msgstr "Some conditionals like `target_os` are implicitly provided by `rustc`, but custom conditionals deve be passed to `rustc` usando o `--cfg` flag."
+
+#: src/attribute/cfg/custom.md:9
+msgid "\"condition met!\""
+msgstr "\"condition met!\""
+
+#: src/attribute/cfg/custom.md:17
+msgid "Try to run this to see what happens without the custom `cfg` flag."
+msgstr "Tente to run este to see what happens sno custom `cfg` flag."
+
+#: src/attribute/cfg/custom.md:19
+msgid "With the custom `cfg` flag:"
+msgstr "Com o custom `cfg` flag:"
+
+#: src/generics.md:3
+msgid ""
+"_Generics_ is the topic of generalizing types and functionalities to broader "
+"cases. This is extremely useful for reducing code duplication in many ways, "
+"but can call for rather involved syntax. Namely, being generic requires "
+"taking great care to specify over which types a generic type is actually "
+"considered valid. The simplest and most common use of generics is for type "
+"parameters."
+msgstr "_Generics_ is o topic of generalizing tipos e functionalities to broader cases. Este is extremely useful para reducing code duplication in many ways, but pode call para rather involved syntax. Namely, being generic requires taking great care to specify over which tipos um generic tipo is actually considered válido. O simplest e most common use of generics is para tipo parâmetros."
+
+#: src/generics.md:10
+msgid ""
+"A type parameter is specified as generic by the use of angle brackets and "
+"upper [camel case](https://en.wikipedia.org/wiki/CamelCase): `<Aaa, Bbb, ..."
+">`. \"Generic type parameters\" are typically represented as `<T>`. In Rust, "
+"\"generic\" also describes anything that accepts one or more generic type "
+"parameters `<T>`. Any type specified as a generic type parameter is generic, "
+"and everything else is concrete (non-generic)."
+msgstr "UM tipo parâmetro is specified as generic by o use of angle brackets e upper [camel case](https://en.wikipedia.org/wiki/CamelCase): `<Aaa, Bbb, ...>`. \"Generic tipo parâmetros\" are typically represented as `<T>`. In Rust, \"generic\" also describes anything aquele accepts one ou more generic tipo parâmetros `<T>`. Any tipo specified as um generic tipo parâmetro is generic, e everything else is concrete (non-generic)."
+
+#: src/generics.md:16
+msgid ""
+"For example, defining a _generic function_ named `foo` that takes an "
+"argument `T` of any type:"
+msgstr "Para example, defining um _generic function_ named `foo` aquele takes um argumento `T` of any tipo:"
+
+#: src/generics.md:23
+msgid ""
+"Because `T` has been specified as a generic type parameter using `<T>`, it "
+"is considered generic when used here as `(arg: T)`. This is the case even if "
+"`T` has previously been defined as a `struct`."
+msgstr "Because `T` has been specified as a generic type parameter using `<T>`, it is considered generic when used here as `(arg: T)`. This is the case even if `T` has previously been defined as a `struct`."
+
+#: src/generics.md:27
+msgid "This example shows some of the syntax in action:"
+msgstr "Este example shows some of o syntax in action:"
+
+#: src/generics.md:30
+msgid "// A concrete type `A`.\n"
+msgstr ""
+"// UM concrete tipo `A`.\n"
+
+#: src/generics.md:32
+msgid ""
+"// In defining the type `Single`, the first use of `A` is not preceded by "
+"`<A>`.\n"
+"// Therefore, `Single` is a concrete type, and `A` is defined as above.\n"
+msgstr ""
+"// In defining the type `Single`, the first use of `A` is not preceded by `<A>`.\n"
+"// Therefore, `Single` is a concrete type, and `A` is defined as above.\n"
+
+#: src/generics.md:35
+msgid "//            ^ Here is `Single`s first use of the type `A`.\n"
+msgstr ""
+"//            ^ Here is `Single`s primeiro use of o tipo `A`.\n"
+
+#: src/generics.md:37
+msgid ""
+"// Here, `<T>` precedes the first use of `T`, so `SingleGen` is a generic "
+"type.\n"
+"// Because the type parameter `T` is generic, it could be anything, "
+"including\n"
+"// the concrete type `A` defined at the top.\n"
+msgstr ""
+"// Here, `<T>` precedes o primeiro use of `T`, so `SingleGen` is um generic tipo.\n"
+"// Porque o tipo parâmetro `T` is generic, it could be anything, including\n"
+"// o concrete tipo `A` defined at o top.\n"
+
+#: src/generics.md:44
+msgid "// `Single` is concrete and explicitly takes `A`.\n"
+msgstr ""
+"// `Single` is concrete e explicitly takes `A`.\n"
+
+#: src/generics.md:47
+msgid ""
+"// Create a variable `_char` of type `SingleGen<char>`\n"
+"    // and give it the value `SingleGen('a')`.\n"
+"    // Here, `SingleGen` has a type parameter explicitly specified.\n"
+msgstr ""
+"// Cria uma variável `_char` of tipo `SingleGen<char>`\n"
+"    // e give it o valor `SingleGen('a')`.\n"
+"    // Here, `SingleGen` has um tipo parâmetro explicitly specified.\n"
+
+#: src/generics.md:52
+msgid "// `SingleGen` can also have a type parameter implicitly specified:\n"
+msgstr ""
+"// `SingleGen` pode also have um tipo parâmetro implicitly specified:\n"
+
+#: src/generics.md:53
+msgid "// Uses `A` defined at the top.\n"
+msgstr ""
+"// Usas `A` defined at o top.\n"
+
+#: src/generics.md:54
+msgid "// Uses `i32`.\n"
+msgstr ""
+"// Usas `i32`.\n"
+
+#: src/generics.md:55
+msgid "// Uses `char`.\n"
+msgstr ""
+"// Usas `char`.\n"
+
+#: src/generics.md:61
+msgid "[`structs`](custom_types/structs.md)"
+msgstr "[`structs`](custom_types/structs.md)"
+
+#: src/generics/gen_fn.md:3
+msgid ""
+"The same set of rules can be applied to functions: a type `T` becomes "
+"generic when preceded by `<T>`."
+msgstr "O mesmo set of rules pode be applied to funções: um tipo `T` becomes generic when preceded by `<T>`."
+
+#: src/generics/gen_fn.md:6
+msgid ""
+"Using generic functions sometimes requires explicitly specifying type "
+"parameters. This may be the case if the function is called where the return "
+"type is generic, or if the compiler doesn't have enough information to infer "
+"the necessary type parameters."
+msgstr "Usando generic funções sometimes requires explicitly specifying tipo parâmetros. Este may be o case if a função is chamado where o retorna tipo is generic, ou if o compiler doesn't have enough information to infer o necessary tipo parâmetros."
+
+#: src/generics/gen_fn.md:11
+msgid ""
+"A function call with explicitly specified type parameters looks like: `fun::"
+"<A, B, ...>()`."
+msgstr "UM função call com explicitly specified tipo parâmetros looks like: `fun::<A, B, ...>()`."
+
+#: src/generics/gen_fn.md:15
+msgid "// Concrete type `A`.\n"
+msgstr ""
+"// Concrete tipo `A`.\n"
+
+#: src/generics/gen_fn.md:16
+msgid "// Concrete type `S`.\n"
+msgstr ""
+"// Concrete tipo `S`.\n"
+
+#: src/generics/gen_fn.md:17
+msgid "// Generic type `SGen`.\n"
+msgstr ""
+"// Generic tipo `SGen`.\n"
+
+#: src/generics/gen_fn.md:18
+msgid ""
+"// The following functions all take ownership of the variable passed into\n"
+"// them and immediately go out of scope, freeing the variable.\n"
+msgstr ""
+"// O following funções all take ownership of o variável passed em\n"
+"// them e immediately go out of scope, freeing o variável.\n"
+
+#: src/generics/gen_fn.md:21
+msgid ""
+"// Define a function `reg_fn` that takes an argument `_s` of type `S`.\n"
+"// This has no `<T>` so this is not a generic function.\n"
+msgstr ""
+"// Define um função `reg_fn` aquele takes um argumento `_s` of tipo `S`.\n"
+"// Este has no `<T>` so este is not um generic função.\n"
+
+#: src/generics/gen_fn.md:25
+msgid ""
+"// Define a function `gen_spec_t` that takes an argument `_s` of type "
+"`SGen<T>`.\n"
+"// It has been explicitly given the type parameter `A`, but because `A` has "
+"not \n"
+"// been specified as a generic type parameter for `gen_spec_t`, it is not "
+"generic.\n"
+msgstr ""
+"// Define um função `gen_spec_t` aquele takes um argumento `_s` of tipo `SGen<T>`.\n"
+"// It has been explicitly given o tipo parâmetro `A`, but porque `A` has not \n"
+"// been specified as um generic tipo parâmetro para `gen_spec_t`, it is not generic.\n"
+
+#: src/generics/gen_fn.md:30
+msgid ""
+"// Define a function `gen_spec_i32` that takes an argument `_s` of type "
+"`SGen<i32>`.\n"
+"// It has been explicitly given the type parameter `i32`, which is a "
+"specific type.\n"
+"// Because `i32` is not a generic type, this function is also not generic.\n"
+msgstr ""
+"// Define um função `gen_spec_i32` aquele takes um argumento `_s` of tipo `SGen<i32>`.\n"
+"// It has been explicitly given o tipo parâmetro `i32`, which is um specific tipo.\n"
+"// Porque `i32` is not um generic tipo, este função is also not generic.\n"
+
+#: src/generics/gen_fn.md:35
+msgid ""
+"// Define a function `generic` that takes an argument `_s` of type "
+"`SGen<T>`.\n"
+"// Because `SGen<T>` is preceded by `<T>`, this function is generic over "
+"`T`.\n"
+msgstr ""
+"// Define um função `generic` aquele takes um argumento `_s` of tipo `SGen<T>`.\n"
+"// Porque `SGen<T>` is preceded by `<T>`, este função is generic over `T`.\n"
+
+#: src/generics/gen_fn.md:41
+msgid "// Using the non-generic functions\n"
+msgstr ""
+"// Usando o non-generic funções\n"
+
+#: src/generics/gen_fn.md:42
+msgid "// Concrete type.\n"
+msgstr ""
+"// Concrete tipo.\n"
+
+#: src/generics/gen_fn.md:43
+msgid "// Implicitly specified type parameter `A`.\n"
+msgstr ""
+"// Implicitly specified tipo parâmetro `A`.\n"
+
+#: src/generics/gen_fn.md:44
+msgid "// Implicitly specified type parameter `i32`.\n"
+msgstr ""
+"// Implicitly specified tipo parâmetro `i32`.\n"
+
+#: src/generics/gen_fn.md:46
+msgid "// Explicitly specified type parameter `char` to `generic()`.\n"
+msgstr ""
+"// Explicitly specified tipo parâmetro `char` to `generic()`.\n"
+
+#: src/generics/gen_fn.md:49
+msgid "// Implicitly specified type parameter `char` to `generic()`.\n"
+msgstr ""
+"// Implicitly specified tipo parâmetro `char` to `generic()`.\n"
+
+#: src/generics/gen_fn.md:50
+msgid "'c'"
+msgstr "'c'"
+
+#: src/generics/gen_fn.md:56
+msgid "[functions](../fn.md) and [`struct`s](../custom_types/structs.md)"
+msgstr "[functions](../fn.md) e [`struct`s](../custom_types/structs.md)"
+
+#: src/generics/impl.md:3
+msgid "Similar to functions, implementations require care to remain generic."
+msgstr "Similar to funções, implementations require care to remain generic."
+
+#: src/generics/impl.md:6
+msgid "// Concrete type `S`\n"
+msgstr ""
+"// Concrete tipo `S`\n"
+
+#: src/generics/impl.md:7
+msgid "// Generic type `GenericVal`\n"
+msgstr ""
+"// Generic tipo `GenericVal`\n"
+
+#: src/generics/impl.md:8
+msgid "// impl of GenericVal where we explicitly specify type parameters:\n"
+msgstr ""
+"// impl of GenericVal where we explicitly specify tipo parâmetros:\n"
+
+#: src/generics/impl.md:10
+msgid "// Specify `f32`\n"
+msgstr ""
+"// Specify `f32`\n"
+
+#: src/generics/impl.md:11
+msgid "// Specify `S` as defined above\n"
+msgstr ""
+"// Specify `S` as defined acima\n"
+
+#: src/generics/impl.md:12
+msgid "// `<T>` Must precede the type to remain generic\n"
+msgstr ""
+"// `<T>` Deve precedo tipo to remain generic\n"
+
+#: src/generics/impl.md:25
+msgid "// impl of Val\n"
+msgstr ""
+"// impl of Val\n"
+
+#: src/generics/impl.md:32
+msgid "// impl of GenVal for a generic type `T`\n"
+msgstr ""
+"// impl of GenVal para um generic tipo `T`\n"
+
+#: src/generics/impl.md:50
+msgid ""
+"[functions returning references](../scope/lifetime/fn.md), [`impl`](../fn/"
+"methods.md), and [`struct`](../custom_types/structs.md)"
+msgstr "[functions returning references](../scope/lifetime/fn.md), [`impl`](../fn/methods.md), e [`struct`](../custom_types/structs.md)"
+
+#: src/generics/gen_trait.md:3
+msgid ""
+"Of course `trait`s can also be generic. Here we define one which "
+"reimplements the `Drop` `trait` as a generic method to `drop` itself and an "
+"input."
+msgstr "Of course `trait`s pode also be generic. Here we define one which reimplements o `Drop` `trait` as um generic método to `drop` itself e um entrada."
+
+#: src/generics/gen_trait.md:7
+msgid "// Non-copyable types.\n"
+msgstr ""
+"// Non-copyable tipos.\n"
+
+#: src/generics/gen_trait.md:10
+msgid "// A trait generic over `T`.\n"
+msgstr ""
+"// UM trait generic over `T`.\n"
+
+#: src/generics/gen_trait.md:13
+msgid ""
+"// Define a method on the caller type which takes an\n"
+"    // additional single parameter `T` and does nothing with it.\n"
+msgstr ""
+"// Define um método on o caller tipo which takes um\n"
+"    // additional single parâmetro `T` e does nothing com it.\n"
+
+#: src/generics/gen_trait.md:17
+msgid ""
+"// Implement `DoubleDrop<T>` for any generic parameter `T` and\n"
+"// caller `U`.\n"
+msgstr ""
+"// Implement `DoubleDrop<T>` para any generic parâmetro `T` e\n"
+"// caller `U`.\n"
+
+#: src/generics/gen_trait.md:21
+msgid ""
+"// This method takes ownership of both passed arguments,\n"
+"    // deallocating both.\n"
+msgstr ""
+"// Este método takes ownership of both passed argumentos,\n"
+"    // deallocating both.\n"
+
+#: src/generics/gen_trait.md:30
+msgid "// Deallocate `empty` and `null`.\n"
+msgstr ""
+"// Deallocate `empty` e `null`.\n"
+
+#: src/generics/gen_trait.md:33
+msgid ""
+"//empty;\n"
+"    //null;\n"
+"    // ^ TODO: Try uncommenting these lines.\n"
+msgstr ""
+"//vazio;\n"
+"    //null;\n"
+"    // ^ TODO: Tente uncommenting estes lines.\n"
+
+#: src/generics/gen_trait.md:41
+msgid ""
+"[`Drop`](https://doc.rust-lang.org/std/ops/trait.Drop.html), [`struct`](../"
+"custom_types/structs.md), and [`trait`](../trait.md)"
+msgstr "[`Drop`](https://doc.rust-lang.org/std/ops/trait.Drop.html), [`struct`](../custom_types/structs.md), e [`trait`](../trait.md)"
+
+#: src/generics/bounds.md:3
+msgid ""
+"When working with generics, the type parameters often must use traits as "
+"_bounds_ to stipulate what functionality a type implements. For example, the "
+"following example uses the trait `Display` to print and so it requires `T` "
+"to be bound by `Display`; that is, `T` _must_ implement `Display`."
+msgstr "When working com generics, o tipo parâmetros often deve use traits as _bounds_ to stipulate what functionality um tipo implements. Para example, o following example uses o trait `Display` to print e so it requires `T` to be bound by `Display`; aquele is, `T` _must_ implement `Display`."
+
+#: src/generics/bounds.md:9
+msgid ""
+"// Define a function `printer` that takes a generic type `T` which\n"
+"// must implement trait `Display`.\n"
+msgstr ""
+"// Define um função `printer` aquele takes um generic tipo `T` which\n"
+"// deve implement trait `Display`.\n"
+
+#: src/generics/bounds.md:16
+msgid ""
+"Bounding restricts the generic to types that conform to the bounds. That is:"
+msgstr "Bounding restricts o generic to tipos aquele conform to o bounds. Aquele is:"
+
+#: src/generics/bounds.md:20
+msgid ""
+"// Error! `Vec<T>` does not implement `Display`. This\n"
+"// specialization will fail.\n"
+msgstr ""
+"// Erro! `Vec<T>` does not implement `Display`. Este\n"
+"// specialization vai fail.\n"
+
+#: src/generics/bounds.md:26
+msgid ""
+"Another effect of bounding is that generic instances are allowed to access "
+"the [methods](../fn/methods.md) of traits specified in the bounds. For "
+"example:"
+msgstr "Another effect of bounding is aquele generic instances are allowed to access o [methods](../fn/methods.md) of traits specified in o bounds. Para example:"
+
+#: src/generics/bounds.md:30
+msgid "// A trait which implements the print marker: `{:?}`.\n"
+msgstr ""
+"// UM trait which implements o print marker: `{:?}`.\n"
+
+#: src/generics/bounds.md:45
+msgid ""
+"// The generic `T` must implement `Debug`. Regardless\n"
+"// of the type, this will work properly.\n"
+msgstr ""
+"// O generic `T` deve implement `Debug`. Regardless\n"
+"// of o tipo, este vai work properly.\n"
+
+#: src/generics/bounds.md:51
+msgid ""
+"// `T` must implement `HasArea`. Any type which meets\n"
+"// the bound can access `HasArea`'s function `area`.\n"
+msgstr ""
+"// `T` deve implement `HasArea`. Any tipo which meets\n"
+"// o bound pode access `HasArea`'s função `area`.\n"
+
+#: src/generics/bounds.md:61
+msgid "\"Area: {}\""
+msgstr "\"Area: {}\""
+
+#: src/generics/bounds.md:63
+msgid ""
+"//print_debug(&_triangle);\n"
+"    //println!(\"Area: {}\", area(&_triangle));\n"
+"    // ^ TODO: Try uncommenting these.\n"
+"    // | Error: Does not implement either `Debug` or `HasArea`. \n"
+msgstr ""
+"//print_debug(&_triangle);\n"
+"    //println!(\"Area: {}\", area(&_triangle));\n"
+"    // ^ TODO: Tente uncommenting estes.\n"
+"    // | Erro: Does not implement either `Debug` ou `HasArea`. \n"
+
+#: src/generics/bounds.md:70
+msgid ""
+"As an additional note, [`where`](../generics/where.md) clauses can also be "
+"used to apply bounds in some cases to be more expressive."
+msgstr "As an additional note, [`where`](../generics/where.md) clauses can also be used to apply bounds in some cases to be more expressive."
+
+#: src/generics/bounds.md:75
+msgid ""
+"[`std::fmt`](../hello/print.md), [`struct`s](../custom_types/structs.md), "
+"and [`trait`s](../trait.md)"
+msgstr "[`std::fmt`](../hello/print.md), [`struct`s](../custom_types/structs.md), e [`trait`s](../trait.md)"
+
+#: src/generics/bounds/testcase_empty.md:3
+msgid ""
+"A consequence of how bounds work is that even if a `trait` doesn't include "
+"any functionality, you can still use it as a bound. `Eq` and `Copy` are "
+"examples of such `trait`s from the `std` library."
+msgstr "UM consequence of how bounds work is aquele even if um `trait` doesn't include any functionality, you pode still use it as um bound. `Eq` e `Copy` are examples of such `trait`s do `std` library."
+
+#: src/generics/bounds/testcase_empty.md:17
+msgid ""
+"// These functions are only valid for types which implement these\n"
+"// traits. The fact that the traits are empty is irrelevant.\n"
+msgstr ""
+"// Estes funções are only válido para tipos which implement estes\n"
+"// traits. O fact aquele o traits are vazio is irrelevant.\n"
+
+#: src/generics/bounds/testcase_empty.md:20
+msgid "\"red\""
+msgstr "\"red\""
+
+#: src/generics/bounds/testcase_empty.md:21
+msgid "\"blue\""
+msgstr "\"blue\""
+
+#: src/generics/bounds/testcase_empty.md:28
+msgid ""
+"// `red()` won't work on a blue jay nor vice versa\n"
+"    // because of the bounds.\n"
+msgstr ""
+"// `red()` won't work on um blue jay nor vice versa\n"
+"    // porque of o bounds.\n"
+
+#: src/generics/bounds/testcase_empty.md:30
+msgid "\"A cardinal is {}\""
+msgstr "\"UM cardinal is {}\""
+
+#: src/generics/bounds/testcase_empty.md:31
+msgid "\"A blue jay is {}\""
+msgstr "\"UM blue jay is {}\""
+
+#: src/generics/bounds/testcase_empty.md:32
+msgid ""
+"//println!(\"A turkey is {}\", red(&_turkey));\n"
+"    // ^ TODO: Try uncommenting this line.\n"
+msgstr ""
+"//println!(\"UM turkey is {}\", red(&_turkey));\n"
+"    // ^ TODO: Tente uncommenting este line.\n"
+
+#: src/generics/bounds/testcase_empty.md:39
+msgid ""
+"[`std::cmp::Eq`](https://doc.rust-lang.org/std/cmp/trait.Eq.html), [`std::"
+"marker::Copy`](https://doc.rust-lang.org/std/marker/trait.Copy.html), and "
+"[`trait`s](../../trait.md)"
+msgstr "[`std::cmp::Eq`](https://doc.rust-lang.org/std/cmp/trait.Eq.html), [`std::marker::Copy`](https://doc.rust-lang.org/std/marker/trait.Copy.html), e [`trait`s](../../trait.md)"
+
+#: src/generics/multi_bounds.md:3
+msgid ""
+"Multiple bounds for a single type can be applied with a `+`. Like normal, "
+"different types are separated with `,`."
+msgstr "Multiple bounds para um single tipo pode be applied com um `+`. Like normal, diferente tipos are separated com `,`."
+
+#: src/generics/multi_bounds.md:10
+msgid "\"Debug: `{:?}`\""
+msgstr "\"Debug: `{:?}`\""
+
+#: src/generics/multi_bounds.md:11
+msgid "\"Display: `{}`\""
+msgstr "\"Display: `{}`\""
+
+#: src/generics/multi_bounds.md:15
+msgid "\"t: `{:?}`\""
+msgstr "\"t: `{:?}`\""
+
+#: src/generics/multi_bounds.md:16
+msgid "\"u: `{:?}`\""
+msgstr "\"u: `{:?}`\""
+
+#: src/generics/multi_bounds.md:20
+msgid "\"words\""
+msgstr "\"words\""
+
+#: src/generics/multi_bounds.md:25
+msgid ""
+"//compare_prints(&array);\n"
+"    // TODO ^ Try uncommenting this.\n"
+msgstr ""
+"//compare_prints(&array);\n"
+"    // TODO ^ Tente uncommenting este.\n"
+
+#: src/generics/multi_bounds.md:34
+msgid "[`std::fmt`](../hello/print.md) and [`trait`s](../trait.md)"
+msgstr "[`std::fmt`](../hello/print.md) e [`trait`s](../trait.md)"
+
+#: src/generics/where.md:3
+msgid ""
+"A bound can also be expressed using a `where` clause immediately before the "
+"opening `{`, rather than at the type's first mention. Additionally, `where` "
+"clauses can apply bounds to arbitrary types, rather than just to type "
+"parameters."
+msgstr "UM bound pode also be expressed usando um `where` clause immediately before o opening `{`, rather than at o tipo's primeiro mention. Adicionaitionally, `where` clauses pode apply bounds to arbitrary tipos, rather than just to tipo parâmetros."
+
+#: src/generics/where.md:8
+msgid "Some cases that a `where` clause is useful:"
+msgstr "Some cases aquele um `where` clause is useful:"
+
+#: src/generics/where.md:10
+msgid "When specifying generic types and bounds separately is clearer:"
+msgstr "When specifying generic tipos e bounds separately is clearer:"
+
+#: src/generics/where.md:14
+msgid "// Expressing bounds with a `where` clause\n"
+msgstr ""
+"// Expressing bounds com um `where` clause\n"
+
+#: src/generics/where.md:21
+msgid ""
+"When using a `where` clause is more expressive than using normal syntax. The "
+"`impl` in this example cannot be directly expressed without a `where` clause:"
+msgstr "When usando um `where` clause is more expressive than usando normal syntax. O `impl` in este example não pode be directly expressed sem um `where` clause:"
+
+#: src/generics/where.md:30
+msgid ""
+"// Because we would otherwise have to express this as `T: Debug` or \n"
+"// use another method of indirect approach, this requires a `where` clause:\n"
+msgstr ""
+"// Porque we would otherwise have to express este as `T: Debug` ou \n"
+"// use another método of indirect approach, este requires um `where` clause:\n"
+
+#: src/generics/where.md:35
+msgid ""
+"// We want `Option<T>: Debug` as our bound because that is what's\n"
+"    // being printed. Doing otherwise would be using the wrong bound.\n"
+msgstr ""
+"// We want `Option<T>: Debug` as our bound porque aquele is what's\n"
+"    // being printed. Doing otherwise would be usando o wrong bound.\n"
+
+#: src/generics/where.md:51
+msgid ""
+"[RFC](https://github.com/rust-lang/rfcs/blob/master/text/0135-where.md), "
+"[`struct`](../custom_types/structs.md), and [`trait`](../trait.md)"
+msgstr "[RFC](https://github.com/rust-lang/rfcs/blob/master/text/0135-where.md), [`struct`](../custom_types/structs.md), e [`trait`](../trait.md)"
+
+#: src/generics/new_types.md:3
+msgid ""
+"The `newtype` idiom gives compile time guarantees that the right type of "
+"value is supplied to a program."
+msgstr "O `newtype` idiom gives compile time guarantees aquele o right tipo of valor is supplied to um program."
+
+#: src/generics/new_types.md:6
+msgid ""
+"For example, an age verification function that checks age in years, _must_ "
+"be given a value of type `Years`."
+msgstr "Para example, um age verification função aquele checks age in years, _must_ be given um valor of tipo `Years`."
+
+#: src/generics/new_types.md:21
+msgid "/// truncates partial years\n"
+msgstr ""
+"/// truncates partial years\n"
+
+#: src/generics/new_types.md:34 src/generics/new_types.md:35
+msgid "\"Is an adult? {}\""
+msgstr "\"Is um adult? {}\""
+
+#: src/generics/new_types.md:36
+msgid "// println!(\"Is an adult? {}\", is_adult(&age_days));\n"
+msgstr ""
+"// println!(\"Is um adult? {}\", is_adult(&age_days));\n"
+
+#: src/generics/new_types.md:40
+msgid ""
+"Uncomment the last print statement to observe that the type supplied must be "
+"`Years`."
+msgstr "Remova o comentário do último print statement to observe aquele o tipo supplied deve be `Years`."
+
+#: src/generics/new_types.md:42
+msgid ""
+"To obtain the `newtype`'s value as the base type, you may use the tuple or "
+"destructuring syntax like so:"
+msgstr "To obtain o `newtype`'s valor as o base tipo, you may use o tuple ou destructuring syntax like so:"
+
+#: src/generics/new_types.md:49
+msgid "// Tuple\n"
+msgstr ""
+"// Tuple\n"
+
+#: src/generics/new_types.md:50
+msgid "// Destructuring\n"
+msgstr ""
+"// Destructuring\n"
+
+#: src/generics/new_types.md:56
+msgid "[`structs`](../custom_types/structs.md)"
+msgstr "[`structs`](../custom_types/structs.md)"
+
+#: src/generics/assoc_items.md:3
+msgid ""
+"\"Associated Items\" refers to a set of rules pertaining to [`item`](https://"
+"doc.rust-lang.org/reference/items.html)s of various types. It is an "
+"extension to `trait` generics, and allows `trait`s to internally define new "
+"items."
+msgstr "\"Associated Items\" refers to um set of rules pertaining to [`item`](https://doc.rust-lang.org/reference/items.html)s of various tipos. It is um extension to `trait` generics, e allows `trait`s to internally define novo items."
+
+#: src/generics/assoc_items.md:7
+msgid ""
+"One such item is called an _associated type_, providing simpler usage "
+"patterns when the `trait` is generic over its container type."
+msgstr "One such item is chamado um _associated type_, providing simpler usage patterns when o `trait` is generic over its container tipo."
+
+#: src/generics/assoc_items.md:12
+msgid ""
+"[RFC](https://github.com/rust-lang/rfcs/blob/master/text/0195-associated-"
+"items.md)"
+msgstr "[RFC](https://github.com/rust-lang/rfcs/blob/master/text/0195-associated-items.md)"
+
+#: src/generics/assoc_items/the_problem.md:3
+msgid ""
+"A `trait` that is generic over its container type has type specification "
+"requirements - users of the `trait` _must_ specify all of its generic types."
+msgstr "UM `trait` aquele is generic over its container tipo has tipo specification requirements - users of o `trait` _must_ specify all of its generic tipos."
+
+#: src/generics/assoc_items/the_problem.md:6
+msgid ""
+"In the example below, the `Contains` `trait` allows the use of the generic "
+"types `A` and `B`. The trait is then implemented for the `Container` type, "
+"specifying `i32` for `A` and `B` so that it can be used with `fn "
+"difference()`."
+msgstr "In o example abaixo, o `Contains` `trait` allows o use of o generic tipos `A` e `B`. O trait is then implemented para o `Container` tipo, specifying `i32` para `A` e `B` so aquele it pode be usado com `fn difference()`."
+
+#: src/generics/assoc_items/the_problem.md:10
+msgid ""
+"Because `Contains` is generic, we are forced to explicitly state _all_ of "
+"the generic types for `fn difference()`. In practice, we want a way to "
+"express that `A` and `B` are determined by the _input_ `C`. As you will see "
+"in the next section, associated types provide exactly that capability."
+msgstr "Porque `Contains` is generic, we are forced to explicitly state _all_ of o generic tipos para `fn difference()`. In practice, we want um way to express aquele `A` e `B` are determined by o _input_ `C`. As you vai see in o próximo section, associated tipos provide exactly aquele capability."
+
+#: src/generics/assoc_items/the_problem.md:17
+#: src/generics/assoc_items/types.md:36
+msgid ""
+"// A trait which checks if 2 items are stored inside of container.\n"
+"// Also retrieves first or last value.\n"
+msgstr ""
+"// UM trait which checks if 2 items are stored dentro of container.\n"
+"// Also retrieves primeiro ou último valor.\n"
+
+#: src/generics/assoc_items/the_problem.md:21
+msgid "// Explicitly requires `A` and `B`.\n"
+msgstr ""
+"// Explicitly requires `A` e `B`.\n"
+
+#: src/generics/assoc_items/the_problem.md:22
+#: src/generics/assoc_items/the_problem.md:23
+msgid "// Doesn't explicitly require `A` or `B`.\n"
+msgstr ""
+"// Doesn't explicitly require `A` ou `B`.\n"
+
+#: src/generics/assoc_items/the_problem.md:27
+msgid "// True if the numbers stored are equal.\n"
+msgstr ""
+"// True if o números stored are equal.\n"
+
+#: src/generics/assoc_items/the_problem.md:32
+#: src/generics/assoc_items/types.md:60
+msgid "// Grab the first number.\n"
+msgstr ""
+"// Grab o primeiro número.\n"
+
+#: src/generics/assoc_items/the_problem.md:35
+#: src/generics/assoc_items/types.md:63
+msgid "// Grab the last number.\n"
+msgstr ""
+"// Grab o último número.\n"
+
+#: src/generics/assoc_items/the_problem.md:38
+msgid ""
+"// `C` contains `A` and `B`. In light of that, having to express `A` and\n"
+"// `B` again is a nuisance.\n"
+msgstr ""
+"// `C` contains `A` e `B`. In light of aquele, having to express `A` e\n"
+"// `B` again is um nuisance.\n"
+
+#: src/generics/assoc_items/the_problem.md:52
+#: src/generics/assoc_items/types.md:77
+msgid "\"Does container contain {} and {}: {}\""
+msgstr "\"Does container contain {} e {}: {}\""
+
+#: src/generics/assoc_items/the_problem.md:55
+#: src/generics/assoc_items/types.md:80
+msgid "\"First number: {}\""
+msgstr "\"Primeiro número: {}\""
+
+#: src/generics/assoc_items/the_problem.md:56
+#: src/generics/assoc_items/types.md:81
+msgid "\"Last number: {}\""
+msgstr "\"Último número: {}\""
+
+#: src/generics/assoc_items/the_problem.md:58
+#: src/generics/assoc_items/types.md:83
+msgid "\"The difference is: {}\""
+msgstr "\"O difference is: {}\""
+
+#: src/generics/assoc_items/the_problem.md:64
+msgid ""
+"[`struct`s](../../custom_types/structs.md), and [`trait`s](../../trait.md)"
+msgstr "[`struct`s](../../custom_types/structs.md), e [`trait`s](../../trait.md)"
+
+#: src/generics/assoc_items/types.md:3
+msgid ""
+"The use of \"Associated types\" improves the overall readability of code by "
+"moving inner types locally into a trait as _output_ types. Syntax for the "
+"`trait` definition is as follows:"
+msgstr "O use of \"Associated tipos\" improves o overall readability of code by moving inner tipos locally em um trait as _output_ tipos. Syntax para o `trait` definition is as follows:"
+
+#: src/generics/assoc_items/types.md:8
+msgid ""
+"// `A` and `B` are defined in the trait via the `type` keyword.\n"
+"// (Note: `type` in this context is different from `type` when used for\n"
+"// aliases).\n"
+msgstr ""
+"// `A` e `B` are defined in o trait via o `type` keyword.\n"
+"// (Note: `type` in este context is diferente de `type` when usado para\n"
+"// aliases).\n"
+
+#: src/generics/assoc_items/types.md:15
+msgid "// Updated syntax to refer to these new types generically.\n"
+msgstr ""
+"// Updated syntax to refer to estes novo tipos generically.\n"
+
+#: src/generics/assoc_items/types.md:20
+msgid ""
+"Note that functions that use the `trait` `Contains` are no longer required "
+"to express `A` or `B` at all:"
+msgstr "Note aquele funções aquele use o `trait` `Contains` are no longer required to express `A` ou `B` at all:"
+
+#: src/generics/assoc_items/types.md:24
+msgid "// Without using associated types\n"
+msgstr ""
+"// Sem usando associated tipos\n"
+
+#: src/generics/assoc_items/types.md:27
+msgid "// Using associated types\n"
+msgstr ""
+"// Usando associated tipos\n"
+
+#: src/generics/assoc_items/types.md:32
+msgid ""
+"Let's rewrite the example from the previous section using associated types:"
+msgstr "Let's rewrite o example do anterior section usando associated tipos:"
+
+#: src/generics/assoc_items/types.md:40
+msgid "// Define generic types here which methods will be able to utilize.\n"
+msgstr ""
+"// Define generic tipos here which métodos vai be able to utilize.\n"
+
+#: src/generics/assoc_items/types.md:50
+msgid ""
+"// Specify what types `A` and `B` are. If the `input` type\n"
+"    // is `Container(i32, i32)`, the `output` types are determined\n"
+"    // as `i32` and `i32`.\n"
+msgstr ""
+"// Specify what tipos `A` e `B` are. If o `input` tipo\n"
+"    // is `Container(i32, i32)`, o `output` tipos are determined\n"
+"    // as `i32` e `i32`.\n"
+
+#: src/generics/assoc_items/types.md:56
+msgid "// `&Self::A` and `&Self::B` are also valid here.\n"
+msgstr ""
+"// `&Self::A` e `&Self::B` are also válido here.\n"
+
+#: src/generics/phantom.md:3
+msgid ""
+"A phantom type parameter is one that doesn't show up at runtime, but is "
+"checked statically (and only) at compile time."
+msgstr "UM phantom tipo parâmetro is one aquele doesn't show up at runtime, but is checked statically (e only) at compile time."
+
+#: src/generics/phantom.md:6
+msgid ""
+"Data types can use extra generic type parameters to act as markers or to "
+"perform type checking at compile time. These extra parameters hold no "
+"storage values, and have no runtime behavior."
+msgstr "Data tipos pode use extra generic tipo parâmetros to act as markers ou to perform tipo checking at compile time. Estes extra parâmetros hold no storage valores, e have no runtime behavior."
+
+#: src/generics/phantom.md:10
+msgid ""
+"In the following example, we combine [std::marker::PhantomData](https://doc."
+"rust-lang.org/std/marker/struct.PhantomData.html) with the phantom type "
+"parameter concept to create tuples containing different data types."
+msgstr "In o following example, we combine [std::marker::PhantomData](https://doc.rust-lang.org/std/marker/struct.PhantomData.html) com o phantom tipo parâmetro concept to create tuples containing diferente data tipos."
+
+#: src/generics/phantom.md:16
+msgid ""
+"// A phantom tuple struct which is generic over `A` with hidden parameter "
+"`B`.\n"
+msgstr ""
+"// UM phantom tuple struct which is generic over `A` com hidden parâmetro `B`.\n"
+
+#: src/generics/phantom.md:18 src/generics/phantom.md:22
+msgid "// Allow equality test for this type.\n"
+msgstr ""
+"// Allow equality test para este tipo.\n"
+
+#: src/generics/phantom.md:20
+msgid ""
+"// A phantom type struct which is generic over `A` with hidden parameter "
+"`B`.\n"
+msgstr ""
+"// UM phantom tipo struct which is generic over `A` com hidden parâmetro `B`.\n"
+
+#: src/generics/phantom.md:24
+msgid ""
+"// Note: Storage is allocated for generic type `A`, but not for `B`.\n"
+"//       Therefore, `B` cannot be used in computations.\n"
+msgstr ""
+"// Note: Storage is allocated para generic tipo `A`, but not para `B`.\n"
+"//       Therefore, `B` não pode be usado in computations.\n"
+
+#: src/generics/phantom.md:29
+msgid ""
+"// Here, `f32` and `f64` are the hidden parameters.\n"
+"    // PhantomTuple type specified as `<char, f32>`.\n"
+msgstr ""
+"// Here, `f32` e `f64` are o hidden parâmetros.\n"
+"    // PhantomTuple tipo specified as `<char, f32>`.\n"
+
+#: src/generics/phantom.md:31 src/generics/phantom.md:33
+#: src/generics/phantom.md:37 src/generics/phantom.md:42
+#: src/scope/borrow/ref.md:12
+msgid "'Q'"
+msgstr "'Q'"
+
+#: src/generics/phantom.md:32
+msgid "// PhantomTuple type specified as `<char, f64>`.\n"
+msgstr ""
+"// PhantomTuple tipo specified as `<char, f64>`.\n"
+
+#: src/generics/phantom.md:35
+msgid "// Type specified as `<char, f32>`.\n"
+msgstr ""
+"// Tipo specified as `<char, f32>`.\n"
+
+#: src/generics/phantom.md:40
+msgid "// Type specified as `<char, f64>`.\n"
+msgstr ""
+"// Tipo specified as `<char, f64>`.\n"
+
+#: src/generics/phantom.md:46
+msgid ""
+"// Compile-time Error! Type mismatch so these cannot be compared:\n"
+"    // println!(\"_tuple1 == _tuple2 yields: {}\",\n"
+"    //           _tuple1 == _tuple2);\n"
+msgstr ""
+"// Compile-time Erro! Tipo mismatch so estes não pode be compared:\n"
+"    // println!(\"_tuple1 == _tuple2 yields: {}\",\n"
+"    //           _tuple1 == _tuple2);\n"
+
+#: src/generics/phantom.md:50
+msgid ""
+"// Compile-time Error! Type mismatch so these cannot be compared:\n"
+"    // println!(\"_struct1 == _struct2 yields: {}\",\n"
+"    //           _struct1 == _struct2);\n"
+msgstr ""
+"// Compile-time Erro! Tipo mismatch so estes não pode be compared:\n"
+"    // println!(\"_struct1 == _struct2 yields: {}\",\n"
+"    //           _struct1 == _struct2);\n"
+
+#: src/generics/phantom.md:58
+msgid ""
+"[Derive](../trait/derive.md), [struct](../custom_types/structs.md), and "
+"[TupleStructs](../custom_types/structs.md)"
+msgstr "[Derive](../trait/derive.md), [struct](../custom_types/structs.md), e [TupleStructs](../custom_types/structs.md)"
+
+#: src/generics/phantom/testcase_units.md:3
+msgid ""
+"A useful method of unit conversions can be examined by implementing `Add` "
+"with a phantom type parameter. The `Add` `trait` is examined below:"
+msgstr "UM useful método of unit conversions pode be examined by implementing `Add` com um phantom tipo parâmetro. O `Add` `trait` is examined abaixo:"
+
+#: src/generics/phantom/testcase_units.md:7
+msgid ""
+"// This construction would impose: `Self + RHS = Output`\n"
+"// where RHS defaults to Self if not specified in the implementation.\n"
+msgstr ""
+"// This construction would impose: `Self + RHS = Output`\n"
+"// where RHS defaults to Self if not specified in the implementation.\n"
+
+#: src/generics/phantom/testcase_units.md:14
+msgid "// `Output` must be `T<U>` so that `T<U> + T<U> = T<U>`.\n"
+msgstr ""
+"// `Output` deve be `T<U>` so aquele `T<U> + T<U> = T<U>`.\n"
+
+#: src/generics/phantom/testcase_units.md:22
+msgid "The whole implementation:"
+msgstr "O whole implementation:"
+
+#: src/generics/phantom/testcase_units.md:27
+msgid "/// Create void enumerations to define unit types.\n"
+msgstr ""
+"/// Cria void enumerations to define unit tipos.\n"
+
+#: src/generics/phantom/testcase_units.md:33
+msgid ""
+"/// `Length` is a type with phantom type parameter `Unit`,\n"
+"/// and is not generic over the length type (that is `f64`).\n"
+"///\n"
+"/// `f64` already implements the `Clone` and `Copy` traits.\n"
+msgstr ""
+"/// `Length` is um tipo com phantom tipo parâmetro `Unit`,\n"
+"/// e is not generic over o length tipo (aquele is `f64`).\n"
+"///\n"
+"/// `f64` already implements o `Clone` e `Copy` traits.\n"
+
+#: src/generics/phantom/testcase_units.md:40
+msgid "/// The `Add` trait defines the behavior of the `+` operator.\n"
+msgstr ""
+"/// O `Add` trait defines o behavior of o `+` operator.\n"
+
+#: src/generics/phantom/testcase_units.md:45
+msgid "// add() returns a new `Length` struct containing the sum.\n"
+msgstr ""
+"// add() retorna um novo `Length` struct containing o sum.\n"
+
+#: src/generics/phantom/testcase_units.md:47
+msgid "// `+` calls the `Add` implementation for `f64`.\n"
+msgstr ""
+"// `+` calls o `Add` implementation para `f64`.\n"
+
+#: src/generics/phantom/testcase_units.md:53
+msgid "// Specifies `one_foot` to have phantom type parameter `Inch`.\n"
+msgstr ""
+"// Specifies `one_foot` to have phantom tipo parâmetro `Inch`.\n"
+
+#: src/generics/phantom/testcase_units.md:55
+msgid "// `one_meter` has phantom type parameter `Mm`.\n"
+msgstr ""
+"// `one_meter` has phantom tipo parâmetro `Mm`.\n"
+
+#: src/generics/phantom/testcase_units.md:58
+msgid ""
+"// `+` calls the `add()` method we implemented for `Length<Unit>`.\n"
+"    //\n"
+"    // Since `Length` implements `Copy`, `add()` does not consume\n"
+"    // `one_foot` and `one_meter` but copies them into `self` and `rhs`.\n"
+msgstr ""
+"// `+` calls o `add()` método we implemented para `Length<Unit>`.\n"
+"    //\n"
+"    // Since `Length` implements `Copy`, `add()` does not consume\n"
+"    // `one_foot` e `one_meter` but copies them em `self` e `rhs`.\n"
+
+#: src/generics/phantom/testcase_units.md:65
+msgid "// Addition works.\n"
+msgstr ""
+"// Adicionaition works.\n"
+
+#: src/generics/phantom/testcase_units.md:66
+msgid "\"one foot + one_foot = {:?} in\""
+msgstr "\"one foot + one_foot = {:?} in\""
+
+#: src/generics/phantom/testcase_units.md:67
+msgid "\"one meter + one_meter = {:?} mm\""
+msgstr "\"one meter + one_meter = {:?} mm\""
+
+#: src/generics/phantom/testcase_units.md:69
+msgid ""
+"// Nonsensical operations fail as they should:\n"
+"    // Compile-time Error: type mismatch.\n"
+"    //let one_feter = one_foot + one_meter;\n"
+msgstr ""
+"// Nonsensical operations fail as they deve:\n"
+"    // Compile-time Erro: tipo mismatch.\n"
+"    //let one_feter = one_foot + one_meter;\n"
+
+#: src/generics/phantom/testcase_units.md:77
+msgid ""
+"[Borrowing (`&`)](../../scope/borrow.md), [Bounds (`X: Y`)](../../generics/"
+"bounds.md), [enum](../../custom_types/enum.md), [impl & self](../../fn/"
+"methods.md), [Overloading](../../trait/ops.md), [ref](../../scope/borrow/ref."
+"md), [Traits (`X for Y`)](../../trait.md), and [TupleStructs](../../"
+"custom_types/structs.md)."
+msgstr "[Borrowing (`&`)](../../scope/borrow.md), [Bounds (`X: Y`)](../../generics/bounds.md), [enum](../../custom_types/enum.md), [impl & self](../../fn/methods.md), [Overloading](../../trait/ops.md), [ref](../../scope/borrow/ref.md), [Traits (`X for Y`)](../../trait.md), e [TupleStructs](../../custom_types/structs.md)."
+
+#: src/scope.md:3
+msgid ""
+"Scopes play an important part in ownership, borrowing, and lifetimes. That "
+"is, they indicate to the compiler when borrows are valid, when resources can "
+"be freed, and when variables are created or destroyed."
+msgstr "Scopes play an important part in ownership, borrowing, and lifetimes. That is, they indicate to the compiler when borrows are valid, when resources can be freed, and when variables are created or destroyed."
+
+#: src/scope/raii.md:3
+msgid ""
+"Variables in Rust do more than just hold data in the stack: they also _own_ "
+"resources, e.g. `Box<T>` owns memory in the heap. Rust enforces [RAII]"
+"(https://en.wikipedia.org/wiki/Resource_Acquisition_Is_Initialization) "
+"(Resource Acquisition Is Initialization), so whenever an object goes out of "
+"scope, its destructor is called and its owned resources are freed."
+msgstr "Variables in Rust do more than just hold data in the stack: they also _own_ resources, e.g. `Box<T>` owns memory in the heap. Rust enforces [RAII](https://en.wikipedia.org/wiki/Resource_Acquisition_Is_Initialization) (Resource Acquisition Is Initialization), so whenever an object goes out of scope, its destructor is called and its owned resources are freed."
+
+#: src/scope/raii.md:8
+msgid ""
+"This behavior shields against _resource leak_ bugs, so you'll never have to "
+"manually free memory or worry about memory leaks again! Here's a quick "
+"showcase:"
+msgstr "This behavior shields against _resource leak_ bugs, so you'll never have to manually free memory or worry about memory leaks again! Here's a quick showcase:"
+
+#: src/scope/raii.md:12
+msgid "// raii.rs\n"
+msgstr ""
+"// raii.rs\n"
+
+#: src/scope/raii.md:14 src/scope/raii.md:21 src/scope/raii.md:26
+msgid "// Allocate an integer on the heap\n"
+msgstr ""
+"// Allocate um inteiro on o heap\n"
+
+#: src/scope/raii.md:17
+msgid "// `_box1` is destroyed here, and memory gets freed\n"
+msgstr ""
+"// `_box1` is destroyed here, e memory gets freed\n"
+
+#: src/scope/raii.md:24
+msgid "// A nested scope:\n"
+msgstr ""
+"// UM nested scope:\n"
+
+#: src/scope/raii.md:29
+msgid "// `_box3` is destroyed here, and memory gets freed\n"
+msgstr ""
+"// `_box3` is destroyed here, e memory gets freed\n"
+
+#: src/scope/raii.md:32
+msgid ""
+"// Creating lots of boxes just for fun\n"
+"    // There's no need to manually free memory!\n"
+msgstr ""
+"// Creating lots of boxes just for fun\n"
+"    // There's no need to manually free memory!\n"
+
+#: src/scope/raii.md:38
+msgid "// `_box2` is destroyed here, and memory gets freed\n"
+msgstr ""
+"// `_box2` is destroyed here, e memory gets freed\n"
+
+#: src/scope/raii.md:42
+msgid ""
+"Of course, we can double check for memory errors using [`valgrind`](http://"
+"valgrind.org/info/):"
+msgstr "Of course, we pode double check para memory erros usando [`valgrind`](http://valgrind.org/info/):"
+
+#: src/scope/raii.md:65
+msgid "No leaks here!"
+msgstr "No leaks here!"
+
+#: src/scope/raii.md:67
+msgid "Destructor"
+msgstr "Destructor"
+
+#: src/scope/raii.md:69
+msgid ""
+"The notion of a destructor in Rust is provided through the [`Drop`](https://"
+"doc.rust-lang.org/std/ops/trait.Drop.html) trait. The destructor is called "
+"when the resource goes out of scope. This trait is not required to be "
+"implemented for every type, only implement it for your type if you require "
+"its own destructor logic."
+msgstr "The notion of a destructor in Rust is provided through the [`Drop`](https://doc.rust-lang.org/std/ops/trait.Drop.html) trait. The destructor is called when the resource goes out of scope. This trait is not required to be implemented for every type, only implement it for your type if you require its own destructor logic."
+
+#: src/scope/raii.md:74
+msgid ""
+"Run the below example to see how the [`Drop`](https://doc.rust-lang.org/std/"
+"ops/trait.Drop.html) trait works. When the variable in the `main` function "
+"goes out of scope the custom destructor will be invoked."
+msgstr "Run o abaixo example to see how o [`Drop`](https://doc.rust-lang.org/std/ops/trait.Drop.html) trait works. When o variável in o `main` função goes out of scope o custom destructor vai be invoked."
+
+#: src/scope/raii.md:82
+msgid "\"ToDrop is being dropped\""
+msgstr "\"ToDescarta is being dropped\""
+
+#: src/scope/raii.md:88
+msgid "\"Made a ToDrop!\""
+msgstr "\"Made um ToDescarta!\""
+
+#: src/scope/raii.md:94
+msgid "[Box](../std/box.md)"
+msgstr "[Box](../std/box.md)"
+
+#: src/scope/move.md:3
+msgid ""
+"Because variables are in charge of freeing their own resources, **resources "
+"can only have one owner**. This prevents resources from being freed more "
+"than once. Note that not all variables own resources (e.g. [references](../"
+"flow_control/match/destructuring/destructure_pointers.md))."
+msgstr "Because variables are in charge of freeing their own resources, **resources can only have one owner**. This prevents resources from being freed more than once. Note that not all variables own resources (e.g. [references](../flow_control/match/destructuring/destructure_pointers.md))."
+
+#: src/scope/move.md:8
+msgid ""
+"When doing assignments (`let x = y`) or passing function arguments by value "
+"(`foo(x)`), the _ownership_ of the resources is transferred. In Rust-speak, "
+"this is known as a _move_."
+msgstr "When doing assignments (`let x = y`) ou passing função argumentos by valor (`foo(x)`), o _ownership_ of o resources is transferred. In Rust-speak, este is known as um _move_."
+
+#: src/scope/move.md:12
+msgid ""
+"After moving resources, the previous owner can no longer be used. This "
+"avoids creating dangling pointers."
+msgstr "After moving resources, o anterior owner pode no longer be usado. Este avoids creating dangling pointers."
+
+#: src/scope/move.md:16
+msgid "// This function takes ownership of the heap allocated memory\n"
+msgstr ""
+"// Este função takes ownership of o heap allocated memory\n"
+
+#: src/scope/move.md:18
+msgid "\"Destroying a box that contains {}\""
+msgstr "\"Destroying um box aquele contains {}\""
+
+#: src/scope/move.md:20
+msgid "// `c` is destroyed and the memory freed\n"
+msgstr ""
+"// `c` is destroyed e o memory freed\n"
+
+#: src/scope/move.md:24
+msgid "// _Stack_ allocated integer\n"
+msgstr ""
+"// _Stack_ allocated inteiro\n"
+
+#: src/scope/move.md:27
+msgid "// *Copy* `x` into `y` - no resources are moved\n"
+msgstr ""
+"// *Copy* `x` em `y` - no resources are moved\n"
+
+#: src/scope/move.md:30
+msgid "// Both values can be independently used\n"
+msgstr ""
+"// Both valores pode be independently usado\n"
+
+#: src/scope/move.md:31
+msgid "\"x is {}, and y is {}\""
+msgstr "\"x is {}, e y is {}\""
+
+#: src/scope/move.md:33
+msgid "// `a` is a pointer to a _heap_ allocated integer\n"
+msgstr ""
+"// `a` is um pointer to um _heap_ allocated inteiro\n"
+
+#: src/scope/move.md:36
+msgid "\"a contains: {}\""
+msgstr "\"um contains: {}\""
+
+#: src/scope/move.md:38
+msgid "// *Move* `a` into `b`\n"
+msgstr ""
+"// *Move* `a` em `b`\n"
+
+#: src/scope/move.md:40
+msgid ""
+"// The pointer address of `a` is copied (not the data) into `b`.\n"
+"    // Both are now pointers to the same heap allocated data, but\n"
+"    // `b` now owns it.\n"
+msgstr ""
+"// The pointer address of `a` is copied (not the data) into `b`.\n"
+"    // Both are now pointers to the same heap allocated data, but\n"
+"    // `b` now owns it.\n"
+
+#: src/scope/move.md:44
+msgid ""
+"// Error! `a` can no longer access the data, because it no longer owns the\n"
+"    // heap memory\n"
+"    //println!(\"a contains: {}\", a);\n"
+"    // TODO ^ Try uncommenting this line\n"
+msgstr ""
+"// Erro! `a` pode no longer access o data, porque it no longer owns o\n"
+"    // heap memory\n"
+"    //println!(\"um contains: {}\", um);\n"
+"    // TODO ^ Tente uncommenting este line\n"
+
+#: src/scope/move.md:49
+msgid ""
+"// This function takes ownership of the heap allocated memory from `b`\n"
+msgstr ""
+"// Este função takes ownership of o heap allocated memory de `b`\n"
+
+#: src/scope/move.md:52
+msgid ""
+"// Since the heap memory has been freed at this point, this action would\n"
+"    // result in dereferencing freed memory, but it's forbidden by the "
+"compiler\n"
+"    // Error! Same reason as the previous Error\n"
+"    //println!(\"b contains: {}\", b);\n"
+"    // TODO ^ Try uncommenting this line\n"
+msgstr ""
+"// Since the heap memory has been freed at this point, this action would\n"
+"    // result in dereferencing freed memory, but it's forbidden by the compiler\n"
+"    // Error! Same reason as the previous Error\n"
+"    //println!(\"b contains: {}\", b);\n"
+"    // TODO ^ Try uncommenting this line\n"
+
+#: src/scope/move/mut.md:3
+msgid "Mutability of data can be changed when ownership is transferred."
+msgstr "Mutability of data can be changed when ownership is transferred."
+
+#: src/scope/move/mut.md:9
+msgid "\"immutable_box contains {}\""
+msgstr "\"immutable_box contains {}\""
+
+#: src/scope/move/mut.md:11
+msgid ""
+"// Mutability error\n"
+"    //*immutable_box = 4;\n"
+msgstr ""
+"// Mutability erro\n"
+"    //*immutable_box = 4;\n"
+
+#: src/scope/move/mut.md:14
+msgid "// *Move* the box, changing the ownership (and mutability)\n"
+msgstr ""
+"// *Move* o box, changing o ownership (e mutability)\n"
+
+#: src/scope/move/mut.md:17
+msgid "\"mutable_box contains {}\""
+msgstr "\"mutable_box contains {}\""
+
+#: src/scope/move/mut.md:19
+msgid "// Modify the contents of the box\n"
+msgstr ""
+"// Modify o contents of o box\n"
+
+#: src/scope/move/mut.md:22
+msgid "\"mutable_box now contains {}\""
+msgstr "\"mutable_box now contains {}\""
+
+#: src/scope/move/partial_move.md:3
+msgid ""
+"Within the [destructuring](../../flow_control/match/destructuring.md) of a "
+"single variable, both `by-move` and `by-reference` pattern bindings can be "
+"used at the same time. Doing this will result in a _partial move_ of the "
+"variable, which means that parts of the variable will be moved while other "
+"parts stay. In such a case, the parent variable cannot be used afterwards as "
+"a whole, however the parts that are only referenced (and not moved) can "
+"still be used. Note that types that implement the [`Drop` trait](../../trait/"
+"drop.md) cannot be partially moved from, because its `drop` method would use "
+"it afterwards as a whole."
+msgstr "Within o [destructuring](../../flow_control/match/destructuring.md) of um single variável, both `by-move` e `by-reference` pattern bindings pode be usado at o mesmo time. Doing este vai resultado in um _partial move_ of o variável, which means aquele parts of o variável vai be moved while other parts stay. In such um case, o parent variável não pode be usado afterwards as um whole, however o parts aquele are only referenced (e not moved) pode still be usado. Note aquele tipos aquele implement o [`Drop` trait](../../trait/drop.md) não pode be partially moved de, porque its `drop` método would use it afterwards as um whole."
+
+#: src/scope/move/partial_move.md:22
+msgid ""
+"// Error! cannot move out of a type which implements the `Drop` trait\n"
+"    //impl Drop for Person {\n"
+"    //    fn drop(&mut self) {\n"
+"    //        println!(\"Dropping the person struct {:?}\", self)\n"
+"    //    }\n"
+"    //}\n"
+"    // TODO ^ Try uncommenting these lines\n"
+msgstr ""
+"// Erro! não pode move out of um tipo which implements o `Drop` trait\n"
+"    //impl Descarta para Person {\n"
+"    //    fn drop(&mut self) {\n"
+"    //        println!(\"Descartaping o person struct {:?}\", self)\n"
+"    //    }\n"
+"    //}\n"
+"    // TODO ^ Tente uncommenting estes lines\n"
+
+#: src/scope/move/partial_move.md:35
+msgid "// `name` is moved out of person, but `age` is referenced\n"
+msgstr ""
+"// `name` is moved out of person, but `age` is referenced\n"
+
+#: src/scope/move/partial_move.md:38
+msgid "\"The person's age is {}\""
+msgstr "\"O person's age is {}\""
+
+#: src/scope/move/partial_move.md:40
+msgid "\"The person's name is {}\""
+msgstr "\"O person's name is {}\""
+
+#: src/scope/move/partial_move.md:42
+msgid ""
+"// Error! borrow of partially moved value: `person` partial move occurs\n"
+"    //println!(\"The person struct is {:?}\", person);\n"
+msgstr ""
+"// Erro! emprestar of partially moved valor: `person` partial move occurs\n"
+"    //println!(\"O person struct is {:?}\", person);\n"
+
+#: src/scope/move/partial_move.md:45
+msgid ""
+"// `person` cannot be used but `person.age` can be used as it is not moved\n"
+msgstr ""
+"// `person` cannot be used but `person.age` can be used as it is not moved\n"
+
+#: src/scope/move/partial_move.md:46
+msgid "\"The person's age from person struct is {}\""
+msgstr "\"O person's age de person struct is {}\""
+
+#: src/scope/move/partial_move.md:50
+msgid ""
+"(In this example, we store the `age` variable on the heap to illustrate the "
+"partial move: deleting `ref` in the above code would give an error as the "
+"ownership of `person.age` would be moved to the variable `age`. If `Person."
+"age` were stored on the stack, `ref` would not be required as the definition "
+"of `age` would copy the data from `person.age` without moving it.)"
+msgstr "(In this example, we store the `age` variable on the heap to illustrate the partial move: deleting `ref` in the above code would give an error as the ownership of `person.age` would be moved to the variable `age`. If `Person.age` were stored on the stack, `ref` would not be required as the definition of `age` would copy the data from `person.age` without moving it.)"
+
+#: src/scope/move/partial_move.md:59
+msgid "[destructuring](../../flow_control/match/destructuring.md)"
+msgstr "[destructuring](../../flow_control/match/destructuring.md)"
+
+#: src/scope/borrow.md:3
+msgid ""
+"Most of the time, we'd like to access data without taking ownership over it. "
+"To accomplish this, Rust uses a _borrowing_ mechanism. Instead of passing "
+"objects by value (`T`), objects can be passed by reference (`&T`)."
+msgstr "Most of o time, we'd like to access data sem taking ownership over it. To accomplish este, Rust uses um _borrowing_ mechanism. Instead of passing objects by valor (`T`), objects pode be passed by reference (`&T`)."
+
+#: src/scope/borrow.md:7
+msgid ""
+"The compiler statically guarantees (via its borrow checker) that references "
+"_always_ point to valid objects. That is, while references to an object "
+"exist, the object cannot be destroyed."
+msgstr "O compiler statically guarantees (via its emprestar checker) aquele references _always_ point to válido objects. Aquele is, while references to um object exist, o object não pode be destroyed."
+
+#: src/scope/borrow.md:12
+msgid "// This function takes ownership of a box and destroys it\n"
+msgstr ""
+"// Este função takes ownership of um box e destroys it\n"
+
+#: src/scope/borrow.md:14
+msgid "\"Destroying box that contains {}\""
+msgstr "\"Destroying box aquele contains {}\""
+
+#: src/scope/borrow.md:16
+msgid "// This function borrows an i32\n"
+msgstr ""
+"// Este função empréstimos um i32\n"
+
+#: src/scope/borrow.md:19
+msgid "\"This int is: {}\""
+msgstr "\"Este int is: {}\""
+
+#: src/scope/borrow.md:23
+msgid ""
+"// Create a boxed i32 in the heap, and a i32 on the stack\n"
+"    // Remember: numbers can have arbitrary underscores added for "
+"readability\n"
+"    // 5_i32 is the same as 5i32\n"
+msgstr ""
+"// Cria um boxed i32 in o heap, e um i32 on o stack\n"
+"    // Remember: números pode have arbitrary underscores added para readability\n"
+"    // 5_i32 is o mesmo as 5i32\n"
+
+#: src/scope/borrow.md:29
+msgid ""
+"// Borrow the contents of the box. Ownership is not taken,\n"
+"    // so the contents can be borrowed again.\n"
+msgstr ""
+"// Empresta o contents of o box. Ownership is not taken,\n"
+"    // so o contents pode be emprestadas again.\n"
+
+#: src/scope/borrow.md:35
+msgid "// Take a reference to the data contained inside the box\n"
+msgstr ""
+"// Take um reference to o data contained dentro o box\n"
+
+#: src/scope/borrow.md:38
+msgid ""
+"// Error!\n"
+"        // Can't destroy `boxed_i32` while the inner value is borrowed later "
+"in scope.\n"
+msgstr ""
+"// Erro!\n"
+"        // Pode't destroy `boxed_i32` while o inner valor is emprestadas later in scope.\n"
+
+#: src/scope/borrow.md:43
+msgid "// Attempt to borrow `_ref_to_i32` after inner value is destroyed\n"
+msgstr ""
+"// Attempt to emprestar `_ref_to_i32` after inner valor is destroyed\n"
+
+#: src/scope/borrow.md:45
+msgid "// `_ref_to_i32` goes out of scope and is no longer borrowed.\n"
+msgstr ""
+"// `_ref_to_i32` goes out of scope and is no longer borrowed.\n"
+
+#: src/scope/borrow.md:48
+msgid ""
+"// `boxed_i32` can now give up ownership to `eat_box_i32` and be destroyed\n"
+msgstr ""
+"// `boxed_i32` pode now give up ownership to `eat_box_i32` e be destroyed\n"
+
+#: src/scope/borrow/mut.md:3
+msgid ""
+"Mutable data can be mutably borrowed using `&mut T`. This is called a "
+"_mutable reference_ and gives read/write access to the borrower. In "
+"contrast, `&T` borrows the data via an immutable reference, and the borrower "
+"can read the data but not modify it:"
+msgstr "Mutável data pode be mutably emprestadas usando `&mut T`. Este is chamado um _mutable reference_ e gives read/write access to o borrower. In contrast, `&T` empréstimos o data via um imutável reference, e o borrower pode read o data but not modify it:"
+
+#: src/scope/borrow/mut.md:12
+msgid ""
+"// `&'static str` is a reference to a string allocated in read only memory\n"
+msgstr ""
+"// `&'static str` is a reference to a string allocated in read only memory\n"
+
+#: src/scope/borrow/mut.md:17
+msgid "// This function takes a reference to a book\n"
+msgstr ""
+"// Este função takes um reference to um book\n"
+
+#: src/scope/borrow/mut.md:20
+msgid "\"I immutably borrowed {} - {} edition\""
+msgstr "\"I immutably emprestadas {} - {} edition\""
+
+#: src/scope/borrow/mut.md:22
+msgid ""
+"// This function takes a reference to a mutable book and changes `year` to "
+"2014\n"
+msgstr ""
+"// Este função takes um reference to um mutável book e changes `year` to 2014\n"
+
+#: src/scope/borrow/mut.md:26
+msgid "\"I mutably borrowed {} - {} edition\""
+msgstr "\"I mutably emprestadas {} - {} edition\""
+
+#: src/scope/borrow/mut.md:30
+msgid "// Create an immutable Book named `immutabook`\n"
+msgstr ""
+"// Cria um imutável Book named `immutabook`\n"
+
+#: src/scope/borrow/mut.md:32
+msgid "// string literals have type `&'static str`\n"
+msgstr ""
+"// string literals have tipo `&'static str`\n"
+
+#: src/scope/borrow/mut.md:33
+msgid "\"Douglas Hofstadter\""
+msgstr "\"Douglas Hofstadter\""
+
+#: src/scope/borrow/mut.md:34
+msgid "\"Gödel, Escher, Bach\""
+msgstr "\"Gödel, Escher, Bach\""
+
+#: src/scope/borrow/mut.md:38
+msgid "// Create a mutable copy of `immutabook` and call it `mutabook`\n"
+msgstr ""
+"// Cria um mutável copy of `immutabook` e call it `mutabook`\n"
+
+#: src/scope/borrow/mut.md:41
+msgid "// Immutably borrow an immutable object\n"
+msgstr ""
+"// Immutably emprestar um imutável object\n"
+
+#: src/scope/borrow/mut.md:44
+msgid "// Immutably borrow a mutable object\n"
+msgstr ""
+"// Immutably emprestar um mutável object\n"
+
+#: src/scope/borrow/mut.md:47
+msgid "// Borrow a mutable object as mutable\n"
+msgstr ""
+"// Empresta um mutável object as mutável\n"
+
+#: src/scope/borrow/mut.md:50
+msgid "// Error! Cannot borrow an immutable object as mutable\n"
+msgstr ""
+"// Erro! Não pode emprestar um imutável object as mutável\n"
+
+#: src/scope/borrow/mut.md:58
+msgid "[`static`](../lifetime/static_lifetime.md)"
+msgstr "[`static`](../lifetime/static_lifetime.md)"
+
+#: src/scope/borrow/alias.md:3
+msgid ""
+"Data can be immutably borrowed any number of times, but while immutably "
+"borrowed, the original data can't be mutably borrowed. On the other hand, "
+"only _one_ mutable borrow is allowed at a time. The original data can be "
+"borrowed again only _after_ the mutable reference has been used for the last "
+"time."
+msgstr "Data pode be immutably emprestadas any número of times, but while immutably emprestadas, o original data pode't be mutably emprestadas. On o other hand, only _one_ mutável emprestar is allowed at um time. O original data pode be emprestadas again only _after_ o mutável reference has been usado para o último time."
+
+#: src/scope/borrow/alias.md:17
+msgid "// Data can be accessed via the references and the original owner\n"
+msgstr ""
+"// Data pode be accessed via o references e o original owner\n"
+
+#: src/scope/borrow/alias.md:18 src/scope/borrow/alias.md:27
+#: src/scope/borrow/alias.md:49
+msgid "\"Point has coordinates: ({}, {}, {})\""
+msgstr "\"Point has coordinates: ({}, {}, {})\""
+
+#: src/scope/borrow/alias.md:21
+msgid ""
+"// Error! Can't borrow `point` as mutable because it's currently\n"
+"    // borrowed as immutable.\n"
+"    // let mutable_borrow = &mut point;\n"
+"    // TODO ^ Try uncommenting this line\n"
+msgstr ""
+"// Erro! Pode't emprestar `point` as mutável porque it's currently\n"
+"    // emprestadas as imutável.\n"
+"    // let mutable_borrow = &mut point;\n"
+"    // TODO ^ Tente uncommenting este line\n"
+
+#: src/scope/borrow/alias.md:26
+msgid "// The borrowed values are used again here\n"
+msgstr ""
+"// O emprestadas valores are usado again here\n"
+
+#: src/scope/borrow/alias.md:30
+msgid ""
+"// The immutable references are no longer used for the rest of the code so\n"
+"    // it is possible to reborrow with a mutable reference.\n"
+msgstr ""
+"// O imutável references are no longer usado para o rest of o code so\n"
+"    // it is possible to reborrow com um mutável reference.\n"
+
+#: src/scope/borrow/alias.md:34
+msgid "// Change data via mutable reference\n"
+msgstr ""
+"// Change data via mutável reference\n"
+
+#: src/scope/borrow/alias.md:39
+msgid ""
+"// Error! Can't borrow `point` as immutable because it's currently\n"
+"    // borrowed as mutable.\n"
+"    // let y = &point.y;\n"
+"    // TODO ^ Try uncommenting this line\n"
+msgstr ""
+"// Erro! Pode't emprestar `point` as imutável porque it's currently\n"
+"    // emprestadas as mutável.\n"
+"    // let y = &point.y;\n"
+"    // TODO ^ Tente uncommenting este line\n"
+
+#: src/scope/borrow/alias.md:44
+msgid ""
+"// Error! Can't print because `println!` takes an immutable reference.\n"
+"    // println!(\"Point Z coordinate is {}\", point.z);\n"
+"    // TODO ^ Try uncommenting this line\n"
+msgstr ""
+"// Erro! Pode't print porque `println!` takes um imutável reference.\n"
+"    // println!(\"Point Z coordinate is {}\", point.z);\n"
+"    // TODO ^ Tente uncommenting este line\n"
+
+#: src/scope/borrow/alias.md:48
+msgid "// Ok! Mutable references can be passed as immutable to `println!`\n"
+msgstr ""
+"// Ok! Mutável references pode be passed as imutável to `println!`\n"
+
+#: src/scope/borrow/alias.md:52
+msgid ""
+"// The mutable reference is no longer used for the rest of the code so it\n"
+"    // is possible to reborrow\n"
+msgstr ""
+"// O mutável reference is no longer usado para o rest of o code so it\n"
+"    // is possible to reborrow\n"
+
+#: src/scope/borrow/alias.md:55
+msgid "\"Point now has coordinates: ({}, {}, {})\""
+msgstr "\"Point now has coordinates: ({}, {}, {})\""
+
+#: src/scope/borrow/ref.md:3
+msgid ""
+"When doing pattern matching or destructuring via the `let` binding, the "
+"`ref` keyword can be used to take references to the fields of a struct/"
+"tuple. The example below shows a few instances where this can be useful:"
+msgstr "When doing pattern matching ou destructuring via o `let` binding, o `ref` keyword pode be usado to take references to o campos of um struct/tuple. O example abaixo shows um few instances where este pode be useful:"
+
+#: src/scope/borrow/ref.md:14
+msgid ""
+"// A `ref` borrow on the left side of an assignment is equivalent to\n"
+"    // an `&` borrow on the right side.\n"
+msgstr ""
+"// UM `ref` emprestar on o left side of um assignment is equivalent to\n"
+"    // um `&` emprestar on o right side.\n"
+
+#: src/scope/borrow/ref.md:19
+msgid "\"ref_c1 equals ref_c2: {}\""
+msgstr "\"ref_c1 equals ref_c2: {}\""
+
+#: src/scope/borrow/ref.md:23
+msgid "// `ref` is also valid when destructuring a struct.\n"
+msgstr ""
+"// `ref` is also válido when destructuring um struct.\n"
+
+#: src/scope/borrow/ref.md:25
+msgid "// `ref_to_x` is a reference to the `x` field of `point`.\n"
+msgstr ""
+"// `ref_to_x` is um reference to o `x` campo of `point`.\n"
+
+#: src/scope/borrow/ref.md:28
+msgid "// Return a copy of the `x` field of `point`.\n"
+msgstr ""
+"// Retorna um copy of o `x` campo of `point`.\n"
+
+#: src/scope/borrow/ref.md:32
+msgid "// A mutable copy of `point`\n"
+msgstr ""
+"// UM mutável copy of `point`\n"
+
+#: src/scope/borrow/ref.md:36
+msgid "// `ref` can be paired with `mut` to take mutable references.\n"
+msgstr ""
+"// `ref` pode be paired com `mut` to take mutável references.\n"
+
+#: src/scope/borrow/ref.md:39
+msgid "// Mutate the `y` field of `mutable_point` via a mutable reference.\n"
+msgstr ""
+"// Mutate o `y` campo of `mutable_point` via um mutável reference.\n"
+
+#: src/scope/borrow/ref.md:43
+msgid "\"point is ({}, {})\""
+msgstr "\"point is ({}, {})\""
+
+#: src/scope/borrow/ref.md:44
+msgid "\"mutable_point is ({}, {})\""
+msgstr "\"mutable_point is ({}, {})\""
+
+#: src/scope/borrow/ref.md:46
+msgid "// A mutable tuple that includes a pointer\n"
+msgstr ""
+"// UM mutável tuple aquele includes um pointer\n"
+
+#: src/scope/borrow/ref.md:50
+msgid "// Destructure `mutable_tuple` to change the value of `last`.\n"
+msgstr ""
+"// Destructure `mutable_tuple` to change o valor of `last`.\n"
+
+#: src/scope/borrow/ref.md:55
+msgid "\"tuple is {:?}\""
+msgstr "\"tuple is {:?}\""
+
+#: src/scope/lifetime.md:3
+msgid ""
+"A _lifetime_ is a construct the compiler (or more specifically, its _borrow "
+"checker_) uses to ensure all borrows are valid. Specifically, a variable's "
+"lifetime begins when it is created and ends when it is destroyed. While "
+"lifetimes and scopes are often referred to together, they are not the same."
+msgstr "A _lifetime_ is a construct the compiler (or more specifically, its _borrow checker_) uses to ensure all borrows are valid. Specifically, a variable's lifetime begins when it is created and ends when it is destroyed. While lifetimes and scopes are often referred to together, they are not the same."
+
+#: src/scope/lifetime.md:8
+msgid ""
+"Take, for example, the case where we borrow a variable via `&`. The borrow "
+"has a lifetime that is determined by where it is declared. As a result, the "
+"borrow is valid as long as it ends before the lender is destroyed. However, "
+"the scope of the borrow is determined by where the reference is used."
+msgstr "Take, for example, the case where we borrow a variable via `&`. The borrow has a lifetime that is determined by where it is declared. As a result, the borrow is valid as long as it ends before the lender is destroyed. However, the scope of the borrow is determined by where the reference is used."
+
+#: src/scope/lifetime.md:13
+msgid ""
+"In the following example and in the rest of this section, we will see how "
+"lifetimes relate to scopes, as well as how the two differ."
+msgstr "In o following example e in o rest of este section, we vai see how lifetimes relate to scopes, as well as how o two differ."
+
+#: src/scope/lifetime.md:17
+msgid ""
+"// Lifetimes are annotated below with lines denoting the creation\n"
+"// and destruction of each variable.\n"
+"// `i` has the longest lifetime because its scope entirely encloses \n"
+"// both `borrow1` and `borrow2`. The duration of `borrow1` compared \n"
+"// to `borrow2` is irrelevant since they are disjoint.\n"
+msgstr ""
+"// Lifetimes are annotated below with lines denoting the creation\n"
+"// and destruction of each variable.\n"
+"// `i` has the longest lifetime because its scope entirely encloses \n"
+"// both `borrow1` and `borrow2`. The duration of `borrow1` compared \n"
+"// to `borrow2` is irrelevant since they are disjoint.\n"
+
+#: src/scope/lifetime.md:23
+msgid ""
+"// Lifetime for `i` starts. ────────────────┐\n"
+"    //                                                     │\n"
+msgstr ""
+"// Lifetime para `i` starts. ────────────────┐\n"
+"    //                                                     │\n"
+
+#: src/scope/lifetime.md:25 src/scope/lifetime.md:32
+msgid "//                                                   │\n"
+msgstr ""
+"//                                                   │\n"
+
+#: src/scope/lifetime.md:26
+msgid ""
+"// `borrow1` lifetime starts. ──┐│\n"
+"        //                                                ││\n"
+msgstr ""
+"// `borrow1` lifetime starts. ──┐│\n"
+"        //                                                ││\n"
+
+#: src/scope/lifetime.md:28
+msgid "\"borrow1: {}\""
+msgstr "\"borrow1: {}\""
+
+#: src/scope/lifetime.md:28 src/scope/lifetime.md:35
+msgid "//              ││\n"
+msgstr ""
+"//              ││\n"
+
+#: src/scope/lifetime.md:29
+msgid ""
+"// `borrow1` ends. ─────────────────────────────────┘│\n"
+"    //                                                     │\n"
+"    //                                                     │\n"
+msgstr ""
+"// `borrow1` ends. ─────────────────────────────────┘│\n"
+"    //                                                     │\n"
+"    //                                                     │\n"
+
+#: src/scope/lifetime.md:33
+msgid ""
+"// `borrow2` lifetime starts. ──┐│\n"
+"        //                                                ││\n"
+msgstr ""
+"// `borrow2` lifetime starts. ──┐│\n"
+"        //                                                ││\n"
+
+#: src/scope/lifetime.md:35
+msgid "\"borrow2: {}\""
+msgstr "\"borrow2: {}\""
+
+#: src/scope/lifetime.md:36
+msgid ""
+"// `borrow2` ends. ─────────────────────────────────┘│\n"
+"    //                                                     │\n"
+msgstr ""
+"// `borrow2` ends. ─────────────────────────────────┘│\n"
+"    //                                                     │\n"
+
+#: src/scope/lifetime.md:38
+msgid "// Lifetime ends. ─────────────────────────────────────┘\n"
+msgstr ""
+"// Lifetime ends. ─────────────────────────────────────┘\n"
+
+#: src/scope/lifetime.md:41
+msgid ""
+"Note that no names or types are assigned to label lifetimes. This restricts "
+"how lifetimes will be able to be used as we will see."
+msgstr "Note aquele no names ou tipos are assigned to label lifetimes. Este restricts how lifetimes vai be able to be usado as we vai see."
+
+#: src/scope/lifetime/explicit.md:3
+msgid ""
+"The borrow checker uses explicit lifetime annotations to determine how long "
+"references should be valid. In cases where lifetimes are not elided[^1], "
+"Rust requires explicit annotations to determine what the lifetime of a "
+"reference should be. The syntax for explicitly annotating a lifetime uses an "
+"apostrophe character as follows:"
+msgstr "O emprestar checker uses explícita lifetime annotations to determine how long references deve be válido. In cases where lifetimes are not elided[^1], Rust requires explícita annotations to determine what o lifetime of um reference deve be. O syntax para explicitly annotating um lifetime uses um apostrophe character as follows:"
+
+#: src/scope/lifetime/explicit.md:10
+msgid "// `foo` has a lifetime parameter `'a`\n"
+msgstr ""
+"// `foo` has um lifetime parâmetro `'a`\n"
+
+#: src/scope/lifetime/explicit.md:14
+msgid ""
+"Similar to [closures](../../fn/closures/anonymity.md), using lifetimes "
+"requires generics. Additionally, this lifetime syntax indicates that the "
+"lifetime of `foo` may not exceed that of `'a`. Explicit annotation of a type "
+"has the form `&'a T` where `'a` has already been introduced."
+msgstr "Similar to [closures](../../fn/closures/anonymity.md), usando lifetimes requires generics. Adicionaitionally, este lifetime syntax indicates aquele o lifetime of `foo` may not exceed aquele of `'a`. Explícita anotação of um tipo has o form `&'a T` where `'a` has already been introduced."
+
+#: src/scope/lifetime/explicit.md:19
+msgid "In cases with multiple lifetimes, the syntax is similar:"
+msgstr "In cases com multiple lifetimes, o syntax is similar:"
+
+#: src/scope/lifetime/explicit.md:22
+msgid "// `foo` has lifetime parameters `'a` and `'b`\n"
+msgstr ""
+"// `foo` has lifetime parâmetros `'a` e `'b`\n"
+
+#: src/scope/lifetime/explicit.md:26
+msgid ""
+"In this case, the lifetime of `foo` cannot exceed that of either `'a` _or_ "
+"`'b`."
+msgstr "In this case, the lifetime of `foo` cannot exceed that of either `'a` _or_ `'b`."
+
+#: src/scope/lifetime/explicit.md:28
+msgid "See the following example for explicit lifetime annotation in use:"
+msgstr "See o following example para explícita lifetime anotação in use:"
+
+#: src/scope/lifetime/explicit.md:31
+msgid ""
+"// `print_refs` takes two references to `i32` which have different\n"
+"// lifetimes `'a` and `'b`. These two lifetimes must both be at\n"
+"// least as long as the function `print_refs`.\n"
+msgstr ""
+"// `print_refs` takes two references to `i32` which have diferente\n"
+"// lifetimes `'a` e `'b`. Estes two lifetimes deve both be at\n"
+"// least as long as a função `print_refs`.\n"
+
+#: src/scope/lifetime/explicit.md:35
+msgid "\"x is {} and y is {}\""
+msgstr "\"x is {} e y is {}\""
+
+#: src/scope/lifetime/explicit.md:37
+msgid ""
+"// A function which takes no arguments, but has a lifetime parameter `'a`.\n"
+msgstr ""
+"// UM função which takes no argumentos, but has um lifetime parâmetro `'a`.\n"
+
+#: src/scope/lifetime/explicit.md:42
+msgid "// ERROR: `_x` does not live long enough\n"
+msgstr ""
+"// ERRO: `_x` does not live long enough\n"
+
+#: src/scope/lifetime/explicit.md:44
+msgid ""
+"// Attempting to use the lifetime `'a` as an explicit type annotation \n"
+"    // inside the function will fail because the lifetime of `&_x` is "
+"shorter\n"
+"    // than that of `_y`. A short lifetime cannot be coerced into a longer "
+"one.\n"
+msgstr ""
+"// Tentar usar o lifetime `'a` como uma anotação de tipo explícita \n"
+"    // dentro da função falhará porque o lifetime de `&_x` é mais curto\n"
+"    // que o de `_y`. Um lifetime curto não pode ser coagido para um mais longo.\n"
+
+#: src/scope/lifetime/explicit.md:50
+msgid "// Create variables to be borrowed below.\n"
+msgstr ""
+"// Cria variáveis que serão emprestadas abaixo.\n"
+
+#: src/scope/lifetime/explicit.md:53
+msgid "// Borrows (`&`) of both variables are passed into the function.\n"
+msgstr ""
+"// Emprestas (`&`) of both variáveis are passed na função.\n"
+
+#: src/scope/lifetime/explicit.md:55
+msgid ""
+"// Any input which is borrowed must outlive the borrower. \n"
+"    // In other words, the lifetime of `four` and `nine` must \n"
+"    // be longer than that of `print_refs`.\n"
+msgstr ""
+"// Qualquer entrada emprestada deve viver mais que quem um empresta. \n"
+"    // In other words, o lifetime of `four` e `nine` deve \n"
+"    // be longer que o de `print_refs`.\n"
+
+#: src/scope/lifetime/explicit.md:60
+msgid ""
+"// `failed_borrow` contains no references to force `'a` to be \n"
+"    // longer than the lifetime of the function, but `'a` is longer.\n"
+"    // Because the lifetime is never constrained, it defaults to `'static`.\n"
+msgstr ""
+"// `failed_borrow` contains no references to force `'a` to be \n"
+"    // longer than the lifetime of the function, but `'a` is longer.\n"
+"    // Because the lifetime is never constrained, it defaults to `'static`.\n"
+
+#: src/scope/lifetime/explicit.md:66
+msgid ""
+"[elision](elision.md) implicitly annotates lifetimes and so is different."
+msgstr "[elision](elision.md) implicitly annotates lifetimes e so is diferente."
+
+#: src/scope/lifetime/explicit.md:70
+msgid "[generics](../../generics.md) and [closures](../../fn/closures.md)"
+msgstr "[generics](../../generics.md) e [closures](../../fn/closures.md)"
+
+#: src/scope/lifetime/fn.md:3
+msgid ""
+"Ignoring [elision](elision.md), function signatures with lifetimes have a "
+"few constraints:"
+msgstr "Ignoring [elision](elision.md), função signatures com lifetimes have um few constraints:"
+
+#: src/scope/lifetime/fn.md:5
+msgid "any reference _must_ have an annotated lifetime."
+msgstr "any reference _must_ have um annotated lifetime."
+
+#: src/scope/lifetime/fn.md:6
+msgid ""
+"any reference being returned _must_ have the same lifetime as an input or be "
+"`static`."
+msgstr "any reference being returned _must_ have the same lifetime as an input or be `static`."
+
+#: src/scope/lifetime/fn.md:9
+msgid ""
+"Additionally, note that returning references without input is banned if it "
+"would result in returning references to invalid data. The following example "
+"shows off some valid forms of functions with lifetimes:"
+msgstr "Adicionaitionally, note aquele returning references sem entrada is banned if it would resultado in returning references to inválido data. O following example shows off some válido forms of funções com lifetimes:"
+
+#: src/scope/lifetime/fn.md:14
+msgid ""
+"// One input reference with lifetime `'a` which must live\n"
+"// at least as long as the function.\n"
+msgstr ""
+"// One entrada reference com lifetime `'a` which deve live\n"
+"// at least as long as a função.\n"
+
+#: src/scope/lifetime/fn.md:17
+msgid "\"`print_one`: x is {}\""
+msgstr "\"`print_one`: x is {}\""
+
+#: src/scope/lifetime/fn.md:19
+msgid "// Mutable references are possible with lifetimes as well.\n"
+msgstr ""
+"// Mutável references are possible com lifetimes as well.\n"
+
+#: src/scope/lifetime/fn.md:24
+msgid ""
+"// Multiple elements with different lifetimes. In this case, it\n"
+"// would be fine for both to have the same lifetime `'a`, but\n"
+"// in more complex cases, different lifetimes may be required.\n"
+msgstr ""
+"// Multiple elements with different lifetimes. In this case, it\n"
+"// would be fine for both to have the same lifetime `'a`, but\n"
+"// in more complex cases, different lifetimes may be required.\n"
+
+#: src/scope/lifetime/fn.md:29
+msgid "\"`print_multi`: x is {}, y is {}\""
+msgstr "\"`print_multi`: x is {}, y is {}\""
+
+#: src/scope/lifetime/fn.md:31
+msgid ""
+"// Returning references that have been passed in is acceptable.\n"
+"// However, the correct lifetime must be returned.\n"
+msgstr ""
+"// Returning references that have been passed in is acceptable.\n"
+"// However, the correct lifetime must be returned.\n"
+
+#: src/scope/lifetime/fn.md:35
+msgid ""
+"//fn invalid_output<'a>() -> &'a String { &String::from(\"foo\") }\n"
+"// The above is invalid: `'a` must live longer than the function.\n"
+"// Here, `&String::from(\"foo\")` would create a `String`, followed by a\n"
+"// reference. Then the data is dropped upon exiting the scope, leaving\n"
+"// a reference to invalid data to be returned.\n"
+msgstr ""
+"//fn invalid_output<'a>() -> &'a String { &String::from(\"foo\") }\n"
+"// The above is invalid: `'a` must live longer than the function.\n"
+"// Here, `&String::from(\"foo\")` would create a `String`, followed by a\n"
+"// reference. Then the data is dropped upon exiting the scope, leaving\n"
+"// a reference to invalid data to be returned.\n"
+
+#: src/scope/lifetime/fn.md:60
+msgid "[Functions](../../fn.md)"
+msgstr "[Functions](../../fn.md)"
+
+#: src/scope/lifetime/methods.md:3
+msgid "Methods are annotated similarly to functions:"
+msgstr "Métodos are annotated similarly to funções:"
+
+#: src/scope/lifetime/methods.md:9
+msgid "// Annotate lifetimes as in a standalone function.\n"
+msgstr ""
+"// Annotate lifetimes as in um standalone função.\n"
+
+#: src/scope/lifetime/methods.md:12
+msgid "\"`print`: {}\""
+msgstr "\"`print`: {}\""
+
+#: src/scope/lifetime/methods.md:26
+msgid "[methods](../../fn/methods.md)"
+msgstr "[methods](../../fn/methods.md)"
+
+#: src/scope/lifetime/struct.md:3
+msgid "Annotation of lifetimes in structures are also similar to functions:"
+msgstr "Annotation of lifetimes in structures are also similar to functions:"
+
+#: src/scope/lifetime/struct.md:6
+msgid ""
+"// A type `Borrowed` which houses a reference to an\n"
+"// `i32`. The reference to `i32` must outlive `Borrowed`.\n"
+msgstr ""
+"// UM tipo `Borrowed` which houses um reference to um\n"
+"// `i32`. O reference to `i32` deve outlive `Borrowed`.\n"
+
+#: src/scope/lifetime/struct.md:10
+msgid "// Similarly, both references here must outlive this structure.\n"
+msgstr ""
+"// Similarly, both references here deve outlive este estrutura.\n"
+
+#: src/scope/lifetime/struct.md:17
+msgid "// An enum which is either an `i32` or a reference to one.\n"
+msgstr ""
+"// Um enum which is either um `i32` ou um reference to one.\n"
+
+#: src/scope/lifetime/struct.md:34 src/scope/lifetime/struct.md:36
+msgid "\"x is borrowed in {:?}\""
+msgstr "\"x is emprestadas in {:?}\""
+
+#: src/scope/lifetime/struct.md:35
+msgid "\"x and y are borrowed in {:?}\""
+msgstr "\"x e y are emprestadas in {:?}\""
+
+#: src/scope/lifetime/struct.md:37
+msgid "\"y is *not* borrowed in {:?}\""
+msgstr "\"y is *not* emprestadas in {:?}\""
+
+#: src/scope/lifetime/struct.md:43
+msgid "[`struct`s](../../custom_types/structs.md)"
+msgstr "[`struct`s](../../custom_types/structs.md)"
+
+#: src/scope/lifetime/trait.md:3
+msgid ""
+"Annotation of lifetimes in trait methods basically are similar to functions. "
+"Note that `impl` may have annotation of lifetimes too."
+msgstr "Anotação of lifetimes in trait métodos basically are similar to funções. Note aquele `impl` may have anotação of lifetimes too."
+
+#: src/scope/lifetime/trait.md:7
+msgid "// A struct with annotation of lifetimes.\n"
+msgstr ""
+"// UM struct com anotação of lifetimes.\n"
+
+#: src/scope/lifetime/trait.md:12
+msgid "// Annotate lifetimes to impl.\n"
+msgstr ""
+"// Annotate lifetimes to impl.\n"
+
+#: src/scope/lifetime/trait.md:24
+msgid "\"b is {:?}\""
+msgstr "\"b is {:?}\""
+
+#: src/scope/lifetime/trait.md:30
+msgid "[`trait`s](../../trait.md)"
+msgstr "[`trait`s](../../trait.md)"
+
+#: src/scope/lifetime/lifetime_bounds.md:3
+msgid ""
+"Just like generic types can be bounded, lifetimes (themselves generic) use "
+"bounds as well. The `:` character has a slightly different meaning here, but "
+"`+` is the same. Note how the following read:"
+msgstr "Just like generic tipos pode be bounded, lifetimes (themselves generic) use bounds as well. O `:` character has um slightly diferente meaning here, but `+` is o mesmo. Note how o following read:"
+
+#: src/scope/lifetime/lifetime_bounds.md:7
+msgid "`T: 'a`: _All_ references in `T` must outlive lifetime `'a`."
+msgstr "`T: 'a`: _All_ references in `T` deve outlive lifetime `'a`."
+
+#: src/scope/lifetime/lifetime_bounds.md:8
+msgid ""
+"`T: Trait + 'a`: Type `T` must implement trait `Trait` and _all_ references "
+"in `T` must outlive `'a`."
+msgstr "`T: Trait + 'a`: Tipo `T` deve implement trait `Trait` e _all_ references in `T` deve outlive `'a`."
+
+#: src/scope/lifetime/lifetime_bounds.md:11
+msgid ""
+"The example below shows the above syntax in action used after keyword "
+"`where`:"
+msgstr "O example abaixo shows o acima syntax in action usado after keyword `where`:"
+
+#: src/scope/lifetime/lifetime_bounds.md:14
+msgid "// Trait to bound with.\n"
+msgstr ""
+"// Trait to bound com.\n"
+
+#: src/scope/lifetime/lifetime_bounds.md:17
+msgid ""
+"// `Ref` contains a reference to a generic type `T` that has\n"
+"// some lifetime `'a` unknown by `Ref`. `T` is bounded such that any\n"
+"// *references* in `T` must outlive `'a`. Additionally, the lifetime\n"
+"// of `Ref` may not exceed `'a`.\n"
+msgstr ""
+"// `Ref` contains um reference to um generic tipo `T` aquele has\n"
+"// some lifetime `'a` unknown by `Ref`. `T` is bounded such aquele any\n"
+"// *references* in `T` deve outlive `'a`. Adicionaitionally, o lifetime\n"
+"// of `Ref` may not exceed `'a`.\n"
+
+#: src/scope/lifetime/lifetime_bounds.md:22
+msgid "// A generic function which prints using the `Debug` trait.\n"
+msgstr ""
+"// UM generic função which prints usando o `Debug` trait.\n"
+
+#: src/scope/lifetime/lifetime_bounds.md:26
+msgid "\"`print`: t is {:?}\""
+msgstr "\"`print`: t is {:?}\""
+
+#: src/scope/lifetime/lifetime_bounds.md:28
+msgid ""
+"// Here a reference to `T` is taken where `T` implements\n"
+"// `Debug` and all *references* in `T` outlive `'a`. In\n"
+"// addition, `'a` must outlive the function.\n"
+msgstr ""
+"// Here um reference to `T` is taken where `T` implements\n"
+"// `Debug` e all *references* in `T` outlive `'a`. In\n"
+"// addition, `'a` deve outlive a função.\n"
+
+#: src/scope/lifetime/lifetime_bounds.md:34
+msgid "\"`print_ref`: t is {:?}\""
+msgstr "\"`print_ref`: t is {:?}\""
+
+#: src/scope/lifetime/lifetime_bounds.md:48
+msgid ""
+"[generics](../../generics.md), [bounds in generics](../../generics/bounds."
+"md), and [multiple bounds in generics](../../generics/multi_bounds.md)"
+msgstr "[generics](../../generics.md), [bounds in generics](../../generics/bounds.md), e [multiple bounds in generics](../../generics/multi_bounds.md)"
+
+#: src/scope/lifetime/lifetime_coercion.md:3
+msgid ""
+"A longer lifetime can be coerced into a shorter one so that it works inside "
+"a scope it normally wouldn't work in. This comes in the form of inferred "
+"coercion by the Rust compiler, and also in the form of declaring a lifetime "
+"difference:"
+msgstr "UM longer lifetime pode be coerced em um shorter one so aquele it works dentro um scope it normally wouldn't work in. Este comes in o form of inferred coercion by o Rust compiler, e also in o form of declaring um lifetime difference:"
+
+#: src/scope/lifetime/lifetime_coercion.md:9
+msgid ""
+"// Here, Rust infers a lifetime that is as short as possible.\n"
+"// The two references are then coerced to that lifetime.\n"
+msgstr ""
+"// Here, Rust infers a lifetime that is as short as possible.\n"
+"// The two references are then coerced to that lifetime.\n"
+
+#: src/scope/lifetime/lifetime_coercion.md:14
+msgid ""
+"// `<'a: 'b, 'b>` reads as lifetime `'a` is at least as long as `'b`.\n"
+"// Here, we take in an `&'a i32` and return a `&'b i32` as a result of "
+"coercion.\n"
+msgstr ""
+"// `<'a: 'b, 'b>` reads as lifetime `'a` is at least as long as `'b`.\n"
+"// Here, we take in an `&'a i32` and return a `&'b i32` as a result of coercion.\n"
+
+#: src/scope/lifetime/lifetime_coercion.md:22
+msgid "// Longer lifetime\n"
+msgstr ""
+"// Longer lifetime\n"
+
+#: src/scope/lifetime/lifetime_coercion.md:25
+msgid "// Shorter lifetime\n"
+msgstr ""
+"// Shorter lifetime\n"
+
+#: src/scope/lifetime/lifetime_coercion.md:27
+msgid "\"The product is {}\""
+msgstr "\"O product is {}\""
+
+#: src/scope/lifetime/lifetime_coercion.md:28
+msgid "\"{} is the first\""
+msgstr "\"{} is o primeiro\""
+
+#: src/scope/lifetime/static_lifetime.md:3
+msgid ""
+"Rust has a few reserved lifetime names. One of those is `'static`. You might "
+"encounter it in two situations:"
+msgstr "Rust has um few reserved lifetime names. One of aqueles is `'static`. You might encounter it in two situations:"
+
+#: src/scope/lifetime/static_lifetime.md:7
+msgid "// A reference with 'static lifetime:\n"
+msgstr ""
+"// UM reference com 'static lifetime:\n"
+
+#: src/scope/lifetime/static_lifetime.md:8
+msgid "\"hello world\""
+msgstr "\"hello world\""
+
+#: src/scope/lifetime/static_lifetime.md:9
+msgid "// 'static as part of a trait bound:\n"
+msgstr ""
+"// 'static as part of um trait bound:\n"
+
+#: src/scope/lifetime/static_lifetime.md:14
+msgid ""
+"Both are related but subtly different and this is a common source for "
+"confusion when learning Rust. Here are some examples for each situation:"
+msgstr "Both are related but subtly diferente e este is um common source para confusion when learning Rust. Here are some examples para each situation:"
+
+#: src/scope/lifetime/static_lifetime.md:17
+msgid "Reference lifetime"
+msgstr "Reference lifetime"
+
+#: src/scope/lifetime/static_lifetime.md:19
+msgid ""
+"As a reference lifetime `'static` indicates that the data pointed to by the "
+"reference lives for the remaining lifetime of the running program. It can "
+"still be coerced to a shorter lifetime."
+msgstr "As a reference lifetime `'static` indicates that the data pointed to by the reference lives for the remaining lifetime of the running program. It can still be coerced to a shorter lifetime."
+
+#: src/scope/lifetime/static_lifetime.md:23
+msgid ""
+"There are two common ways to make a variable with `'static` lifetime, and "
+"both are stored in the read-only memory of the binary:"
+msgstr "There are two common ways to make uma variável com `'static` lifetime, e both are stored in o read-only memory of o binary:"
+
+#: src/scope/lifetime/static_lifetime.md:26
+msgid "Make a constant with the `static` declaration."
+msgstr "Make um constant com o `static` declaration."
+
+#: src/scope/lifetime/static_lifetime.md:27
+msgid "Make a `string` literal which has type: `&'static str`."
+msgstr "Make um `string` literal which has tipo: `&'static str`."
+
+#: src/scope/lifetime/static_lifetime.md:29
+msgid "See the following example for a display of each method:"
+msgstr "See o following example para um display of each método:"
+
+#: src/scope/lifetime/static_lifetime.md:32
+msgid "// Make a constant with `'static` lifetime.\n"
+msgstr ""
+"// Make um constant com `'static` lifetime.\n"
+
+#: src/scope/lifetime/static_lifetime.md:34
+msgid ""
+"// Returns a reference to `NUM` where its `'static`\n"
+"// lifetime is coerced to that of the input argument.\n"
+msgstr ""
+"// Returns a reference to `NUM` where its `'static`\n"
+"// lifetime is coerced to that of the input argument.\n"
+
+#: src/scope/lifetime/static_lifetime.md:43
+msgid "// Make a `string` literal and print it:\n"
+msgstr ""
+"// Make um `string` literal e print it:\n"
+
+#: src/scope/lifetime/static_lifetime.md:44
+msgid "\"I'm in read-only memory\""
+msgstr "\"I'm in read-only memory\""
+
+#: src/scope/lifetime/static_lifetime.md:45
+msgid "\"static_string: {}\""
+msgstr "\"static_string: {}\""
+
+#: src/scope/lifetime/static_lifetime.md:47
+msgid ""
+"// When `static_string` goes out of scope, the reference\n"
+"        // can no longer be used, but the data remains in the binary.\n"
+msgstr ""
+"// When `static_string` goes out of scope, the reference\n"
+"        // can no longer be used, but the data remains in the binary.\n"
+
+#: src/scope/lifetime/static_lifetime.md:52
+msgid "// Make an integer to use for `coerce_static`:\n"
+msgstr ""
+"// Make um inteiro to use para `coerce_static`:\n"
+
+#: src/scope/lifetime/static_lifetime.md:55
+msgid "// Coerce `NUM` to lifetime of `lifetime_num`:\n"
+msgstr ""
+"// Coerce `NUM` to lifetime of `lifetime_num`:\n"
+
+#: src/scope/lifetime/static_lifetime.md:58
+msgid "\"coerced_static: {}\""
+msgstr "\"coerced_static: {}\""
+
+#: src/scope/lifetime/static_lifetime.md:61
+msgid "\"NUM: {} stays accessible!\""
+msgstr "\"NUM: {} stays accessible!\""
+
+#: src/scope/lifetime/static_lifetime.md:65
+msgid ""
+"Since `'static` references only need to be valid for the _remainder_ of a "
+"program's life, they can be created while the program is executed. Just to "
+"demonstrate, the below example uses [`Box::leak`](https://doc.rust-lang.org/"
+"std/boxed/struct.Box.html#method.leak) to dynamically create `'static` "
+"references. In that case it definitely doesn't live for the entire duration, "
+"but only from the leaking point onward."
+msgstr "Since `'static` references only need to be válido para o _remainder_ of um program's life, they pode be created while o program is executed. Just to demonstrate, o abaixo example uses [`Box::leak`](https://doc.rust-lang.org/std/boxed/struct.Box.html#method.leak) to dynamically create `'static` references. In aquele case it definitely doesn't live para o entire duration, but only do leaking point onward."
+
+#: src/scope/lifetime/static_lifetime.md:90
+msgid "Trait bound"
+msgstr "Trait bound"
+
+#: src/scope/lifetime/static_lifetime.md:92
+msgid ""
+"As a trait bound, it means the type does not contain any non-static "
+"references. Eg. the receiver can hold on to the type for as long as they "
+"want and it will never become invalid until they drop it."
+msgstr "As um trait bound, it means o tipo does not contain any non-static references. Eg. o receiver pode hold on to o tipo para as long as they want e it vai never become inválido until they drop it."
+
+#: src/scope/lifetime/static_lifetime.md:96
+msgid ""
+"It's important to understand this means that any owned data always passes a "
+"`'static` lifetime bound, but a reference to that owned data generally does "
+"not:"
+msgstr "It's important to understand este means aquele any owned data always passes um `'static` lifetime bound, but um reference to aquele owned data generally does not:"
+
+#: src/scope/lifetime/static_lifetime.md:104
+msgid "\"'static value passed in is: {:?}\""
+msgstr "\"'static valor passed in is: {:?}\""
+
+#: src/scope/lifetime/static_lifetime.md:108
+msgid "// i is owned and contains no references, thus it's 'static:\n"
+msgstr ""
+"// i is owned e contains no references, thus it's 'static:\n"
+
+#: src/scope/lifetime/static_lifetime.md:112
+msgid ""
+"// oops, &i only has the lifetime defined by the scope of\n"
+"    // main(), so it's not 'static:\n"
+msgstr ""
+"// oops, &i only has the lifetime defined by the scope of\n"
+"    // main(), so it's not 'static:\n"
+
+#: src/scope/lifetime/static_lifetime.md:118
+msgid "The compiler will tell you:"
+msgstr "O compiler vai tell you:"
+
+#: src/scope/lifetime/static_lifetime.md:135
+msgid "[`'static` constants](../../custom_types/constants.md)"
+msgstr "[`'static` constants](../../custom_types/constants.md)"
+
+#: src/scope/lifetime/elision.md:3
+msgid ""
+"Some lifetime patterns are overwhelmingly common and so the borrow checker "
+"will allow you to omit them to save typing and to improve readability. This "
+"is known as elision. Elision exists in Rust solely because these patterns "
+"are common."
+msgstr "Some lifetime patterns are overwhelmingly common e so o emprestar checker vai allow you to omit them to save typing e to improve readability. Este is known as elision. Elision exists in Rust solely porque estes patterns are common."
+
+#: src/scope/lifetime/elision.md:8
+msgid ""
+"The following code shows a few examples of elision. For a more comprehensive "
+"description of elision, see [lifetime elision](https://doc.rust-lang.org/"
+"book/ch10-03-lifetime-syntax.html#lifetime-elision) in the book."
+msgstr "O following code shows um few examples of elision. Para um more comprehensive description of elision, see [lifetime elision](https://doc.rust-lang.org/book/ch10-03-lifetime-syntax.html#lifetime-elision) in o book."
+
+#: src/scope/lifetime/elision.md:12
+msgid ""
+"// `elided_input` and `annotated_input` essentially have identical "
+"signatures\n"
+"// because the lifetime of `elided_input` is inferred by the compiler:\n"
+msgstr ""
+"// `elided_input` and `annotated_input` essentially have identical signatures\n"
+"// because the lifetime of `elided_input` is inferred by the compiler:\n"
+
+#: src/scope/lifetime/elision.md:15
+msgid "\"`elided_input`: {}\""
+msgstr "\"`elided_input`: {}\""
+
+#: src/scope/lifetime/elision.md:19
+msgid "\"`annotated_input`: {}\""
+msgstr "\"`annotated_input`: {}\""
+
+#: src/scope/lifetime/elision.md:21
+msgid ""
+"// Similarly, `elided_pass` and `annotated_pass` have identical signatures\n"
+"// because the lifetime is added implicitly to `elided_pass`:\n"
+msgstr ""
+"// Similarly, `elided_pass` e `annotated_pass` have identical signatures\n"
+"// porque o lifetime is added implicitly to `elided_pass`:\n"
+
+#: src/scope/lifetime/elision.md:34
+msgid "\"`elided_pass`: {}\""
+msgstr "\"`elided_pass`: {}\""
+
+#: src/scope/lifetime/elision.md:35
+msgid "\"`annotated_pass`: {}\""
+msgstr "\"`annotated_pass`: {}\""
+
+#: src/scope/lifetime/elision.md:41
+msgid ""
+"[elision](https://doc.rust-lang.org/book/ch10-03-lifetime-syntax."
+"html#lifetime-elision)"
+msgstr "[elision](https://doc.rust-lang.org/book/ch10-03-lifetime-syntax.html#lifetime-elision)"
+
+#: src/trait.md:3
+msgid ""
+"A `trait` is a collection of methods defined for an unknown type: `Self`. "
+"They can access other methods declared in the same trait."
+msgstr "UM `trait` is um collection of métodos defined para um unknown tipo: `Self`. They pode access other métodos declared in o mesmo trait."
+
+#: src/trait.md:6
+msgid ""
+"Traits can be implemented for any data type. In the example below, we define "
+"`Animal`, a group of methods. The `Animal` `trait` is then implemented for "
+"the `Sheep` data type, allowing the use of methods from `Animal` with a "
+"`Sheep`."
+msgstr "Traits pode be implemented para any data tipo. In o example abaixo, we define `Animal`, um group of métodos. O `Animal` `trait` is then implemented para o `Sheep` data tipo, allowing o use of métodos de `Animal` com um `Sheep`."
+
+#: src/trait.md:15
+msgid ""
+"// Associated function signature; `Self` refers to the implementor type.\n"
+msgstr ""
+"// Associated função signature; `Self` refers to o implementor tipo.\n"
+
+#: src/trait.md:18
+msgid "// Method signatures; these will return a string.\n"
+msgstr ""
+"// Método signatures; estes vai retorna um string.\n"
+
+#: src/trait.md:22
+msgid "// Traits can provide default method definitions.\n"
+msgstr ""
+"// Traits pode provide default método definitions.\n"
+
+#: src/trait.md:24
+msgid "\"{} says {}\""
+msgstr "\"{} says {}\""
+
+#: src/trait.md:35
+msgid "// Implementor methods can use the implementor's trait methods.\n"
+msgstr ""
+"// Implementor métodos pode use o implementor's trait métodos.\n"
+
+#: src/trait.md:36
+msgid "\"{} is already naked...\""
+msgstr "\"{} is already naked...\""
+
+#: src/trait.md:38
+msgid "\"{} gets a haircut!\""
+msgstr "\"{} gets um haircut!\""
+
+#: src/trait.md:44 src/trait/dyn.md:25
+msgid "// Implement the `Animal` trait for `Sheep`.\n"
+msgstr ""
+"// Implement o `Animal` trait para `Sheep`.\n"
+
+#: src/trait.md:47
+msgid "// `Self` is the implementor type: `Sheep`.\n"
+msgstr ""
+"// `Self` is o implementor tipo: `Sheep`.\n"
+
+#: src/trait.md:58
+msgid "\"baaaaah?\""
+msgstr "\"baaaaah?\""
+
+#: src/trait.md:60 src/trait/dyn.md:29
+msgid "\"baaaaah!\""
+msgstr "\"baaaaah!\""
+
+#: src/trait.md:64
+msgid "// Default trait methods can be overridden.\n"
+msgstr ""
+"// Default trait métodos pode be overridden.\n"
+
+#: src/trait.md:66
+msgid "// For example, we can add some quiet contemplation.\n"
+msgstr ""
+"// Para example, we pode add some quiet contemplation.\n"
+
+#: src/trait.md:67
+msgid "\"{} pauses briefly... {}\""
+msgstr "\"{} pauses briefly... {}\""
+
+#: src/trait.md:72
+msgid "// Type annotation is necessary in this case.\n"
+msgstr ""
+"// Tipo anotação is necessary in este case.\n"
+
+#: src/trait.md:73
+msgid "\"Dolly\""
+msgstr "\"Dolly\""
+
+#: src/trait.md:74
+msgid "// TODO ^ Try removing the type annotations.\n"
+msgstr ""
+"// TODO ^ Tente removing o tipo annotations.\n"
+
+#: src/trait/derive.md:3
+msgid ""
+"The compiler is capable of providing basic implementations for some traits "
+"via the `#[derive]` [attribute](../attribute.md). These traits can still be "
+"manually implemented if a more complex behavior is required."
+msgstr "The compiler is capable of providing basic implementations for some traits via the `#[derive]` [attribute](../attribute.md). These traits can still be manually implemented if a more complex behavior is required."
+
+#: src/trait/derive.md:7
+msgid "The following is a list of derivable traits:"
+msgstr "O following is um list of derivable traits:"
+
+#: src/trait/derive.md:9
+msgid ""
+"Comparison traits: [`Eq`](https://doc.rust-lang.org/std/cmp/trait.Eq.html), "
+"[`PartialEq`](https://doc.rust-lang.org/std/cmp/trait.PartialEq.html), "
+"[`Ord`](https://doc.rust-lang.org/std/cmp/trait.Ord.html), [`PartialOrd`]"
+"(https://doc.rust-lang.org/std/cmp/trait.PartialOrd.html)."
+msgstr "Comparison traits: [`Eq`](https://doc.rust-lang.org/std/cmp/trait.Eq.html), [`PartialEq`](https://doc.rust-lang.org/std/cmp/trait.PartialEq.html), [`Ord`](https://doc.rust-lang.org/std/cmp/trait.Ord.html), [`PartialOrd`](https://doc.rust-lang.org/std/cmp/trait.PartialOrd.html)."
+
+#: src/trait/derive.md:11
+msgid ""
+"[`Clone`](https://doc.rust-lang.org/std/clone/trait.Clone.html), to create "
+"`T` from `&T` via a copy."
+msgstr "[`Clone`](https://doc.rust-lang.org/std/clone/trait.Clone.html), to create `T` de `&T` via um copy."
+
+#: src/trait/derive.md:12
+msgid ""
+"[`Copy`](https://doc.rust-lang.org/core/marker/trait.Copy.html), to give a "
+"type 'copy semantics' instead of 'move semantics'."
+msgstr "[`Copy`](https://doc.rust-lang.org/core/marker/trait.Copy.html), to give um tipo 'copy semantics' instead of 'move semantics'."
+
+#: src/trait/derive.md:13
+msgid ""
+"[`Hash`](https://doc.rust-lang.org/std/hash/trait.Hash.html), to compute a "
+"hash from `&T`."
+msgstr "[`Hash`](https://doc.rust-lang.org/std/hash/trait.Hash.html), to compute um hash de `&T`."
+
+#: src/trait/derive.md:14
+msgid ""
+"[`Default`](https://doc.rust-lang.org/std/default/trait.Default.html), to "
+"create an empty instance of a data type."
+msgstr "[`Default`](https://doc.rust-lang.org/std/default/trait.Default.html), to create um vazio instance of um data tipo."
+
+#: src/trait/derive.md:15
+msgid ""
+"[`Debug`](https://doc.rust-lang.org/std/fmt/trait.Debug.html), to format a "
+"value using the `{:?}` formatter."
+msgstr "[`Debug`](https://doc.rust-lang.org/std/fmt/trait.Debug.html), to format um valor usando o `{:?}` formatter."
+
+#: src/trait/derive.md:18
+msgid "// `Centimeters`, a tuple struct that can be compared\n"
+msgstr ""
+"// `Centimeters`, um tuple struct aquele pode be compared\n"
+
+#: src/trait/derive.md:21
+msgid "// `Inches`, a tuple struct that can be printed\n"
+msgstr ""
+"// `Inches`, um tuple struct aquele pode be printed\n"
+
+#: src/trait/derive.md:33
+msgid "// `Seconds`, a tuple struct with no additional attributes\n"
+msgstr ""
+"// `Seconds`, um tuple struct com no additional attributes\n"
+
+#: src/trait/derive.md:40
+msgid ""
+"// Error: `Seconds` can't be printed; it doesn't implement the `Debug` "
+"trait\n"
+"    //println!(\"One second looks like: {:?}\", _one_second);\n"
+"    // TODO ^ Try uncommenting this line\n"
+msgstr ""
+"// Erro: `Seconds` pode't be printed; it doesn't implement o `Debug` trait\n"
+"    //println!(\"One segundo looks like: {:?}\", _one_second);\n"
+"    // TODO ^ Tente uncommenting este line\n"
+
+#: src/trait/derive.md:44
+msgid ""
+"// Error: `Seconds` can't be compared; it doesn't implement the `PartialEq` "
+"trait\n"
+"    //let _this_is_true = (_one_second == _one_second);\n"
+"    // TODO ^ Try uncommenting this line\n"
+msgstr ""
+"// Erro: `Seconds` pode't be compared; it doesn't implement o `PartialEq` trait\n"
+"    //let _this_is_true = (_one_second == _one_second);\n"
+"    // TODO ^ Tente uncommenting este line\n"
+
+#: src/trait/derive.md:50
+msgid "\"One foot equals {:?}\""
+msgstr "\"One foot equals {:?}\""
+
+#: src/trait/derive.md:56
+msgid "\"smaller\""
+msgstr "\"smaller\""
+
+#: src/trait/derive.md:58
+msgid "\"bigger\""
+msgstr "\"bigger\""
+
+#: src/trait/derive.md:61
+msgid "\"One foot is {} than one meter.\""
+msgstr "\"One foot is {} than one meter.\""
+
+#: src/trait/derive.md:67
+msgid "[`derive`](https://doc.rust-lang.org/reference/attributes.html#derive)"
+msgstr "[`derive`](https://doc.rust-lang.org/reference/attributes.html#derive)"
+
+#: src/trait/dyn.md:3
+msgid ""
+"The Rust compiler needs to know how much space every function's return type "
+"requires. This means all your functions have to return a concrete type. "
+"Unlike other languages, if you have a trait like `Animal`, you can't write a "
+"function that returns `Animal`, because its different implementations will "
+"need different amounts of memory."
+msgstr "O Rust compiler needs to know how much space every função's retorna tipo requires. Este means all your funções have to retorna um concrete tipo. Unlike other languages, if you have um trait like `Animal`, you pode't write um função aquele retorna `Animal`, porque its diferente implementations vai need diferente amounts of memory."
+
+#: src/trait/dyn.md:8
+msgid ""
+"However, there's an easy workaround. Instead of returning a trait object "
+"directly, our functions return a `Box` which _contains_ some `Animal`. A "
+"`box` is just a reference to some memory in the heap. Because a reference "
+"has a statically-known size, and the compiler can guarantee it points to a "
+"heap-allocated `Animal`, we can return a trait from our function!"
+msgstr "However, there's um easy workaround. Instead of returning um trait object directly, our funções retorna um `Box` which _contains_ some `Animal`. UM `box` is just um reference to some memory in o heap. Porque um reference has um statically-known size, e o compiler pode guarantee it points to um heap-allocated `Animal`, we pode retorna um trait de our função!"
+
+#: src/trait/dyn.md:13
+msgid ""
+"Rust tries to be as explicit as possible whenever it allocates memory on the "
+"heap. So if your function returns a pointer-to-trait-on-heap in this way, "
+"you need to write the return type with the `dyn` keyword, e.g. `Box<dyn "
+"Animal>`."
+msgstr "Rust tries to be as explícita as possible whenever it allocates memory on o heap. So if your função retorna um pointer-to-trait-on-heap in este way, you need to write o retorna tipo com o `dyn` keyword, e.g. `Box<dyn Animal>`."
+
+#: src/trait/dyn.md:22
+msgid "// Instance method signature\n"
+msgstr ""
+"// Instance método signature\n"
+
+#: src/trait/dyn.md:32
+msgid "// Implement the `Animal` trait for `Cow`.\n"
+msgstr ""
+"// Implement o `Animal` trait para `Cow`.\n"
+
+#: src/trait/dyn.md:36
+msgid "\"moooooo!\""
+msgstr "\"moooooo!\""
+
+#: src/trait/dyn.md:39
+msgid ""
+"// Returns some struct that implements Animal, but we don't know which one "
+"at compile time.\n"
+msgstr ""
+"// Retornas some struct aquele implements Animal, but we don't know which one at compile time.\n"
+
+#: src/trait/dyn.md:52
+msgid "\"You've randomly chosen an animal, and it says {}\""
+msgstr "\"You've randomly chosen um animal, e it says {}\""
+
+#: src/trait/ops.md:3
+msgid ""
+"In Rust, many of the operators can be overloaded via traits. That is, some "
+"operators can be used to accomplish different tasks based on their input "
+"arguments. This is possible because operators are syntactic sugar for method "
+"calls. For example, the `+` operator in `a + b` calls the `add` method (as "
+"in `a.add(b)`). This `add` method is part of the `Add` trait. Hence, the `+` "
+"operator can be used by any implementor of the `Add` trait."
+msgstr "In Rust, many of o operators pode be overloaded via traits. Aquele is, some operators pode be usado to accomplish diferente tasks based on their entrada argumentos. Este is possible porque operators are syntactic sugar para método calls. Para example, o `+` operator in `a + b` calls o `add` método (as in `a.add(b)`). Este `add` método is part of o `Add` trait. Hence, o `+` operator pode be usado by any implementor of o `Add` trait."
+
+#: src/trait/ops.md:9
+msgid ""
+"A list of the traits, such as `Add`, that overload operators can be found in "
+"[`core::ops`](https://doc.rust-lang.org/core/ops/)."
+msgstr "UM list of o traits, such as `Add`, aquele overload operators pode be found in [`core::ops`](https://doc.rust-lang.org/core/ops/)."
+
+#: src/trait/ops.md:22
+msgid ""
+"// The `std::ops::Add` trait is used to specify the functionality of `+`.\n"
+"// Here, we make `Add<Bar>` - the trait for addition with a RHS of type "
+"`Bar`.\n"
+"// The following block implements the operation: Foo + Bar = FooBar\n"
+msgstr ""
+"// O `std::ops::Add` trait is usado to specify o functionality of `+`.\n"
+"// Here, we make `Add<Bar>` - o trait para addition com um RHS of tipo `Bar`.\n"
+"// O following block implements o operation: Foo + Bar = FooBar\n"
+
+#: src/trait/ops.md:30
+msgid "\"> Foo.add(Bar) was called\""
+msgstr "\"> Foo.add(Bar) was chamado\""
+
+#: src/trait/ops.md:35
+msgid ""
+"// By reversing the types, we end up implementing non-commutative addition.\n"
+"// Here, we make `Add<Foo>` - the trait for addition with a RHS of type "
+"`Foo`.\n"
+"// This block implements the operation: Bar + Foo = BarFoo\n"
+msgstr ""
+"// By reversing o tipos, we end up implementing non-commutative addition.\n"
+"// Here, we make `Add<Foo>` - o trait para addition com um RHS of tipo `Foo`.\n"
+"// Este block implements o operation: Bar + Foo = BarFoo\n"
+
+#: src/trait/ops.md:43
+msgid "\"> Bar.add(Foo) was called\""
+msgstr "\"> Bar.add(Foo) was chamado\""
+
+#: src/trait/ops.md:50
+msgid "\"Foo + Bar = {:?}\""
+msgstr "\"Foo + Bar = {:?}\""
+
+#: src/trait/ops.md:51
+msgid "\"Bar + Foo = {:?}\""
+msgstr "\"Bar + Foo = {:?}\""
+
+#: src/trait/ops.md:55 src/testing.md:16 src/testing/doc_testing.md:104
+#: src/testing/dev_dependencies.md:36
+msgid "See Also"
+msgstr "See Also"
+
+#: src/trait/ops.md:57
+msgid ""
+"[Add](https://doc.rust-lang.org/core/ops/trait.Add.html), [Syntax Index]"
+"(https://doc.rust-lang.org/book/appendix-02-operators.html)"
+msgstr "[Add](https://doc.rust-lang.org/core/ops/trait.Add.html), [Syntax Index](https://doc.rust-lang.org/book/appendix-02-operators.html)"
+
+#: src/trait/drop.md:3
+msgid ""
+"The [`Drop`](https://doc.rust-lang.org/std/ops/trait.Drop.html) trait only "
+"has one method: `drop`, which is called automatically when an object goes "
+"out of scope. The main use of the `Drop` trait is to free the resources that "
+"the implementor instance owns."
+msgstr "The [`Drop`](https://doc.rust-lang.org/std/ops/trait.Drop.html) trait only has one method: `drop`, which is called automatically when an object goes out of scope. The main use of the `Drop` trait is to free the resources that the implementor instance owns."
+
+#: src/trait/drop.md:7
+msgid ""
+"`Box`, `Vec`, `String`, `File`, and `Process` are some examples of types "
+"that implement the `Drop` trait to free resources. The `Drop` trait can also "
+"be manually implemented for any custom data type."
+msgstr "`Box`, `Vec`, `String`, `File`, and `Process` are some examples of types that implement the `Drop` trait to free resources. The `Drop` trait can also be manually implemented for any custom data type."
+
+#: src/trait/drop.md:11
+msgid ""
+"The following example adds a print to console to the `drop` function to "
+"announce when it is called."
+msgstr "O following example adds um print to console to o `drop` função to announce when it is chamado."
+
+#: src/trait/drop.md:18
+msgid "// This trivial implementation of `drop` adds a print to console.\n"
+msgstr ""
+"// Este trivial implementation of `drop` adds um print to console.\n"
+
+#: src/trait/drop.md:22
+msgid "\"> Dropping {}\""
+msgstr "\"> Descartaping {}\""
+
+#: src/trait/drop.md:27 src/std_misc/path.md:33 src/std_misc/fs.md:44
+#: src/std_misc/fs.md:87
+msgid "\"a\""
+msgstr "\"um\""
+
+#: src/trait/drop.md:29
+msgid "// block A\n"
+msgstr ""
+"// block UM\n"
+
+#: src/trait/drop.md:31 src/std_misc/path.md:33
+msgid "\"b\""
+msgstr "\"b\""
+
+#: src/trait/drop.md:33
+msgid "// block B\n"
+msgstr ""
+"// block B\n"
+
+#: src/trait/drop.md:35 src/std_misc/path.md:36
+msgid "\"c\""
+msgstr "\"c\""
+
+#: src/trait/drop.md:36
+msgid "\"d\""
+msgstr "\"d\""
+
+#: src/trait/drop.md:38
+msgid "\"Exiting block B\""
+msgstr "\"Exiting block B\""
+
+#: src/trait/drop.md:40
+msgid "\"Just exited block B\""
+msgstr "\"Just exited block B\""
+
+#: src/trait/drop.md:42
+msgid "\"Exiting block A\""
+msgstr "\"Exiting block UM\""
+
+#: src/trait/drop.md:44
+msgid "\"Just exited block A\""
+msgstr "\"Just exited block UM\""
+
+#: src/trait/drop.md:46
+msgid "// Variable can be manually dropped using the `drop` function\n"
+msgstr ""
+"// Variável pode be manually dropped usando o `drop` função\n"
+
+#: src/trait/drop.md:48
+msgid "// TODO ^ Try commenting this line\n"
+msgstr ""
+"// TODO ^ Tente commenting este line\n"
+
+#: src/trait/drop.md:50
+msgid "\"end of the main function\""
+msgstr "\"end of o main função\""
+
+#: src/trait/drop.md:52
+msgid ""
+"// `_a` *won't* be `drop`ed again here, because it already has been\n"
+"    // (manually) `drop`ed\n"
+msgstr ""
+"// `_a` *won't* be `drop`ed again here, because it already has been\n"
+"    // (manually) `drop`ed\n"
+
+#: src/trait/iter.md:3
+msgid ""
+"The [`Iterator`](https://doc.rust-lang.org/core/iter/trait.Iterator.html) "
+"trait is used to implement iterators over collections such as arrays."
+msgstr "O [`Iterator`](https://doc.rust-lang.org/core/iter/trait.Iterator.html) trait is usado to implement iterators over collections such as arrays."
+
+#: src/trait/iter.md:6
+msgid ""
+"The trait requires only a method to be defined for the `next` element, which "
+"may be manually defined in an `impl` block or automatically defined (as in "
+"arrays and ranges)."
+msgstr "O trait requires only um método to be defined para o `next` element, which may be manually defined in um `impl` block ou automatically defined (as in arrays e ranges)."
+
+#: src/trait/iter.md:10
+msgid ""
+"As a point of convenience for common situations, the `for` construct turns "
+"some collections into iterators using the [`.into_iter()`](https://doc.rust-"
+"lang.org/std/iter/trait.IntoIterator.html) method."
+msgstr "As um point of convenience para common situations, o `for` construct turns some collections em iterators usando o [`.into_iter()`](https://doc.rust-lang.org/std/iter/trait.IntoIterator.html) método."
+
+#: src/trait/iter.md:18
+msgid ""
+"// Implement `Iterator` for `Fibonacci`.\n"
+"// The `Iterator` trait only requires a method to be defined for the `next` "
+"element,\n"
+"// and an `associated type` to declare the return type of the iterator.\n"
+msgstr ""
+"// Implement `Iterator` para `Fibonacci`.\n"
+"// O `Iterator` trait only requires um método to be defined para o `next` element,\n"
+"// e um `associated type` to declare o retorna tipo of o iterator.\n"
+
+#: src/trait/iter.md:23
+msgid "// We can refer to this type using Self::Item\n"
+msgstr ""
+"// We pode refer to este tipo usando Self::Item\n"
+
+#: src/trait/iter.md:26
+msgid ""
+"// Here, we define the sequence using `.curr` and `.next`.\n"
+"    // The return type is `Option<T>`:\n"
+"    //     * When the `Iterator` is finished, `None` is returned.\n"
+"    //     * Otherwise, the next value is wrapped in `Some` and returned.\n"
+"    // We use Self::Item in the return type, so we can change\n"
+"    // the type without having to update the function signatures.\n"
+msgstr ""
+"// Here, we define o sequence usando `.curr` e `.next`.\n"
+"    // O retorna tipo is `Option<T>`:\n"
+"    //     * When o `Iterator` is finished, `None` is retornado.\n"
+"    //     * Otherwise, o próximo valor is wrapped in `Some` e retornado.\n"
+"    // We use Self::Item in o retorna tipo, so we pode change\n"
+"    // o tipo sem having to update a função signatures.\n"
+
+#: src/trait/iter.md:38
+msgid ""
+"// Since there's no endpoint to a Fibonacci sequence, the `Iterator` \n"
+"        // will never return `None`, and `Some` is always returned.\n"
+msgstr ""
+"// Since there's no endpoint to um Fibonacci sequence, o `Iterator` \n"
+"        // vai never retorna `None`, e `Some` is always retornado.\n"
+
+#: src/trait/iter.md:43
+msgid "// Returns a Fibonacci sequence generator\n"
+msgstr ""
+"// Retornas um Fibonacci sequence generator\n"
+
+#: src/trait/iter.md:50
+msgid "// `0..3` is an `Iterator` that generates: 0, 1, and 2.\n"
+msgstr ""
+"// `0..3` is um `Iterator` aquele generates: 0, 1, e 2.\n"
+
+#: src/trait/iter.md:53
+msgid "\"Four consecutive `next` calls on 0..3\""
+msgstr "\"Four consecutive `next` calls on 0..3\""
+
+#: src/trait/iter.md:54 src/trait/iter.md:55 src/trait/iter.md:56
+#: src/trait/iter.md:57 src/std_misc/fs.md:90
+msgid "\"> {:?}\""
+msgstr "\"> {:?}\""
+
+#: src/trait/iter.md:59
+msgid ""
+"// `for` works through an `Iterator` until it returns `None`.\n"
+"    // Each `Some` value is unwrapped and bound to a variable (here, `i`).\n"
+msgstr ""
+"// `for` works through um `Iterator` until it retorna `None`.\n"
+"    // Each `Some` valor is unwrapped e bound to uma variável (here, `i`).\n"
+
+#: src/trait/iter.md:61
+msgid "\"Iterate through 0..3 using `for`\""
+msgstr "\"Iterate through 0..3 usando `for`\""
+
+#: src/trait/iter.md:63 src/trait/iter.md:69 src/trait/iter.md:75
+#: src/trait/iter.md:83 src/std/vec.md:50 src/std/str.md:22
+#: src/std_misc/fs.md:82
+msgid "\"> {}\""
+msgstr "\"> {}\""
+
+#: src/trait/iter.md:66
+msgid "// The `take(n)` method reduces an `Iterator` to its first `n` terms.\n"
+msgstr ""
+"// O `take(n)` método reduces um `Iterator` to its primeiro `n` terms.\n"
+
+#: src/trait/iter.md:67
+msgid "\"The first four terms of the Fibonacci sequence are: \""
+msgstr "\"O primeiro four terms of o Fibonacci sequence are: \""
+
+#: src/trait/iter.md:72
+msgid ""
+"// The `skip(n)` method shortens an `Iterator` by dropping its first `n` "
+"terms.\n"
+msgstr ""
+"// O `skip(n)` método shortens um `Iterator` by dropping its primeiro `n` terms.\n"
+
+#: src/trait/iter.md:73
+msgid "\"The next four terms of the Fibonacci sequence are: \""
+msgstr "\"O próximo four terms of o Fibonacci sequence are: \""
+
+#: src/trait/iter.md:80
+msgid "// The `iter` method produces an `Iterator` over an array/slice.\n"
+msgstr ""
+"// O `iter` método produces um `Iterator` over um array/slice.\n"
+
+#: src/trait/iter.md:81
+msgid "\"Iterate the following array {:?}\""
+msgstr "\"Iterate o following array {:?}\""
+
+#: src/trait/impl_trait.md:3
+msgid "`impl Trait` can be used in two locations:"
+msgstr "`impl Trait` pode be usado in two locations:"
+
+#: src/trait/impl_trait.md:5
+msgid "as an argument type"
+msgstr "as um argumento tipo"
+
+#: src/trait/impl_trait.md:6
+msgid "as a return type"
+msgstr "as um retorna tipo"
+
+#: src/trait/impl_trait.md:8
+msgid "As an argument type"
+msgstr "As um argumento tipo"
+
+#: src/trait/impl_trait.md:10
+msgid ""
+"If your function is generic over a trait but you don't mind the specific "
+"type, you can simplify the function declaration using `impl Trait` as the "
+"type of the argument."
+msgstr "If your função is generic over um trait but you don't mind o specific tipo, you pode simplify a função declaration usando `impl Trait` as o tipo of o argumento."
+
+#: src/trait/impl_trait.md:12
+msgid "For example, consider the following code:"
+msgstr "Para example, consider o following code:"
+
+#: src/trait/impl_trait.md:18 src/trait/impl_trait.md:37
+msgid "// For each line in the source\n"
+msgstr ""
+"// Para each line in o source\n"
+
+#: src/trait/impl_trait.md:20 src/trait/impl_trait.md:39
+msgid ""
+"// If the line was read successfully, process it, if not, return the error\n"
+msgstr ""
+"// If the line was read successfully, process it, if not, return the error\n"
+
+#: src/trait/impl_trait.md:21 src/trait/impl_trait.md:40 src/std/str.md:41
+msgid "','"
+msgstr "','"
+
+#: src/trait/impl_trait.md:21 src/trait/impl_trait.md:40
+msgid "// Split the line separated by commas\n"
+msgstr ""
+"// Split o line separated by commas\n"
+
+#: src/trait/impl_trait.md:22 src/trait/impl_trait.md:41
+msgid "// Remove leading and trailing whitespace\n"
+msgstr ""
+"// Remove leading e trailing whitespace\n"
+
+#: src/trait/impl_trait.md:23 src/trait/impl_trait.md:42
+msgid "// Collect all strings in a row into a Vec<String>\n"
+msgstr ""
+"// Collect all strings in um row em um Vec<String>\n"
+
+#: src/trait/impl_trait.md:26 src/trait/impl_trait.md:45
+msgid "// Collect all lines into a Vec<Vec<String>>\n"
+msgstr ""
+"// Collect all lines em um Vec<Vec<String>>\n"
+
+#: src/trait/impl_trait.md:30
+msgid ""
+"`parse_csv_document` is generic, allowing it to take any type which "
+"implements BufRead, such as `BufReader<File>` or `[u8]`, but it's not "
+"important what type `R` is, and `R` is only used to declare the type of "
+"`src`, so the function can also be written as:"
+msgstr "`parse_csv_document` is generic, allowing it to take any tipo which implements BufLê, such as `BufReader<File>` ou `[u8]`, but it's not important what tipo `R` is, e `R` is only usado to declare o tipo of `src`, so a função pode also be written as:"
+
+#: src/trait/impl_trait.md:49
+msgid ""
+"Note that using `impl Trait` as an argument type means that you cannot "
+"explicitly state what form of the function you use, i.e. "
+"`parse_csv_document::<std::io::Empty>(std::io::empty())` will not work with "
+"the second example."
+msgstr "Note aquele usando `impl Trait` as um argumento tipo means aquele you não pode explicitly state what form of a função you use, i.e. `parse_csv_document::<std::io::Empty>(std::io::empty())` vai not work com o segundo example."
+
+#: src/trait/impl_trait.md:51
+msgid "As a return type"
+msgstr "As um retorna tipo"
+
+#: src/trait/impl_trait.md:53
+msgid ""
+"If your function returns a type that implements `MyTrait`, you can write its "
+"return type as `-> impl MyTrait`. This can help simplify your type "
+"signatures quite a lot!"
+msgstr "If your função retorna um tipo aquele implements `MyTrait`, you pode write its retorna tipo as `-> impl MyTrait`. Este pode help simplify your tipo signatures quite um lot!"
+
+#: src/trait/impl_trait.md:59
+msgid ""
+"// This function combines two `Vec<i32>` and returns an iterator over it.\n"
+"// Look how complicated its return type is!\n"
+msgstr ""
+"// Este função combines two `Vec<i32>` e retorna um iterator over it.\n"
+"// Look how complicated its retorna tipo is!\n"
+
+#: src/trait/impl_trait.md:68
+msgid ""
+"// This is the exact same function, but its return type uses `impl Trait`.\n"
+"// Look how much simpler it is!\n"
+msgstr ""
+"// Este is o exact mesma função, but its retorna tipo uses `impl Trait`.\n"
+"// Look how much simpler it is!\n"
+
+#: src/trait/impl_trait.md:87
+msgid "\"all done\""
+msgstr "\"all done\""
+
+#: src/trait/impl_trait.md:91
+msgid ""
+"More importantly, some Rust types can't be written out. For example, every "
+"closure has its own unnamed concrete type. Before `impl Trait` syntax, you "
+"had to allocate on the heap in order to return a closure. But now you can do "
+"it all statically, like this:"
+msgstr "More importantly, some Rust tipos pode't be written out. Para example, every closure has its own unnamed concrete tipo. Before `impl Trait` syntax, you had to allocate on o heap in order to retorna um closure. But now you pode do it all statically, like este:"
+
+#: src/trait/impl_trait.md:97
+msgid "// Returns a function that adds `y` to its input\n"
+msgstr ""
+"// Retornas um função aquele adds `y` to its entrada\n"
+
+#: src/trait/impl_trait.md:109
+msgid ""
+"You can also use `impl Trait` to return an iterator that uses `map` or "
+"`filter` closures! This makes using `map` and `filter` easier. Because "
+"closure types don't have names, you can't write out an explicit return type "
+"if your function returns iterators with closures. But with `impl Trait` you "
+"can do this easily:"
+msgstr "You pode also use `impl Trait` to retorna um iterator aquele uses `map` ou `filter` closures! Este makes usando `map` e `filter` easier. Porque closure tipos don't have names, you pode't write out um explícita retorna tipo if your função retorna iterators com closures. But com `impl Trait` you pode do este easily:"
+
+#: src/trait/clone.md:3
+msgid ""
+"When dealing with resources, the default behavior is to transfer them during "
+"assignments or function calls. However, sometimes we need to make a copy of "
+"the resource as well."
+msgstr "When dealing com resources, o default behavior is to transfer them during assignments ou função calls. However, sometimes we need to make um copy of o resource as well."
+
+#: src/trait/clone.md:7
+msgid ""
+"The [`Clone`](https://doc.rust-lang.org/std/clone/trait.Clone.html) trait "
+"helps us do exactly this. Most commonly, we can use the `.clone()` method "
+"defined by the `Clone` trait."
+msgstr "O [`Clone`](https://doc.rust-lang.org/std/clone/trait.Clone.html) trait helps us do exactly este. Most commonly, we pode use o `.clone()` método defined by o `Clone` trait."
+
+#: src/trait/clone.md:11
+msgid "// A unit struct without resources\n"
+msgstr ""
+"// UM unit struct sem resources\n"
+
+#: src/trait/clone.md:14
+msgid "// A tuple struct with resources that implements the `Clone` trait\n"
+msgstr ""
+"// UM tuple struct com resources aquele implements o `Clone` trait\n"
+
+#: src/trait/clone.md:20
+msgid "// Instantiate `Unit`\n"
+msgstr ""
+"// Instantiate `Unit`\n"
+
+#: src/trait/clone.md:22
+msgid "// Copy `Unit`, there are no resources to move\n"
+msgstr ""
+"// Copy `Unit`, there are no resources to move\n"
+
+#: src/trait/clone.md:25
+msgid "// Both `Unit`s can be used independently\n"
+msgstr ""
+"// Both `Unit`s pode be usado independently\n"
+
+#: src/trait/clone.md:26 src/trait/clone.md:31
+msgid "\"original: {:?}\""
+msgstr "\"original: {:?}\""
+
+#: src/trait/clone.md:27
+msgid "\"copy: {:?}\""
+msgstr "\"copy: {:?}\""
+
+#: src/trait/clone.md:29
+msgid "// Instantiate `Pair`\n"
+msgstr ""
+"// Instantiate `Pair`\n"
+
+#: src/trait/clone.md:33
+msgid "// Move `pair` into `moved_pair`, moves resources\n"
+msgstr ""
+"// Move `pair` em `moved_pair`, moves resources\n"
+
+#: src/trait/clone.md:35
+msgid "\"moved: {:?}\""
+msgstr "\"moved: {:?}\""
+
+#: src/trait/clone.md:37
+msgid ""
+"// Error! `pair` has lost its resources\n"
+"    //println!(\"original: {:?}\", pair);\n"
+"    // TODO ^ Try uncommenting this line\n"
+msgstr ""
+"// Erro! `pair` has lost its resources\n"
+"    //println!(\"original: {:?}\", pair);\n"
+"    // TODO ^ Tente uncommenting este line\n"
+
+#: src/trait/clone.md:41
+msgid "// Clone `moved_pair` into `cloned_pair` (resources are included)\n"
+msgstr ""
+"// Clona `moved_pair` em `cloned_pair` (resources are included)\n"
+
+#: src/trait/clone.md:43
+msgid "// Drop the moved original pair using std::mem::drop\n"
+msgstr ""
+"// Descarta o moved original pair usando std::mem::drop\n"
+
+#: src/trait/clone.md:46
+msgid ""
+"// Error! `moved_pair` has been dropped\n"
+"    //println!(\"moved and dropped: {:?}\", moved_pair);\n"
+"    // TODO ^ Try uncommenting this line\n"
+msgstr ""
+"// Erro! `moved_pair` has been dropped\n"
+"    //println!(\"moved e dropped: {:?}\", moved_pair);\n"
+"    // TODO ^ Tente uncommenting este line\n"
+
+#: src/trait/clone.md:50
+msgid "// The result from .clone() can still be used!\n"
+msgstr ""
+"// O resultado de .clone() pode still be usado!\n"
+
+#: src/trait/clone.md:51
+msgid "\"clone: {:?}\""
+msgstr "\"clone: {:?}\""
+
+#: src/trait/supertraits.md:3
+msgid ""
+"Rust doesn't have \"inheritance\", but you can define a trait as being a "
+"superset of another trait. For example:"
+msgstr "Rust doesn't have \"inheritance\", but you pode define um trait as being um superset of another trait. Para example:"
+
+#: src/trait/supertraits.md:10
+msgid ""
+"// Person is a supertrait of Student.\n"
+"// Implementing Student requires you to also impl Person.\n"
+msgstr ""
+"// Person is um supertrait of Student.\n"
+"// Implementing Student requires you to also impl Person.\n"
+
+#: src/trait/supertraits.md:20
+msgid ""
+"// CompSciStudent (computer science student) is a subtrait of both "
+"Programmer \n"
+"// and Student. Implementing CompSciStudent requires you to impl both "
+"supertraits.\n"
+msgstr ""
+"// CompSciStudent (computer science student) is um subtrait of both Programmer \n"
+"// e Student. Implementing CompSciStudent requires you to impl both supertraits.\n"
+
+#: src/trait/supertraits.md:29
+msgid ""
+"\"My name is {} and I attend {}. My favorite language is {}. My Git username "
+"is {}\""
+msgstr "\"My name is {} e I attend {}. My favorite language is {}. My Git username is {}\""
+
+#: src/trait/supertraits.md:42
+msgid ""
+"[The Rust Programming Language chapter on supertraits](https://doc.rust-lang."
+"org/book/ch19-03-advanced-traits.html#using-supertraits-to-require-one-"
+"traits-functionality-within-another-trait)"
+msgstr "[The Rust Programming Language chapter on supertraits](https://doc.rust-lang.org/book/ch19-03-advanced-traits.html#using-supertraits-to-require-one-traits-functionality-within-another-trait)"
+
+#: src/trait/disambiguating.md:3
+msgid ""
+"A type can implement many different traits. What if two traits both require "
+"the same name for a function? For example, many traits might have a method "
+"named `get()`. They might even have different return types!"
+msgstr "UM tipo pode implement many diferente traits. What if two traits both require o mesmo name para um função? Para example, many traits might have um método named `get()`. They might even have diferente retorna tipos!"
+
+#: src/trait/disambiguating.md:7
+msgid ""
+"Good news: because each trait implementation gets its own `impl` block, it's "
+"clear which trait's `get` method you're implementing."
+msgstr "Good news: porque each trait implementation gets its own `impl` block, it's clear which trait's `get` método you're implementing."
+
+#: src/trait/disambiguating.md:10
+msgid ""
+"What about when it comes time to _call_ those methods? To disambiguate "
+"between them, we have to use Fully Qualified Syntax."
+msgstr "What about when it comes time to _call_ those methods? To disambiguate between them, we have to use Fully Qualified Syntax."
+
+#: src/trait/disambiguating.md:15
+msgid "// Get the selected username out of this widget\n"
+msgstr ""
+"// Get o selected username out of este widget\n"
+
+#: src/trait/disambiguating.md:20
+msgid "// Get the selected age out of this widget\n"
+msgstr ""
+"// Get o selected age out of este widget\n"
+
+#: src/trait/disambiguating.md:23
+msgid "// A form with both a UsernameWidget and an AgeWidget\n"
+msgstr ""
+"// UM form com both um UsarnameWidget e um AgeWidget\n"
+
+#: src/trait/disambiguating.md:44 src/trait/disambiguating.md:54
+msgid "\"rustacean\""
+msgstr "\"rustacean\""
+
+#: src/trait/disambiguating.md:48
+msgid ""
+"// If you uncomment this line, you'll get an error saying\n"
+"    // \"multiple `get` found\". Because, after all, there are multiple "
+"methods\n"
+"    // named `get`.\n"
+"    // println!(\"{}\", form.get());\n"
+msgstr ""
+"// If you uncomment este line, you'll get um erro saying\n"
+"    // \"multiple `get` found\". Porque, after all, there are multiple métodos\n"
+"    // named `get`.\n"
+"    // println!(\"{}\", form.get());\n"
+
+#: src/trait/disambiguating.md:62
+msgid ""
+"[The Rust Programming Language chapter on Fully Qualified syntax](https://"
+"doc.rust-lang.org/book/ch19-03-advanced-traits.html#fully-qualified-syntax-"
+"for-disambiguation-calling-methods-with-the-same-name)"
+msgstr "[The Rust Programming Language chapter on Fully Qualified syntax](https://doc.rust-lang.org/book/ch19-03-advanced-traits.html#fully-qualified-syntax-for-disambiguation-calling-methods-with-the-same-name)"
+
+#: src/macros.md:1
+msgid "`macro_rules!`"
+msgstr "`macro_rules!`"
+
+#: src/macros.md:3
+msgid ""
+"Rust provides a powerful macro system that allows metaprogramming. As you've "
+"seen in previous chapters, macros look like functions, except that their "
+"name ends with a bang `!`, but instead of generating a function call, macros "
+"are expanded into source code that gets compiled with the rest of the "
+"program. However, unlike macros in C and other languages, Rust macros are "
+"expanded into abstract syntax trees, rather than string preprocessing, so "
+"you don't get unexpected precedence bugs."
+msgstr "Rust provides um powerful macro system aquele allows metaprogramming. As you've seen in anterior chapters, macros look like funções, except aquele their name ends com um bang `!`, but instead of generating um função call, macros are expanded em source code aquele gets compiled com o rest of o program. However, unlike macros in C e other languages, Rust macros are expanded em abstract syntax trees, rather than string preprocessing, so you don't get unexpected precedence bugs."
+
+#: src/macros.md:11
+msgid "Macros are created using the `macro_rules!` macro."
+msgstr "Macros are created usando o `macro_rules!` macro."
+
+#: src/macros.md:14
+msgid "// This is a simple macro named `say_hello`.\n"
+msgstr ""
+"// Este is um simple macro named `say_hello`.\n"
+
+#: src/macros.md:16
+msgid "// `()` indicates that the macro takes no argument.\n"
+msgstr ""
+"// `()` indicates aquele o macro takes no argumento.\n"
+
+#: src/macros.md:18
+msgid "// The macro will expand into the contents of this block.\n"
+msgstr ""
+"// O macro vai expand no contents of este block.\n"
+
+#: src/macros.md:19
+msgid "\"Hello!\""
+msgstr "\"Hello!\""
+
+#: src/macros.md:24
+msgid "// This call will expand into `println!(\"Hello!\")`\n"
+msgstr ""
+"// Este call vai expand em `println!(\"Hello!\")`\n"
+
+#: src/macros.md:29
+msgid "So why are macros useful?"
+msgstr "So why are macros useful?"
+
+#: src/macros.md:31
+msgid ""
+"Don't repeat yourself. There are many cases where you may need similar "
+"functionality in multiple places but with different types. Often, writing a "
+"macro is a useful way to avoid repeating code. (More on this later)"
+msgstr "Don't repeat yourself. There are many cases where you may need similar functionality in multiple places but com diferente tipos. Often, writing um macro is um useful way to avoid repeating code. (More on este later)"
+
+#: src/macros.md:35
+msgid ""
+"Domain-specific languages. Macros allow you to define special syntax for a "
+"specific purpose. (More on this later)"
+msgstr "Domain-specific languages. Macros allow you to define special syntax para um specific purpose. (More on este later)"
+
+#: src/macros.md:38
+msgid ""
+"Variadic interfaces. Sometimes you want to define an interface that takes a "
+"variable number of arguments. An example is `println!` which could take any "
+"number of arguments, depending on the format string. (More on this later)"
+msgstr "Variadic interfaces. Sometimes you want to define um interface aquele takes uma variável número of argumentos. Um example is `println!` which could take any número of argumentos, depending on o format string. (More on este later)"
+
+#: src/macros/syntax.md:3
+msgid ""
+"In following subsections, we will show how to define macros in Rust. There "
+"are three basic ideas:"
+msgstr "In following subsections, we vai show how to define macros in Rust. There are three basic ideas:"
+
+#: src/macros/syntax.md:6
+msgid "[Patterns and Designators](designators.md)"
+msgstr "[Patterns and Designators](designators.md)"
+
+#: src/macros/syntax.md:7
+msgid "[Overloading](overload.md)"
+msgstr "[Overloading](overload.md)"
+
+#: src/macros/syntax.md:8
+msgid "[Repetition](repeat.md)"
+msgstr "[Repetition](repeat.md)"
+
+#: src/macros/designators.md:3
+msgid ""
+"The arguments of a macro are prefixed by a dollar sign `$` and type "
+"annotated with a _designator_:"
+msgstr "O argumentos of um macro are prefixed by um dollar sign `$` e tipo annotated com um _designator_:"
+
+#: src/macros/designators.md:8
+msgid ""
+"// This macro takes an argument of designator `ident` and\n"
+"    // creates a function named `$func_name`.\n"
+"    // The `ident` designator is used for variable/function names.\n"
+msgstr ""
+"// Este macro takes um argumento of designator `ident` e\n"
+"    // creates um função named `$func_name`.\n"
+"    // O `ident` designator is usado para variável/função names.\n"
+
+#: src/macros/designators.md:13
+msgid "// The `stringify!` macro converts an `ident` into a string.\n"
+msgstr ""
+"// O `stringify!` macro converts um `ident` em um string.\n"
+
+#: src/macros/designators.md:14
+msgid "\"You called {:?}()\""
+msgstr "\"You chamado {:?}()\""
+
+#: src/macros/designators.md:19
+msgid "// Create functions named `foo` and `bar` with the above macro.\n"
+msgstr ""
+"// Cria funções named `foo` e `bar` com o acima macro.\n"
+
+#: src/macros/designators.md:25
+msgid ""
+"// This macro takes an expression of type `expr` and prints\n"
+"    // it as a string along with its result.\n"
+"    // The `expr` designator is used for expressions.\n"
+msgstr ""
+"// Este macro takes um expression of tipo `expr` e prints\n"
+"    // it as um string along com its resultado.\n"
+"    // O `expr` designator is usado para expressions.\n"
+
+#: src/macros/designators.md:29
+msgid "// `stringify!` will convert the expression *as it is* into a string.\n"
+msgstr ""
+"// `stringify!` vai convert o expression *as it is* em um string.\n"
+
+#: src/macros/designators.md:30
+msgid "\"{:?} = {:?}\""
+msgstr "\"{:?} = {:?}\""
+
+#: src/macros/designators.md:42
+msgid "// Recall that blocks are expressions too!\n"
+msgstr ""
+"// Recall aquele blocks are expressions too!\n"
+
+#: src/macros/designators.md:51
+msgid "These are some of the available designators:"
+msgstr "Estes are some of o available designators:"
+
+#: src/macros/designators.md:53
+msgid "`block`"
+msgstr "`block`"
+
+#: src/macros/designators.md:54
+msgid "`expr` is used for expressions"
+msgstr "`expr` is usado para expressions"
+
+#: src/macros/designators.md:55
+msgid "`ident` is used for variable/function names"
+msgstr "`ident` is usado para variável/função names"
+
+#: src/macros/designators.md:56
+msgid "`item`"
+msgstr "`item`"
+
+#: src/macros/designators.md:57
+msgid "`literal` is used for literal constants"
+msgstr "`literal` is usado para literal constants"
+
+#: src/macros/designators.md:58
+msgid "`pat` (_pattern_)"
+msgstr "`pat` (_pattern_)"
+
+#: src/macros/designators.md:59
+msgid "`path`"
+msgstr "`path`"
+
+#: src/macros/designators.md:60
+msgid "`stmt` (_statement_)"
+msgstr "`stmt` (_statement_)"
+
+#: src/macros/designators.md:61
+msgid "`tt` (_token tree_)"
+msgstr "`tt` (_token tree_)"
+
+#: src/macros/designators.md:62
+msgid "`ty` (_type_)"
+msgstr "`ty` (_type_)"
+
+#: src/macros/designators.md:63
+msgid "`vis` (_visibility qualifier_)"
+msgstr "`vis` (_visibility qualifier_)"
+
+#: src/macros/designators.md:65
+msgid ""
+"For a complete list, see the [Rust Reference](https://doc.rust-lang.org/"
+"reference/macros-by-example.html)."
+msgstr "Para um complete list, see o [Rust Reference](https://doc.rust-lang.org/reference/macros-by-example.html)."
+
+#: src/macros/overload.md:3
+msgid ""
+"Macros can be overloaded to accept different combinations of arguments. In "
+"that regard, `macro_rules!` can work similarly to a match block:"
+msgstr "Macros pode be overloaded to accept diferente combinations of argumentos. In aquele regard, `macro_rules!` pode work similarly to um match block:"
+
+#: src/macros/overload.md:7
+msgid ""
+"// `test!` will compare `$left` and `$right`\n"
+"// in different ways depending on how you invoke it:\n"
+msgstr ""
+"// `test!` vai compare `$left` e `$right`\n"
+"// in diferente ways depending on how you invoke it:\n"
+
+#: src/macros/overload.md:10
+msgid ""
+"// Arguments don't need to be separated by a comma.\n"
+"    // Any template can be used!\n"
+msgstr ""
+"// Argumentos don't need to be separated by um comma.\n"
+"    // Any template pode be usado!\n"
+
+#: src/macros/overload.md:13
+msgid "\"{:?} and {:?} is {:?}\""
+msgstr "\"{:?} e {:?} is {:?}\""
+
+#: src/macros/overload.md:18
+msgid "// ^ each arm must end with a semicolon.\n"
+msgstr ""
+"// ^ each arm deve end com um semicolon.\n"
+
+#: src/macros/overload.md:20
+msgid "\"{:?} or {:?} is {:?}\""
+msgstr "\"{:?} ou {:?} is {:?}\""
+
+#: src/macros/repeat.md:3
+msgid ""
+"Macros can use `+` in the argument list to indicate that an argument may "
+"repeat at least once, or `*`, to indicate that the argument may repeat zero "
+"or more times."
+msgstr "Macros pode use `+` in o argumento list to indicate aquele um argumento may repeat at least once, ou `*`, to indicate aquele o argumento may repeat zero ou more times."
+
+#: src/macros/repeat.md:7
+msgid ""
+"In the following example, surrounding the matcher with `$(...),+` will match "
+"one or more expression, separated by commas. Also note that the semicolon is "
+"optional on the last case."
+msgstr "In o following example, surrounding o matcher com `$(...),+` vai match one ou more expression, separated by commas. Also note aquele o semicolon is optional on o último case."
+
+#: src/macros/repeat.md:12
+msgid "// `find_min!` will calculate the minimum of any number of arguments.\n"
+msgstr ""
+"// `find_min!` vai calculate o minimum of any número of argumentos.\n"
+
+#: src/macros/repeat.md:14
+msgid "// Base case:\n"
+msgstr ""
+"// Base case:\n"
+
+#: src/macros/repeat.md:16
+msgid "// `$x` followed by at least one `$y,`\n"
+msgstr ""
+"// `$x` followed by at least one `$y,`\n"
+
+#: src/macros/repeat.md:18
+msgid "// Call `find_min!` on the tail `$y`\n"
+msgstr ""
+"// Chama `find_min!` on o tail `$y`\n"
+
+#: src/macros/dry.md:3
+msgid ""
+"Macros allow writing DRY code by factoring out the common parts of functions "
+"and/or test suites. Here is an example that implements and tests the `+=`, "
+"`*=` and `-=` operators on `Vec<T>`:"
+msgstr "Macros allow writing DRY code by factoring out o common parts of funções e/ou test suites. Here is um example aquele implements e tests o `+=`, `*=` e `-=` operators on `Vec<T>`:"
+
+#: src/macros/dry.md:11
+msgid ""
+"// The `tt` (token tree) designator is used for\n"
+"    // operators and tokens.\n"
+msgstr ""
+"// O `tt` (token tree) designator is usado para\n"
+"    // operators e tokens.\n"
+
+#: src/macros/dry.md:15
+msgid "\"{:?}: dimension mismatch: {:?} {:?} {:?}\""
+msgstr "\"{:?}: dimension mismatch: {:?} {:?} {:?}\""
+
+#: src/macros/dry.md:30
+msgid "// *x = x.$method(*y);\n"
+msgstr ""
+"// *x = x.$método(*y);\n"
+
+#: src/macros/dry.md:35
+msgid "// Implement `add_assign`, `mul_assign`, and `sub_assign` functions.\n"
+msgstr ""
+"// Implement `add_assign`, `mul_assign`, e `sub_assign` funções.\n"
+
+#: src/macros/dry.md:60
+msgid "// Test `add_assign`, `mul_assign`, and `sub_assign`.\n"
+msgstr ""
+"// Test `add_assign`, `mul_assign`, e `sub_assign`.\n"
+
+#: src/macros/dsl.md:1
+msgid "Domain Specific Languages (DSLs)"
+msgstr "Domain Specific Languages (DSLs)"
+
+#: src/macros/dsl.md:3
+msgid ""
+"A DSL is a mini \"language\" embedded in a Rust macro. It is completely "
+"valid Rust because the macro system expands into normal Rust constructs, but "
+"it looks like a small language. This allows you to define concise or "
+"intuitive syntax for some special functionality (within bounds)."
+msgstr "UM DSL is um mini \"language\" embedded in um Rust macro. It is completely válido Rust porque o macro system expands em normal Rust constructs, but it looks like um small language. Este allows you to define concise ou intuitive syntax para some special functionality (within bounds)."
+
+#: src/macros/dsl.md:8
+msgid ""
+"Suppose that I want to define a little calculator API. I would like to "
+"supply an expression and have the output printed to console."
+msgstr "Suppose aquele I want to define um little calculator API. I would like to supply um expression e have a saída printed to console."
+
+#: src/macros/dsl.md:15
+msgid "// Force types to be unsigned integers\n"
+msgstr ""
+"// Force tipos to be unsigned inteiros\n"
+
+#: src/macros/dsl.md:16 src/macros/variadics.md:15
+msgid "\"{} = {}\""
+msgstr "\"{} = {}\""
+
+#: src/macros/dsl.md:23
+msgid "// hehehe `eval` is _not_ a Rust keyword!\n"
+msgstr ""
+"// hehehe `eval` is _not_ um Rust keyword!\n"
+
+#: src/macros/dsl.md:32 src/macros/variadics.md:35
+msgid "Output:"
+msgstr "Output:"
+
+#: src/macros/dsl.md:39
+msgid ""
+"This was a very simple example, but much more complex interfaces have been "
+"developed, such as [`lazy_static`](https://crates.io/crates/lazy_static) or "
+"[`clap`](https://crates.io/crates/clap)."
+msgstr "Este was um very simple example, but much more complex interfaces have been developed, such as [`lazy_static`](https://crates.io/crates/lazy_static) ou [`clap`](https://crates.io/crates/clap)."
+
+#: src/macros/dsl.md:43
+msgid ""
+"Also, note the two pairs of braces in the macro. The outer ones are part of "
+"the syntax of `macro_rules!`, in addition to `()` or `[]`."
+msgstr "Also, note o two pairs of braces in o macro. O outer ones are part of o syntax of `macro_rules!`, in addition to `()` ou `[]`."
+
+#: src/macros/variadics.md:1
+msgid "Variadic Interfaces"
+msgstr "Variadic Interfaces"
+
+#: src/macros/variadics.md:3
+msgid ""
+"A _variadic_ interface takes an arbitrary number of arguments. For example, "
+"`println!` can take an arbitrary number of arguments, as determined by the "
+"format string."
+msgstr "UM _variadic_ interface takes um arbitrary número of argumentos. Para example, `println!` pode take um arbitrary número of argumentos, as determined by o format string."
+
+#: src/macros/variadics.md:7
+msgid ""
+"We can extend our `calculate!` macro from the previous section to be "
+"variadic:"
+msgstr "We pode extend our `calculate!` macro do anterior section to be variadic:"
+
+#: src/macros/variadics.md:11
+msgid "// The pattern for a single `eval`\n"
+msgstr ""
+"// O pattern para um single `eval`\n"
+
+#: src/macros/variadics.md:14
+msgid "// Force types to be integers\n"
+msgstr ""
+"// Force tipos to be inteiros\n"
+
+#: src/macros/variadics.md:19
+msgid "// Decompose multiple `eval`s recursively\n"
+msgstr ""
+"// Decompose multiple `eval`s recursively\n"
+
+#: src/macros/variadics.md:27
+msgid "// Look ma! Variadic `calculate!`!\n"
+msgstr ""
+"// Look ma! Variadic `calculate!`!\n"
+
+#: src/error.md:3
+msgid ""
+"Error handling is the process of handling the possibility of failure. For "
+"example, failing to read a file and then continuing to use that _bad_ input "
+"would clearly be problematic. Noticing and explicitly managing those errors "
+"saves the rest of the program from various pitfalls."
+msgstr "Erro handling is o process of handling o possibility of failure. Para example, failing to read um arquivo e then continuing to use aquele _bad_ entrada would clearly be problematic. Noticing e explicitly managing aqueles erros saves o rest of o program de various pitfalls."
+
+#: src/error.md:8
+msgid ""
+"There are various ways to deal with errors in Rust, which are described in "
+"the following subchapters. They all have more or less subtle differences and "
+"different use cases. As a rule of thumb:"
+msgstr "There are various ways to deal com erros in Rust, which are described in o following subchapters. They all have more ou less subtle differences e diferente use cases. As um rule of thumb:"
+
+#: src/error.md:12
+msgid ""
+"An explicit `panic` is mainly useful for tests and dealing with "
+"unrecoverable errors. For prototyping it can be useful, for example when "
+"dealing with functions that haven't been implemented yet, but in those cases "
+"the more descriptive `unimplemented` is better. In tests `panic` is a "
+"reasonable way to explicitly fail."
+msgstr "Um explícita `panic` is mainly useful para tests e dealing com unrecoverable erros. Para prototyping it pode be useful, para example when dealing com funções aquele haven't been implemented yet, but in aqueles cases o more descriptive `unimplemented` is better. In tests `panic` is um reasonable way to explicitly fail."
+
+#: src/error.md:17
+msgid ""
+"The `Option` type is for when a value is optional or when the lack of a "
+"value is not an error condition. For example the parent of a directory - `/` "
+"and `C:` don't have one. When dealing with `Option`s, `unwrap` is fine for "
+"prototyping and cases where it's absolutely certain that there is guaranteed "
+"to be a value. However `expect` is more useful since it lets you specify an "
+"error message in case something goes wrong anyway."
+msgstr "O `Option` tipo is para when um valor is optional ou when o lack of um valor is not um erro condition. Para example o parent of um directory - `/` e `C:` don't have one. When dealing com `Option`s, `unwrap` is fine para prototyping e cases where it's absolutely certain aquele there is guaranteed to be um valor. However `expect` is more useful since it lets you specify um erro message in case something goes wrong anyway."
+
+#: src/error.md:24
+msgid ""
+"When there is a chance that things do go wrong and the caller has to deal "
+"with the problem, use `Result`. You can `unwrap` and `expect` them as well "
+"(please don't do that unless it's a test or quick prototype)."
+msgstr "When there is um chance aquele things do go wrong e o caller has to deal com o problem, use `Result`. You pode `unwrap` e `expect` them as well (please don't do aquele unless it's um test ou quick prototype)."
+
+#: src/error.md:28
+msgid ""
+"For a more rigorous discussion of error handling, refer to the error "
+"handling section in the [official book](https://doc.rust-lang.org/book/"
+"ch09-00-error-handling.html)."
+msgstr "Para um more rigorous discussion of erro handling, refer to o erro handling section in o [official book](https://doc.rust-lang.org/book/ch09-00-error-handling.html)."
+
+#: src/error/panic.md:3
+msgid ""
+"The simplest error handling mechanism we will see is `panic`. It prints an "
+"error message, starts unwinding the stack, and usually exits the program. "
+"Here, we explicitly call `panic` on our error condition:"
+msgstr "O simplest erro handling mechanism we vai see is `panic`. It prints um erro message, starts unwinding o stack, e usually exits o program. Here, we explicitly call `panic` on our erro condition:"
+
+#: src/error/panic.md:9 src/error/abort_unwind.md:9
+msgid "// You shouldn't drink too much sugary beverages.\n"
+msgstr ""
+"// You shouldn't drink too much sugary beverages.\n"
+
+#: src/error/panic.md:10 src/error/panic.md:17 src/error/abort_unwind.md:10
+#: src/error/abort_unwind.md:23 src/error/abort_unwind.md:41
+#: src/error/abort_unwind.md:50 src/error/option_unwrap.md:32
+#: src/error/option_unwrap.md:43 src/error/option_unwrap.md:50
+msgid "\"lemonade\""
+msgstr "\"lemonade\""
+
+#: src/error/panic.md:10 src/error/option_unwrap.md:43
+msgid "\"AAAaaaaa!!!!\""
+msgstr "\"AAAaaaaa!!!!\""
+
+#: src/error/panic.md:12 src/error/abort_unwind.md:17
+#: src/error/abort_unwind.md:44
+msgid "\"Some refreshing {} is all I need.\""
+msgstr "\"Some refreshing {} is all I need.\""
+
+#: src/error/panic.md:16 src/error/abort_unwind.md:22
+#: src/error/abort_unwind.md:49 src/error/option_unwrap.md:49
+msgid "\"water\""
+msgstr "\"water\""
+
+#: src/error/panic.md:18
+msgid "\"still water\""
+msgstr "\"still water\""
+
+#: src/error/panic.md:22
+msgid ""
+"The first call to `drink` works. The second panics and thus the third is "
+"never called."
+msgstr "O primeiro call to `drink` works. O segundo panics e thus o third is never chamado."
+
+#: src/error/abort_unwind.md:1
+msgid "`abort` and `unwind`"
+msgstr "`abort` e `unwind`"
+
+#: src/error/abort_unwind.md:3
+msgid ""
+"The previous section illustrates the error handling mechanism `panic`.  "
+"Different code paths can be conditionally compiled based on the panic "
+"setting. The current values available are `unwind` and `abort`."
+msgstr "O anterior section illustrates o erro handling mechanism `panic`.  Diferente code paths pode be conditionally compiled based on o panic setting. O current valores available are `unwind` e `abort`."
+
+#: src/error/abort_unwind.md:5
+msgid ""
+"Building on the prior lemonade example, we explicitly use the panic strategy "
+"to exercise different lines of code."
+msgstr "Building on o prior lemonade example, we explicitly use o panic strategy to exercise diferente lines of code."
+
+#: src/error/abort_unwind.md:11
+msgid "\"abort\""
+msgstr "\"abort\""
+
+#: src/error/abort_unwind.md:12 src/error/abort_unwind.md:37
+msgid "\"This is not your party. Run!!!!\""
+msgstr "\"Este is not your party. Run!!!!\""
+
+#: src/error/abort_unwind.md:14 src/error/abort_unwind.md:32
+msgid "\"Spit it out!!!!\""
+msgstr "\"Spit it out!!!!\""
+
+#: src/error/abort_unwind.md:27
+msgid ""
+"Here is another example focusing on rewriting `drink()` and explicitly use "
+"the `unwind` keyword."
+msgstr "Here is another example focusing on rewriting `drink()` e explicitly use o `unwind` keyword."
+
+#: src/error/abort_unwind.md:30 src/error/abort_unwind.md:35
+msgid "\"unwind\""
+msgstr "\"unwind\""
+
+#: src/error/abort_unwind.md:54
+msgid ""
+"The panic strategy can be set from the command line by using `abort` or "
+"`unwind`."
+msgstr "O panic strategy pode be set do command line by usando `abort` ou `unwind`."
+
+#: src/error/option_unwrap.md:3
+msgid ""
+"In the last example, we showed that we can induce program failure at will. "
+"We told our program to `panic` if we drink a sugary lemonade. But what if we "
+"expect _some_ drink but don't receive one? That case would be just as bad, "
+"so it needs to be handled!"
+msgstr "In o último example, we showed aquele we pode induce program failure at vai. We told our program to `panic` if we drink um sugary lemonade. But what if we expect _some_ drink but don't receive one? Aquele case would be just as bad, so it needs to be handled!"
+
+#: src/error/option_unwrap.md:8
+msgid ""
+"We _could_ test this against the null string (`\"\"`) as we do with a "
+"lemonade. Since we're using Rust, let's instead have the compiler point out "
+"cases where there's no drink."
+msgstr "We _could_ test este against o null string (`\"\"`) as we do com um lemonade. Since we're usando Rust, let's instead have o compiler point out cases where there's no drink."
+
+#: src/error/option_unwrap.md:12
+msgid ""
+"An `enum` called `Option<T>` in the `std` library is used when absence is a "
+"possibility. It manifests itself as one of two \"options\":"
+msgstr "An `enum` called `Option<T>` in the `std` library is used when absence is a possibility. It manifests itself as one of two \"options\":"
+
+#: src/error/option_unwrap.md:15
+msgid "`Some(T)`: An element of type `T` was found"
+msgstr "`Some(T)`: Um element of tipo `T` was found"
+
+#: src/error/option_unwrap.md:16
+msgid "`None`: No element was found"
+msgstr "`None`: No element was found"
+
+#: src/error/option_unwrap.md:18
+msgid ""
+"These cases can either be explicitly handled via `match` or implicitly with "
+"`unwrap`. Implicit handling will either return the inner element or `panic`."
+msgstr "Estes cases pode either be explicitly handled via `match` ou implicitly com `unwrap`. Implícita handling vai either retorna o inner element ou `panic`."
+
+#: src/error/option_unwrap.md:21
+msgid ""
+"Note that it's possible to manually customize `panic` with [expect](https://"
+"doc.rust-lang.org/std/option/enum.Option.html#method.expect), but `unwrap` "
+"otherwise leaves us with a less meaningful output than explicit handling. In "
+"the following example, explicit handling yields a more controlled result "
+"while retaining the option to `panic` if desired."
+msgstr "Note aquele it's possible to manually customize `panic` com [expect](https://doc.rust-lang.org/std/option/enum.Option.html#method.expect), but `unwrap` otherwise leaves us com um less meaningful saída than explícita handling. In o following example, explícita handling yields um more controlled resultado while retaining o option to `panic` if desired."
+
+#: src/error/option_unwrap.md:27
+msgid ""
+"// The adult has seen it all, and can handle any drink well.\n"
+"// All drinks are handled explicitly using `match`.\n"
+msgstr ""
+"// O adult has seen it all, e pode handle any drink well.\n"
+"// All drinks are handled explicitly usando `match`.\n"
+
+#: src/error/option_unwrap.md:30
+msgid "// Specify a course of action for each case.\n"
+msgstr ""
+"// Specify um course of action para each case.\n"
+
+#: src/error/option_unwrap.md:32
+msgid "\"Yuck! Too sugary.\""
+msgstr "\"Yuck! Too sugary.\""
+
+#: src/error/option_unwrap.md:33
+msgid "\"{}? How nice.\""
+msgstr "\"{}? How nice.\""
+
+#: src/error/option_unwrap.md:34
+msgid "\"No drink? Oh well.\""
+msgstr "\"No drink? Oh well.\""
+
+#: src/error/option_unwrap.md:37
+msgid ""
+"// Others will `panic` before drinking sugary drinks.\n"
+"// All drinks are handled implicitly using `unwrap`.\n"
+msgstr ""
+"// Others vai `panic` before drinking sugary drinks.\n"
+"// All drinks are handled implicitly usando `unwrap`.\n"
+
+#: src/error/option_unwrap.md:41
+msgid "// `unwrap` returns a `panic` when it receives a `None`.\n"
+msgstr ""
+"// `unwrap` retorna um `panic` when it receives um `None`.\n"
+
+#: src/error/option_unwrap.md:45
+msgid "\"I love {}s!!!!!\""
+msgstr "\"I love {}s!!!!!\""
+
+#: src/error/option_unwrap.md:57
+msgid "\"coffee\""
+msgstr "\"coffee\""
+
+#: src/error/option_unwrap/question_mark.md:3
+msgid ""
+"You can unpack `Option`s by using `match` statements, but it's often easier "
+"to use the `?` operator. If `x` is an `Option`, then evaluating `x?` will "
+"return the underlying value if `x` is `Some`, otherwise it will terminate "
+"whatever function is being executed and return `None`."
+msgstr "You pode unpack `Option`s by usando `match` statements, but it's often easier to use o `?` operator. If `x` is um `Option`, then evaluating `x?` vai retorna o underlying valor if `x` is `Some`, otherwise it vai terminate whatever função is being executed e retorna `None`."
+
+#: src/error/option_unwrap/question_mark.md:10
+msgid ""
+"// If `current_age` is `None`, this returns `None`.\n"
+"    // If `current_age` is `Some`, the inner `u8` value + 1\n"
+"    // gets assigned to `next_age`\n"
+msgstr ""
+"// If `current_age` is `None`, this returns `None`.\n"
+"    // If `current_age` is `Some`, the inner `u8` value + 1\n"
+"    // gets assigned to `next_age`\n"
+
+#: src/error/option_unwrap/question_mark.md:14
+msgid "\"Next year I will be {}\""
+msgstr "\"Próximo year I vai be {}\""
+
+#: src/error/option_unwrap/question_mark.md:18
+msgid "You can chain many `?`s together to make your code much more readable."
+msgstr "You pode chain many `?`s together to make your code much more readable."
+
+#: src/error/option_unwrap/question_mark.md:38
+msgid ""
+"// Gets the area code of the phone number of the person's job, if it "
+"exists.\n"
+msgstr ""
+"// Gets o area code of o phone número of o person's job, if it exists.\n"
+
+#: src/error/option_unwrap/question_mark.md:40
+msgid ""
+"// This would need many nested `match` statements without the `?` operator.\n"
+"        // It would take a lot more code - try writing it yourself and see "
+"which\n"
+"        // is easier.\n"
+msgstr ""
+"// Este would need many nested `match` statements sno `?` operator.\n"
+"        // It would take um lot more code - try writing it yourself e see which\n"
+"        // is easier.\n"
+
+#: src/error/option_unwrap/map.md:3
+msgid ""
+"`match` is a valid method for handling `Option`s. However, you may "
+"eventually find heavy usage tedious, especially with operations only valid "
+"with an input. In these cases, [combinators](https://doc.rust-lang.org/"
+"reference/glossary.html#combinator) can be used to manage control flow in a "
+"modular fashion."
+msgstr "`match` is um válido método para handling `Option`s. However, you may eventually find heavy usage tedious, especially com operations only válido com um entrada. In estes cases, [combinators](https://doc.rust-lang.org/reference/glossary.html#combinator) pode be usado to manage control flow in um modular fashion."
+
+#: src/error/option_unwrap/map.md:8
+msgid ""
+"`Option` has a built in method called `map()`, a combinator for the simple "
+"mapping of `Some -> Some` and `None -> None`. Multiple `map()` calls can be "
+"chained together for even more flexibility."
+msgstr "`Option` has um built in método chamado `map()`, um combinator para o simple mapping of `Some -> Some` e `None -> None`. Multiple `map()` calls pode be chained together para even more flexibility."
+
+#: src/error/option_unwrap/map.md:12
+msgid ""
+"In the following example, `process()` replaces all functions previous to it "
+"while staying compact."
+msgstr "In o following example, `process()` replaces all funções anterior to it while staying compact."
+
+#: src/error/option_unwrap/map.md:23
+msgid ""
+"// Peeling food. If there isn't any, then return `None`.\n"
+"// Otherwise, return the peeled food.\n"
+msgstr ""
+"// Peeling food. If there isn't any, then retorna `None`.\n"
+"// Otherwise, retorna o peeled food.\n"
+
+#: src/error/option_unwrap/map.md:32
+msgid ""
+"// Chopping food. If there isn't any, then return `None`.\n"
+"// Otherwise, return the chopped food.\n"
+msgstr ""
+"// Chopping food. If there isn't any, then retorna `None`.\n"
+"// Otherwise, retorna o chopped food.\n"
+
+#: src/error/option_unwrap/map.md:41
+msgid ""
+"// Cooking food. Here, we showcase `map()` instead of `match` for case "
+"handling.\n"
+msgstr ""
+"// Cooking food. Here, we showcase `map()` instead of `match` para case handling.\n"
+
+#: src/error/option_unwrap/map.md:46
+msgid ""
+"// A function to peel, chop, and cook food all in sequence.\n"
+"// We chain multiple uses of `map()` to simplify the code.\n"
+msgstr ""
+"// UM função to peel, chop, e cook food all in sequence.\n"
+"// We chain multiple uses of `map()` to simplify o code.\n"
+
+#: src/error/option_unwrap/map.md:54
+msgid "// Check whether there's food or not before trying to eat it!\n"
+msgstr ""
+"// Check whether there's food ou not before trying to eat it!\n"
+
+#: src/error/option_unwrap/map.md:58
+msgid "\"Mmm. I love {:?}\""
+msgstr "\"Mmm. I love {:?}\""
+
+#: src/error/option_unwrap/map.md:59
+msgid "\"Oh no! It wasn't edible.\""
+msgstr "\"Oh no! It wasn't edible.\""
+
+#: src/error/option_unwrap/map.md:70
+msgid "// Let's try the simpler looking `process()` now.\n"
+msgstr ""
+"// Let's try o simpler looking `process()` now.\n"
+
+#: src/error/option_unwrap/map.md:81
+msgid ""
+"[closures](../../fn/closures.md), [`Option`](https://doc.rust-lang.org/std/"
+"option/enum.Option.html), [`Option::map()`](https://doc.rust-lang.org/std/"
+"option/enum.Option.html#method.map)"
+msgstr "[closures](../../fn/closures.md), [`Option`](https://doc.rust-lang.org/std/option/enum.Option.html), [`Option::map()`](https://doc.rust-lang.org/std/option/enum.Option.html#method.map)"
+
+#: src/error/option_unwrap/and_then.md:3
+msgid ""
+"`map()` was described as a chainable way to simplify `match` statements. "
+"However, using `map()` on a function that returns an `Option<T>` results in "
+"the nested `Option<Option<T>>`. Chaining multiple calls together can then "
+"become confusing. That's where another combinator called `and_then()`, known "
+"in some languages as flatmap, comes in."
+msgstr "`map()` was described as um chainable way to simplify `match` statements. However, usando `map()` on um função aquele retorna um `Option<T>` resultados in o nested `Option<Option<T>>`. Chaining multiple calls together pode then become confusing. Aquele's where another combinator chamado `and_then()`, known in some languages as flatmap, comes in."
+
+#: src/error/option_unwrap/and_then.md:9
+msgid ""
+"`and_then()` calls its function input with the wrapped value and returns the "
+"result. If the `Option` is `None`, then it returns `None` instead."
+msgstr "`and_then()` calls its funçãa entrada com o wrapped valor e retorna o resultado. If o `Option` is `None`, then it retorna `None` instead."
+
+#: src/error/option_unwrap/and_then.md:11
+msgid ""
+"In the following example, `cookable_v3()` results in an `Option<Food>`. "
+"Using `map()` instead of `and_then()` would have given an "
+"`Option<Option<Food>>`, which is an invalid type for `eat()`."
+msgstr "In o following example, `cookable_v3()` resultados in um `Option<Food>`. Usando `map()` instead of `and_then()` would have given um `Option<Option<Food>>`, which is um inválido tipo para `eat()`."
+
+#: src/error/option_unwrap/and_then.md:20
+msgid "// We don't have the ingredients to make Sushi.\n"
+msgstr ""
+"// We don't have o ingredients to make Sushi.\n"
+
+#: src/error/option_unwrap/and_then.md:28
+msgid "// We have the recipe for everything except Cordon Bleu.\n"
+msgstr ""
+"// We have o recipe para everything except Cordon Bleu.\n"
+
+#: src/error/option_unwrap/and_then.md:36
+msgid ""
+"// To make a dish, we need both the recipe and the ingredients.\n"
+"// We can represent the logic with a chain of `match`es:\n"
+msgstr ""
+"// To make um dish, we need both o recipe e o ingredients.\n"
+"// We pode represent o logic com um chain of `match`es:\n"
+
+#: src/error/option_unwrap/and_then.md:45
+msgid ""
+"// This can conveniently be rewritten more compactly with `and_then()`:\n"
+msgstr ""
+"// Este pode conveniently be rewritten more compactly com `and_then()`:\n"
+
+#: src/error/option_unwrap/and_then.md:50
+msgid ""
+"// Otherwise we'd need to `flatten()` an `Option<Option<Food>>`\n"
+"// to get an `Option<Food>`:\n"
+msgstr ""
+"// Otherwise we'd need to `flatten()` um `Option<Option<Food>>`\n"
+"// to get um `Option<Food>`:\n"
+
+#: src/error/option_unwrap/and_then.md:59
+msgid "\"Yay! On {:?} we get to eat {:?}.\""
+msgstr "\"Yay! On {:?} we get to eat {:?}.\""
+
+#: src/error/option_unwrap/and_then.md:60
+msgid "\"Oh no. We don't get to eat on {:?}?\""
+msgstr "\"Oh no. We don't get to eat on {:?}?\""
+
+#: src/error/option_unwrap/and_then.md:75
+msgid ""
+"[closures](../../fn/closures.md), [`Option`](https://doc.rust-lang.org/std/"
+"option/enum.Option.html), [`Option::and_then()`](https://doc.rust-lang.org/"
+"std/option/enum.Option.html#method.and_then), and [`Option::flatten()`]"
+"(https://doc.rust-lang.org/std/option/enum.Option.html#method.flatten)"
+msgstr "[closures](../../fn/closures.md), [`Option`](https://doc.rust-lang.org/std/option/enum.Option.html), [`Option::and_then()`](https://doc.rust-lang.org/std/option/enum.Option.html#method.and_then), e [`Option::flatten()`](https://doc.rust-lang.org/std/option/enum.Option.html#method.flatten)"
+
+#: src/error/option_unwrap/defaults.md:1
+msgid "Unpacking options and defaults"
+msgstr "Unpacking options e defaults"
+
+#: src/error/option_unwrap/defaults.md:3
+msgid ""
+"There is more than one way to unpack an `Option` and fall back on a default "
+"if it is `None`. To choose the one that meets our needs, we need to consider "
+"the following:"
+msgstr "There is more than one way to unpack um `Option` e fall back on um default if it is `None`. To choose o one aquele meets our needs, we need to consider o following:"
+
+#: src/error/option_unwrap/defaults.md:5
+msgid "do we need eager or lazy evaluation?"
+msgstr "do we need eager ou lazy evaluation?"
+
+#: src/error/option_unwrap/defaults.md:6
+msgid ""
+"do we need to keep the original empty value intact, or modify it in place?"
+msgstr "do we need to keep o original vazio valor intact, ou modify it in place?"
+
+#: src/error/option_unwrap/defaults.md:8
+msgid "`or()` is chainable, evaluates eagerly, keeps empty value intact"
+msgstr "`or()` is chainable, evaluates eagerly, keeps vazio valor intact"
+
+#: src/error/option_unwrap/defaults.md:10
+msgid ""
+"`or()`is chainable and eagerly evaluates its argument, as is shown in the "
+"following example. Note that because `or`'s arguments are evaluated eagerly, "
+"the variable passed to `or` is moved."
+msgstr "`or()`is chainable e eagerly evaluates its argumento, as is shown in o following example. Note aquele porque `or`'s argumentos are evaluated eagerly, o variável passed to `or` is moved."
+
+#: src/error/option_unwrap/defaults.md:22
+#: src/error/option_unwrap/defaults.md:55
+msgid "\"first_available_fruit: {:?}\""
+msgstr "\"first_available_fruit: {:?}\""
+
+#: src/error/option_unwrap/defaults.md:23
+msgid "// first_available_fruit: Some(Orange)\n"
+msgstr ""
+"// first_available_fruit: Some(Orange)\n"
+
+#: src/error/option_unwrap/defaults.md:25
+msgid ""
+"// `or` moves its argument.\n"
+"    // In the example above, `or(orange)` returned a `Some`, so `or(apple)` "
+"was not invoked.\n"
+"    // But the variable named `apple` has been moved regardless, and cannot "
+"be used anymore.\n"
+"    // println!(\"Variable apple was moved, so this line won't compile: "
+"{:?}\", apple);\n"
+"    // TODO: uncomment the line above to see the compiler error\n"
+msgstr ""
+"// `or` moves its argumento.\n"
+"    // In o example acima, `or(orange)` retornado um `Some`, so `or(apple)` was not invoked.\n"
+"    // But o variável named `apple` has been moved regardless, e não pode be usado anymore.\n"
+"    // println!(\"Variável apple was moved, so este line won't compile: {:?}\", apple);\n"
+"    // TODO: uncomment o line acima to see o compiler erro\n"
+
+#: src/error/option_unwrap/defaults.md:33
+msgid "`or_else()` is chainable, evaluates lazily, keeps empty value intact"
+msgstr "`or_else()` is chainable, evaluates lazily, keeps vazio valor intact"
+
+#: src/error/option_unwrap/defaults.md:35
+msgid ""
+"Another alternative is to use `or_else`, which is also chainable, and "
+"evaluates lazily, as is shown in the following example:"
+msgstr "Another alternative is to use `or_else`, which is also chainable, and evaluates lazily, as is shown in the following example:"
+
+#: src/error/option_unwrap/defaults.md:44
+msgid "\"Providing kiwi as fallback\""
+msgstr "\"Providing kiwi as fallback\""
+
+#: src/error/option_unwrap/defaults.md:48
+#: src/error/option_unwrap/defaults.md:93
+msgid "\"Providing lemon as fallback\""
+msgstr "\"Providing lemon as fallback\""
+
+#: src/error/option_unwrap/defaults.md:56
+msgid ""
+"// Providing kiwi as fallback\n"
+"    // first_available_fruit: Some(Kiwi)\n"
+msgstr ""
+"// Providing kiwi as fallback\n"
+"    // first_available_fruit: Some(Kiwi)\n"
+
+#: src/error/option_unwrap/defaults.md:61
+msgid "`get_or_insert()` evaluates eagerly, modifies empty value in place"
+msgstr "`get_or_insert()` evaluates eagerly, modifies vazio valor in place"
+
+#: src/error/option_unwrap/defaults.md:63
+msgid ""
+"To make sure that an `Option` contains a value, we can use `get_or_insert` "
+"to modify it in place with a fallback value, as is shown in the following "
+"example. Note that `get_or_insert` eagerly evaluates its parameter, so "
+"variable `apple` is moved:"
+msgstr "To make sure aquele um `Option` contains um valor, we pode use `get_or_insert` to modify it in place com um fallback valor, as is shown in o following example. Note aquele `get_or_insert` eagerly evaluates its parâmetro, so variável `apple` is moved:"
+
+#: src/error/option_unwrap/defaults.md:73
+#: src/error/option_unwrap/defaults.md:98
+msgid "\"first_available_fruit is: {:?}\""
+msgstr "\"first_available_fruit is: {:?}\""
+
+#: src/error/option_unwrap/defaults.md:74
+#: src/error/option_unwrap/defaults.md:99
+msgid "\"my_fruit is: {:?}\""
+msgstr "\"my_fruit is: {:?}\""
+
+#: src/error/option_unwrap/defaults.md:75
+msgid ""
+"// first_available_fruit is: Apple\n"
+"    // my_fruit is: Some(Apple)\n"
+"    //println!(\"Variable named `apple` is moved: {:?}\", apple);\n"
+"    // TODO: uncomment the line above to see the compiler error\n"
+msgstr ""
+"// first_available_fruit is: Apple\n"
+"    // my_fruit is: Some(Apple)\n"
+"    //println!(\"Variável named `apple` is moved: {:?}\", apple);\n"
+"    // TODO: uncomment o line acima to see o compiler erro\n"
+
+#: src/error/option_unwrap/defaults.md:82
+msgid "`get_or_insert_with()` evaluates lazily, modifies empty value in place"
+msgstr "`get_or_insert_with()` evaluates lazily, modifies vazio valor in place"
+
+#: src/error/option_unwrap/defaults.md:84
+msgid ""
+"Instead of explicitly providing a value to fall back on, we can pass a "
+"closure to `get_or_insert_with`, as follows:"
+msgstr "Instead of explicitly providing um valor to fall back on, we pode pass um closure to `get_or_insert_with`, as follows:"
+
+#: src/error/option_unwrap/defaults.md:100
+msgid ""
+"// Providing lemon as fallback\n"
+"    // first_available_fruit is: Lemon\n"
+"    // my_fruit is: Some(Lemon)\n"
+msgstr ""
+"// Providing lemon as fallback\n"
+"    // first_available_fruit is: Lemon\n"
+"    // my_fruit is: Some(Lemon)\n"
+
+#: src/error/option_unwrap/defaults.md:104
+msgid ""
+"// If the Option has a value, it is left unchanged, and the closure is not "
+"invoked\n"
+msgstr ""
+"// If the Option has a value, it is left unchanged, and the closure is not invoked\n"
+
+#: src/error/option_unwrap/defaults.md:107
+msgid "\"should_be_apple is: {:?}\""
+msgstr "\"should_be_apple is: {:?}\""
+
+#: src/error/option_unwrap/defaults.md:108
+msgid "\"my_apple is unchanged: {:?}\""
+msgstr "\"my_apple is unchanged: {:?}\""
+
+#: src/error/option_unwrap/defaults.md:109
+msgid ""
+"// The output is a follows. Note that the closure `get_lemon_as_fallback` is "
+"not invoked\n"
+"    // should_be_apple is: Apple\n"
+"    // my_apple is unchanged: Some(Apple)\n"
+msgstr ""
+"// O saída is um follows. Note aquele o closure `get_lemon_as_fallback` is not invoked\n"
+"    // should_be_apple is: Apple\n"
+"    // my_apple is unchanged: Some(Apple)\n"
+
+#: src/error/option_unwrap/defaults.md:117
+msgid ""
+"[`closures`](https://doc.rust-lang.org/book/ch13-01-closures.html), "
+"[`get_or_insert`](https://doc.rust-lang.org/core/option/enum.Option."
+"html#method.get_or_insert), [`get_or_insert_with`](https://doc.rust-lang.org/"
+"core/option/enum.Option.html#method.get_or_insert_with), [`moved variables`]"
+"(https://doc.rust-lang.org/book/ch04-02-references-and-borrowing.html), "
+"[`or`](https://doc.rust-lang.org/core/option/enum.Option.html#method.or), "
+"[`or_else`](https://doc.rust-lang.org/core/option/enum.Option.html#method."
+"or_else)"
+msgstr "[`closures`](https://doc.rust-lang.org/book/ch13-01-closures.html), [`get_or_insert`](https://doc.rust-lang.org/core/option/enum.Option.html#method.get_or_insert), [`get_or_insert_with`](https://doc.rust-lang.org/core/option/enum.Option.html#method.get_or_insert_with), [`moved variables`](https://doc.rust-lang.org/book/ch04-02-references-and-borrowing.html), [`or`](https://doc.rust-lang.org/core/option/enum.Option.html#method.or), [`or_else`](https://doc.rust-lang.org/core/option/enum.Option.html#method.or_else)"
+
+#: src/error/result.md:3
+msgid ""
+"[`Result`](https://doc.rust-lang.org/std/result/enum.Result.html) is a "
+"richer version of the [`Option`](https://doc.rust-lang.org/std/option/enum."
+"Option.html) type that describes possible _error_ instead of possible "
+"_absence_."
+msgstr "[`Result`](https://doc.rust-lang.org/std/result/enum.Result.html) is um richer version of o [`Option`](https://doc.rust-lang.org/std/option/enum.Option.html) tipo aquele describes possible _error_ instead of possible _absence_."
+
+#: src/error/result.md:6
+msgid "That is, `Result<T, E>` could have one of two outcomes:"
+msgstr "Aquele is, `Result<T, E>` could have one of two outcomes:"
+
+#: src/error/result.md:8
+msgid "`Ok(T)`: An element `T` was found"
+msgstr "`Ok(T)`: Um element `T` was found"
+
+#: src/error/result.md:9
+msgid "`Err(E)`: An error was found with element `E`"
+msgstr "`Err(E)`: Um erro was found com element `E`"
+
+#: src/error/result.md:11
+msgid ""
+"By convention, the expected outcome is `Ok` while the unexpected outcome is "
+"`Err`."
+msgstr "By convention, o expected outcome is `Ok` while o unexpected outcome is `Err`."
+
+#: src/error/result.md:13
+msgid ""
+"Like `Option`, `Result` has many methods associated with it. `unwrap()`, for "
+"example, either yields the element `T` or `panic`s. For case handling, there "
+"are many combinators between `Result` and `Option` that overlap."
+msgstr "Like `Option`, `Result` has many métodos associated com it. `unwrap()`, para example, either yields o element `T` ou `panic`s. Para case handling, there are many combinators between `Result` e `Option` aquele overlap."
+
+#: src/error/result.md:17
+msgid ""
+"In working with Rust, you will likely encounter methods that return the "
+"`Result` type, such as the [`parse()`](https://doc.rust-lang.org/std/"
+"primitive.str.html#method.parse) method. It might not always be possible to "
+"parse a string into the other type, so `parse()` returns a `Result` "
+"indicating possible failure."
+msgstr "In working com Rust, you vai likely encounter métodos aquele retorna o `Result` tipo, such as o [`parse()`](https://doc.rust-lang.org/std/primitive.str.html#method.parse) método. It might not always be possible to parse um string no other tipo, so `parse()` retorna um `Result` indicating possible failure."
+
+#: src/error/result.md:22
+msgid ""
+"Let's see what happens when we successfully and unsuccessfully `parse()` a "
+"string:"
+msgstr "Let's see what happens when we successfully e unsuccessfully `parse()` um string:"
+
+#: src/error/result.md:26
+msgid "// Let's try using `unwrap()` to get the number out. Will it bite us?\n"
+msgstr ""
+"// Let's try usando `unwrap()` to get o número out. Vai it bite us?\n"
+
+#: src/error/result.md:33 src/error/result.md:36
+#: src/error/result/result_map.md:42 src/error/result/result_map.md:46
+#: src/error/result/result_map.md:75 src/error/result/result_map.md:79
+#: src/error/result/result_alias.md:36 src/error/result/result_alias.md:37
+#: src/error/result/early_returns.md:36 src/error/result/early_returns.md:37
+#: src/error/result/enter_question_mark.md:34
+#: src/error/result/enter_question_mark.md:35
+#: src/error/result/enter_question_mark.md:67
+#: src/error/result/enter_question_mark.md:68
+msgid "\"2\""
+msgstr "\"2\""
+
+#: src/error/result.md:34 src/error/result.md:37
+msgid "\"double is {}\""
+msgstr "\"double is {}\""
+
+#: src/error/result.md:36 src/error/result/result_map.md:46
+#: src/error/result/result_map.md:79 src/error/result/result_alias.md:37
+#: src/error/result/early_returns.md:37
+#: src/error/result/enter_question_mark.md:35
+#: src/error/result/enter_question_mark.md:68
+msgid "\"t\""
+msgstr "\"t\""
+
+#: src/error/result.md:41
+msgid ""
+"In the unsuccessful case, `parse()` leaves us with an error for `unwrap()` "
+"to `panic` on. Additionally, the `panic` exits our program and provides an "
+"unpleasant error message."
+msgstr "In o unsuccessful case, `parse()` leaves us com um erro para `unwrap()` to `panic` on. Adicionaitionally, o `panic` exits our program e provides um unpleasant erro message."
+
+#: src/error/result.md:45
+msgid ""
+"To improve the quality of our error message, we should be more specific "
+"about the return type and consider explicitly handling the error."
+msgstr "To improve o quality of our erro message, we deve be more specific about o retorna tipo e consider explicitly handling o erro."
+
+#: src/error/result.md:48
+msgid "Using `Result` in `main`"
+msgstr "Usando `Result` in `main`"
+
+#: src/error/result.md:50
+msgid ""
+"The `Result` type can also be the return type of the `main` function if "
+"specified explicitly. Typically the `main` function will be of the form:"
+msgstr "O `Result` tipo pode also be o retorna tipo of o `main` função if specified explicitly. Typically o `main` função vai be of o form:"
+
+#: src/error/result.md:59
+msgid ""
+"However `main` is also able to have a return type of `Result`. If an error "
+"occurs within the `main` function it will return an error code and print a "
+"debug representation of the error (using the [`Debug`](https://doc.rust-lang."
+"org/std/fmt/trait.Debug.html) trait). The following example shows such a "
+"scenario and touches on aspects covered in [the following section](result/"
+"early_returns.md)."
+msgstr "However `main` is also able to have um retorna tipo of `Result`. If um erro occurs within o `main` função it vai retorna um erro code e print um debug representation of o erro (usando o [`Debug`](https://doc.rust-lang.org/std/fmt/trait.Debug.html) trait). O following example shows such um scenario e touches on aspects covered in [the following section](result/early_returns.md)."
+
+#: src/error/result/result_map.md:3
+msgid ""
+"Panicking in the previous example's `multiply` does not make for robust "
+"code. Generally, we want to return the error to the caller so it can decide "
+"what is the right way to respond to errors."
+msgstr "Panicking in o anterior example's `multiply` does not make para robust code. Generally, we want to retorna o erro to o caller so it pode decide what is o right way to respond to erros."
+
+#: src/error/result/result_map.md:7
+msgid ""
+"We first need to know what kind of error type we are dealing with. To "
+"determine the `Err` type, we look to [`parse()`](https://doc.rust-lang.org/"
+"std/primitive.str.html#method.parse), which is implemented with the "
+"[`FromStr`](https://doc.rust-lang.org/std/str/trait.FromStr.html) trait for "
+"[`i32`](https://doc.rust-lang.org/std/primitive.i32.html). As a result, the "
+"`Err` type is specified as [`ParseIntError`](https://doc.rust-lang.org/std/"
+"num/struct.ParseIntError.html)."
+msgstr "We primeiro need to know what kind of erro tipo we are dealing com. To determine o `Err` tipo, we look to [`parse()`](https://doc.rust-lang.org/std/primitive.str.html#method.parse), which is implemented com o [`FromStr`](https://doc.rust-lang.org/std/str/trait.FromStr.html) trait para [`i32`](https://doc.rust-lang.org/std/primitive.i32.html). As um resultado, o `Err` tipo is specified as [`ParseIntError`](https://doc.rust-lang.org/std/num/struct.ParseIntError.html)."
+
+#: src/error/result/result_map.md:12
+msgid ""
+"In the example below, the straightforward `match` statement leads to code "
+"that is overall more cumbersome."
+msgstr "In o example abaixo, o straightforward `match` statement leads to code aquele is overall more cumbersome."
+
+#: src/error/result/result_map.md:17
+msgid ""
+"// With the return type rewritten, we use pattern matching without "
+"`unwrap()`.\n"
+msgstr ""
+"// Com o retorna tipo rewritten, we use pattern matching sem `unwrap()`.\n"
+
+#: src/error/result/result_map.md:35 src/error/result/result_map.md:68
+#: src/error/result/result_alias.md:30 src/error/result/early_returns.md:30
+#: src/error/result/enter_question_mark.md:28
+#: src/error/result/enter_question_mark.md:61
+msgid "\"n is {}\""
+msgstr "\"n is {}\""
+
+#: src/error/result/result_map.md:36 src/error/result/result_map.md:69
+#: src/error/result/result_alias.md:31 src/error/result/early_returns.md:31
+#: src/error/result/enter_question_mark.md:29
+#: src/error/result/enter_question_mark.md:62
+#: src/error/multiple_error_types/define_error_type.md:55
+#: src/error/multiple_error_types/boxing_errors.md:42
+#: src/error/multiple_error_types/reenter_question_mark.md:54
+#: src/error/multiple_error_types/wrap_error.md:68
+msgid "\"Error: {}\""
+msgstr "\"Erro: {}\""
+
+#: src/error/result/result_map.md:41 src/error/result/result_map.md:74
+msgid "// This still presents a reasonable answer.\n"
+msgstr ""
+"// Este still presents um reasonable answer.\n"
+
+#: src/error/result/result_map.md:45 src/error/result/result_map.md:78
+msgid "// The following now provides a much more helpful error message.\n"
+msgstr ""
+"// O following now provides um much more helpful erro message.\n"
+
+#: src/error/result/result_map.md:51
+msgid ""
+"Luckily, `Option`'s `map`, `and_then`, and many other combinators are also "
+"implemented for `Result`. [`Result`](https://doc.rust-lang.org/std/result/"
+"enum.Result.html) contains a complete listing."
+msgstr "Luckily, `Option`'s `map`, `and_then`, e many other combinators are also implemented para `Result`. [`Result`](https://doc.rust-lang.org/std/result/enum.Result.html) contains um complete listing."
+
+#: src/error/result/result_map.md:56
+msgid ""
+"// As with `Option`, we can use combinators such as `map()`.\n"
+"// This function is otherwise identical to the one above and reads:\n"
+"// Multiply if both values can be parsed from str, otherwise pass on the "
+"error.\n"
+msgstr ""
+"// As com `Option`, we pode use combinators such as `map()`.\n"
+"// Este função is otherwise identical to o one acima e reads:\n"
+"// Multiply if both valores pode be parsed de str, otherwise pass on o erro.\n"
+
+#: src/error/result/result_alias.md:3
+msgid ""
+"How about when we want to reuse a specific `Result` type many times? Recall "
+"that Rust allows us to create [aliases](../../types/alias.md). Conveniently, "
+"we can define one for the specific `Result` in question."
+msgstr "How about when we want to reuse um specific `Result` tipo many times? Recall aquele Rust allows us to create [aliases](../../types/alias.md). Conveniently, we pode define one para o specific `Result` in question."
+
+#: src/error/result/result_alias.md:7
+msgid ""
+"At a module level, creating aliases can be particularly helpful. Errors "
+"found in a specific module often have the same `Err` type, so a single alias "
+"can succinctly define _all_ associated `Results`. This is so useful that the "
+"`std` library even supplies one: [`io::Result`](https://doc.rust-lang.org/"
+"std/io/type.Result.html)!"
+msgstr "At um módulo level, creating aliases pode be particularly helpful. Erros found in um specific módulo often have o mesmo `Err` tipo, so um single alias pode succinctly define _all_ associated `Results`. Este is so useful aquele o `std` library even supplies one: [`io::Result`](https://doc.rust-lang.org/std/io/type.Result.html)!"
+
+#: src/error/result/result_alias.md:12
+msgid "Here's a quick example to show off the syntax:"
+msgstr "Here's um quick example to show off o syntax:"
+
+#: src/error/result/result_alias.md:16
+msgid ""
+"// Define a generic alias for a `Result` with the error type "
+"`ParseIntError`.\n"
+msgstr ""
+"// Define um generic alias para um `Result` com o erro tipo `ParseIntError`.\n"
+
+#: src/error/result/result_alias.md:19
+msgid "// Use the above alias to refer to our specific `Result` type.\n"
+msgstr ""
+"// Usa o acima alias to refer to our specific `Result` tipo.\n"
+
+#: src/error/result/result_alias.md:26
+msgid "// Here, the alias again allows us to save some space.\n"
+msgstr ""
+"// Here, o alias again allows us to save some space.\n"
+
+#: src/error/result/result_alias.md:43
+msgid "[`io::Result`](https://doc.rust-lang.org/std/io/type.Result.html)"
+msgstr "[`io::Result`](https://doc.rust-lang.org/std/io/type.Result.html)"
+
+#: src/error/result/early_returns.md:3
+msgid ""
+"In the previous example, we explicitly handled the errors using combinators. "
+"Another way to deal with this case analysis is to use a combination of "
+"`match` statements and _early returns_."
+msgstr "In o anterior example, we explicitly handled o erros usando combinators. Another way to deal com este case analysis is to use um combination of `match` statements e _early returns_."
+
+#: src/error/result/early_returns.md:7
+msgid ""
+"That is, we can simply stop executing the function and return the error if "
+"one occurs. For some, this form of code can be easier to both read and "
+"write. Consider this version of the previous example, rewritten using early "
+"returns:"
+msgstr "Aquele is, we pode simply stop executing a função e retorna o erro if one occurs. Para some, este form of code pode be easier to both read e write. Consider este version of o anterior example, rewritten usando early retorna:"
+
+#: src/error/result/early_returns.md:41
+msgid ""
+"At this point, we've learned to explicitly handle errors using combinators "
+"and early returns. While we generally want to avoid panicking, explicitly "
+"handling all of our errors is cumbersome."
+msgstr "At este point, we've learned to explicitly handle erros usando combinators e early retorna. While we generally want to avoid panicking, explicitly handling all of our erros is cumbersome."
+
+#: src/error/result/early_returns.md:45
+msgid ""
+"In the next section, we'll introduce `?` for the cases where we simply need "
+"to `unwrap` without possibly inducing `panic`."
+msgstr "In o próximo section, we'll introduce `?` para o cases where we simply need to `unwrap` sem possibly inducing `panic`."
+
+#: src/error/result/enter_question_mark.md:3
+msgid ""
+"Sometimes we just want the simplicity of `unwrap` without the possibility of "
+"a `panic`. Until now, `unwrap` has forced us to nest deeper and deeper when "
+"what we really wanted was to get the variable _out_. This is exactly the "
+"purpose of `?`."
+msgstr "Sometimes we just want o simplicity of `unwrap` sno possibility of um `panic`. Until now, `unwrap` has forced us to nest deeper e deeper when what we really wanted was to get o variável _out_. Este is exactly o purpose of `?`."
+
+#: src/error/result/enter_question_mark.md:7
+msgid "Upon finding an `Err`, there are two valid actions to take:"
+msgstr "Upon finding um `Err`, there are two válido actions to take:"
+
+#: src/error/result/enter_question_mark.md:9
+msgid "`panic!` which we already decided to try to avoid if possible"
+msgstr "`panic!` which we already decided to try to avoid if possible"
+
+#: src/error/result/enter_question_mark.md:10
+msgid "`return` because an `Err` means it cannot be handled"
+msgstr "`return` porque um `Err` means it não pode be handled"
+
+#: src/error/result/enter_question_mark.md:12
+msgid ""
+"`?` is _almost_[^†] exactly equivalent to an `unwrap` which `return`s "
+"instead of `panic`king on `Err`s. Let's see how we can simplify the earlier "
+"example that used combinators:"
+msgstr "`?` is _almost_[^†] exactly equivalent to um `unwrap` which `return`s instead of `panic`king on `Err`s. Let's see how we pode simplify o earlier example aquele usado combinators:"
+
+#: src/error/result/enter_question_mark.md:39
+msgid "The `try!` macro"
+msgstr "O `try!` macro"
+
+#: src/error/result/enter_question_mark.md:41
+msgid ""
+"Before there was `?`, the same functionality was achieved with the `try!` "
+"macro. The `?` operator is now recommended, but you may still find `try!` "
+"when looking at older code. The same `multiply` function from the previous "
+"example would look like this using `try!`:"
+msgstr "Before there was `?`, o mesmo functionality was achieved com o `try!` macro. O `?` operator is now recommended, but you may still find `try!` when looking at older code. O mesmo `multiply` função do anterior example would look like este usando `try!`:"
+
+#: src/error/result/enter_question_mark.md:47
+msgid ""
+"// To compile and run this example without errors, while using Cargo, change "
+"the value \n"
+"// of the `edition` field, in the `[package]` section of the `Cargo.toml` "
+"file, to \"2015\".\n"
+msgstr ""
+"// To compile e run este example sem erros, while usando Cargo, change o valor \n"
+"// of o `edition` campo, in o `[package]` section of o `Cargo.toml` arquivo, to \"2015\".\n"
+
+#: src/error/result/enter_question_mark.md:72
+msgid ""
+"See [re-enter ?](../multiple_error_types/reenter_question_mark.md) for more "
+"details."
+msgstr "See [re-enter ?](../multiple_error_types/reenter_question_mark.md) para more details."
+
+#: src/error/multiple_error_types.md:3
+msgid ""
+"The previous examples have always been very convenient; `Result`s interact "
+"with other `Result`s and `Option`s interact with other `Option`s."
+msgstr "O anterior examples have always been very convenient; `Result`s interact com other `Result`s e `Option`s interact com other `Option`s."
+
+#: src/error/multiple_error_types.md:6
+msgid ""
+"Sometimes an `Option` needs to interact with a `Result`, or a `Result<T, "
+"Error1>` needs to interact with a `Result<T, Error2>`. In those cases, we "
+"want to manage our different error types in a way that makes them composable "
+"and easy to interact with."
+msgstr "Sometimes um `Option` needs to interact com um `Result`, ou um `Result<T, Error1>` needs to interact com um `Result<T, Error2>`. In aqueles cases, we want to manage our diferente erro tipos in um way aquele makes them composable e easy to interact com."
+
+#: src/error/multiple_error_types.md:11
+msgid ""
+"In the following code, two instances of `unwrap` generate different error "
+"types. `Vec::first` returns an `Option`, while `parse::<i32>` returns a "
+"`Result<i32, ParseIntError>`:"
+msgstr "In o following code, two instances of `unwrap` generate diferente erro tipos. `Vec::first` retorna um `Option`, while `parse::<i32>` retorna um `Result<i32, ParseIntError>`:"
+
+#: src/error/multiple_error_types.md:17
+msgid "// Generate error 1\n"
+msgstr ""
+"// Generate erro 1\n"
+
+#: src/error/multiple_error_types.md:18
+msgid "// Generate error 2\n"
+msgstr ""
+"// Generate erro 2\n"
+
+#: src/error/multiple_error_types.md:22
+#: src/error/multiple_error_types/option_result.md:16
+#: src/error/multiple_error_types/option_result.md:45
+#: src/error/multiple_error_types/define_error_type.md:60
+#: src/error/multiple_error_types/boxing_errors.md:47
+#: src/error/multiple_error_types/reenter_question_mark.md:59
+#: src/error/multiple_error_types/wrap_error.md:77 src/error/iter_result.md:40
+msgid "\"42\""
+msgstr "\"42\""
+
+#: src/error/multiple_error_types.md:22 src/error/multiple_error_types.md:24
+#: src/error/multiple_error_types/option_result.md:16
+#: src/error/multiple_error_types/option_result.md:18
+#: src/error/multiple_error_types/option_result.md:45
+#: src/error/multiple_error_types/option_result.md:47
+#: src/error/multiple_error_types/define_error_type.md:60
+#: src/error/multiple_error_types/define_error_type.md:62
+#: src/error/multiple_error_types/boxing_errors.md:47
+#: src/error/multiple_error_types/boxing_errors.md:49
+#: src/error/multiple_error_types/reenter_question_mark.md:59
+#: src/error/multiple_error_types/reenter_question_mark.md:61
+#: src/error/multiple_error_types/wrap_error.md:77
+#: src/error/multiple_error_types/wrap_error.md:79 src/error/iter_result.md:7
+#: src/error/iter_result.md:24 src/error/iter_result.md:40
+#: src/error/iter_result.md:60 src/error/iter_result.md:75
+#: src/error/iter_result.md:90
+msgid "\"93\""
+msgstr "\"93\""
+
+#: src/error/multiple_error_types.md:22 src/error/multiple_error_types.md:24
+#: src/error/multiple_error_types/option_result.md:16
+#: src/error/multiple_error_types/option_result.md:18
+#: src/error/multiple_error_types/option_result.md:45
+#: src/error/multiple_error_types/option_result.md:47
+#: src/error/multiple_error_types/define_error_type.md:60
+#: src/error/multiple_error_types/define_error_type.md:62
+#: src/error/multiple_error_types/boxing_errors.md:47
+#: src/error/multiple_error_types/boxing_errors.md:49
+#: src/error/multiple_error_types/reenter_question_mark.md:59
+#: src/error/multiple_error_types/reenter_question_mark.md:61
+#: src/error/multiple_error_types/wrap_error.md:77
+#: src/error/multiple_error_types/wrap_error.md:79 src/error/iter_result.md:7
+#: src/error/iter_result.md:24 src/error/iter_result.md:40
+#: src/error/iter_result.md:60 src/error/iter_result.md:75
+#: src/error/iter_result.md:90
+msgid "\"18\""
+msgstr "\"18\""
+
+#: src/error/multiple_error_types.md:24
+#: src/error/multiple_error_types/option_result.md:18
+#: src/error/multiple_error_types/option_result.md:47
+#: src/error/multiple_error_types/define_error_type.md:62
+#: src/error/multiple_error_types/boxing_errors.md:49
+#: src/error/multiple_error_types/reenter_question_mark.md:61
+#: src/error/multiple_error_types/wrap_error.md:79 src/error/iter_result.md:7
+#: src/error/iter_result.md:24 src/error/iter_result.md:40
+#: src/error/iter_result.md:60 src/error/iter_result.md:75
+#: src/error/iter_result.md:90
+msgid "\"tofu\""
+msgstr "\"tofu\""
+
+#: src/error/multiple_error_types.md:26 src/error/multiple_error_types.md:28
+#: src/error/multiple_error_types.md:31
+#: src/error/multiple_error_types/define_error_type.md:54
+#: src/error/multiple_error_types/boxing_errors.md:41
+#: src/error/multiple_error_types/reenter_question_mark.md:53
+#: src/error/multiple_error_types/wrap_error.md:66
+msgid "\"The first doubled is {}\""
+msgstr "\"O primeiro doubled is {}\""
+
+#: src/error/multiple_error_types.md:29
+#: src/error/multiple_error_types/option_result.md:23
+msgid "// Error 1: the input vector is empty\n"
+msgstr ""
+"// Erro 1: a entrada vector is vazio\n"
+
+#: src/error/multiple_error_types.md:32
+#: src/error/multiple_error_types/option_result.md:26
+msgid "// Error 2: the element doesn't parse to a number\n"
+msgstr ""
+"// Erro 2: o element doesn't parse to um número\n"
+
+#: src/error/multiple_error_types.md:36
+msgid ""
+"Over the next sections, we'll see several strategies for handling these kind "
+"of problems."
+msgstr "Over o próximo sections, we'll see several strategies para handling estes kind of problems."
+
+#: src/error/multiple_error_types/option_result.md:3
+msgid ""
+"The most basic way of handling mixed error types is to just embed them in "
+"each other."
+msgstr "The most basic way of handling mixed error types is to just embed them in each other."
+
+#: src/error/multiple_error_types/option_result.md:20
+#: src/error/multiple_error_types/option_result.md:22
+#: src/error/multiple_error_types/option_result.md:25
+#: src/error/multiple_error_types/option_result.md:49
+#: src/error/multiple_error_types/option_result.md:50
+#: src/error/multiple_error_types/option_result.md:51
+msgid "\"The first doubled is {:?}\""
+msgstr "\"O primeiro doubled is {:?}\""
+
+#: src/error/multiple_error_types/option_result.md:30
+msgid ""
+"There are times when we'll want to stop processing on errors (like with [`?`]"
+"(../result/enter_question_mark.md)) but keep going when the `Option` is "
+"`None`. The `transpose` function comes in handy to swap the `Result` and "
+"`Option`."
+msgstr "There are times when we'll want to stop processing on erros (like com [`?`](../result/enter_question_mark.md)) but keep going when o `Option` is `None`. O `transpose` função comes in handy to swap o `Result` e `Option`."
+
+#: src/error/multiple_error_types/define_error_type.md:3
+msgid ""
+"Sometimes it simplifies the code to mask all of the different errors with a "
+"single type of error.  We'll show this with a custom error."
+msgstr "Sometimes it simplifies o code to mask all of o diferente erros com um single tipo of erro.  We'll show este com um custom erro."
+
+#: src/error/multiple_error_types/define_error_type.md:6
+msgid ""
+"Rust allows us to define our own error types. In general, a \"good\" error "
+"type:"
+msgstr "Rust allows us to define our own erro tipos. In general, um \"good\" erro tipo:"
+
+#: src/error/multiple_error_types/define_error_type.md:8
+msgid "Represents different errors with the same type"
+msgstr "Represents diferente erros com o mesmo tipo"
+
+#: src/error/multiple_error_types/define_error_type.md:9
+msgid "Presents nice error messages to the user"
+msgstr "Presents nice erro messages to o user"
+
+#: src/error/multiple_error_types/define_error_type.md:10
+msgid "Is easy to compare with other types"
+msgstr "Is easy to compare com other tipos"
+
+#: src/error/multiple_error_types/define_error_type.md:11
+msgid "Good: `Err(EmptyVec)`"
+msgstr "Good: `Err(EmptyVec)`"
+
+#: src/error/multiple_error_types/define_error_type.md:12
+msgid ""
+"Bad: `Err(\"Please use a vector with at least one element\".to_owned())`"
+msgstr "Bad: `Err(\"Please use a vector with at least one element\".to_owned())`"
+
+#: src/error/multiple_error_types/define_error_type.md:13
+msgid "Can hold information about the error"
+msgstr "Pode hold information about o erro"
+
+#: src/error/multiple_error_types/define_error_type.md:14
+msgid "Good: `Err(BadChar(c, position))`"
+msgstr "Good: `Err(BadChar(c, position))`"
+
+#: src/error/multiple_error_types/define_error_type.md:15
+msgid "Bad: `Err(\"+ cannot be used here\".to_owned())`"
+msgstr "Bad: `Err(\"+ cannot be used here\".to_owned())`"
+
+#: src/error/multiple_error_types/define_error_type.md:16
+msgid "Composes well with other errors"
+msgstr "Composes well com other erros"
+
+#: src/error/multiple_error_types/define_error_type.md:22
+msgid ""
+"// Define our error types. These may be customized for our error handling "
+"cases.\n"
+"// Now we will be able to write our own errors, defer to an underlying "
+"error\n"
+"// implementation, or do something in between.\n"
+msgstr ""
+"// Define our erro tipos. Estes may be customized para our erro handling cases.\n"
+"// Now we vai be able to write our own erros, defer to um underlying erro\n"
+"// implementation, ou do something in between.\n"
+
+#: src/error/multiple_error_types/define_error_type.md:28
+msgid ""
+"// Generation of an error is completely separate from how it is displayed.\n"
+"// There's no need to be concerned about cluttering complex logic with the "
+"display style.\n"
+"//\n"
+"// Note that we don't store any extra info about the errors. This means we "
+"can't state\n"
+"// which string failed to parse without modifying our types to carry that "
+"information.\n"
+msgstr ""
+"// Generation of um erro is completely separate de how it is displayed.\n"
+"// There's no need to be concerned about cluttering complex logic com o display style.\n"
+"//\n"
+"// Note aquele we don't store any extra info about o erros. Este means we pode't state\n"
+"// which string failed to parse sem modifying our tipos to carry aquele information.\n"
+
+#: src/error/multiple_error_types/define_error_type.md:36
+#: src/error/multiple_error_types/boxing_errors.md:23
+#: src/error/multiple_error_types/reenter_question_mark.md:37
+msgid "\"invalid first item to double\""
+msgstr "\"inválido primeiro item to double\""
+
+#: src/error/multiple_error_types/define_error_type.md:42
+msgid "// Change the error to our new type.\n"
+msgstr ""
+"// Change o erro to our novo tipo.\n"
+
+#: src/error/multiple_error_types/define_error_type.md:46
+msgid "// Update to the new error type here also.\n"
+msgstr ""
+"// Update to o novo erro tipo here also.\n"
+
+#: src/error/multiple_error_types/boxing_errors.md:3
+msgid ""
+"A way to write simple code while preserving the original errors is to [`Box`]"
+"(https://doc.rust-lang.org/std/boxed/struct.Box.html) them.  The drawback is "
+"that the underlying error type is only known at runtime and not [statically "
+"determined](https://doc.rust-lang.org/book/ch17-02-trait-objects.html#trait-"
+"objects-perform-dynamic-dispatch)."
+msgstr "UM way to write simple code while preserving o original erros is to [`Box`](https://doc.rust-lang.org/std/boxed/struct.Box.html) them.  O drawback is aquele o underlying erro tipo is only known at runtime e not [statically determined](https://doc.rust-lang.org/book/ch17-02-trait-objects.html#trait-objects-perform-dynamic-dispatch)."
+
+#: src/error/multiple_error_types/boxing_errors.md:7
+msgid ""
+"The stdlib helps in boxing our errors by having `Box` implement conversion "
+"from any type that implements the `Error` trait into the trait object "
+"`Box<Error>`, via [`From`](https://doc.rust-lang.org/std/convert/trait.From."
+"html)."
+msgstr "O stdlib helps in boxing our erros by having `Box` implement conversion de any tipo aquele implements o `Error` trait no trait object `Box<Error>`, via [`From`](https://doc.rust-lang.org/std/convert/trait.From.html)."
+
+#: src/error/multiple_error_types/boxing_errors.md:14
+#: src/error/multiple_error_types/reenter_question_mark.md:28
+msgid "// Change the alias to use `Box<dyn error::Error>`.\n"
+msgstr ""
+"// Change o alias to use `Box<dyn error::Error>`.\n"
+
+#: src/error/multiple_error_types/boxing_errors.md:31
+#: src/error/multiple_error_types/boxing_errors.md:34
+msgid "// Converts to Box\n"
+msgstr ""
+"// Converts to Box\n"
+
+#: src/error/multiple_error_types/boxing_errors.md:59
+msgid ""
+"[Dynamic dispatch](https://doc.rust-lang.org/book/ch17-02-trait-objects."
+"html#trait-objects-perform-dynamic-dispatch) and [`Error` trait](https://doc."
+"rust-lang.org/std/error/trait.Error.html)"
+msgstr "[Dynamic dispatch](https://doc.rust-lang.org/book/ch17-02-trait-objects.html#trait-objects-perform-dynamic-dispatch) e [`Error` trait](https://doc.rust-lang.org/std/error/trait.Error.html)"
+
+#: src/error/multiple_error_types/reenter_question_mark.md:3
+msgid ""
+"Notice in the previous example that our immediate reaction to calling "
+"`parse` is to `map` the error from a library error into a boxed error:"
+msgstr "Notice in o anterior example aquele our immediate reaction to calling `parse` is to `map` o erro de um library erro em um boxed erro:"
+
+#: src/error/multiple_error_types/reenter_question_mark.md:12
+msgid ""
+"Since this is a simple and common operation, it would be convenient if it "
+"could be elided. Alas, because `and_then` is not sufficiently flexible, it "
+"cannot. However, we can instead use `?`."
+msgstr "Since this is a simple and common operation, it would be convenient if it could be elided. Alas, because `and_then` is not sufficiently flexible, it cannot. However, we can instead use `?`."
+
+#: src/error/multiple_error_types/reenter_question_mark.md:16
+msgid ""
+"`?` was previously explained as either `unwrap` or `return Err(err)`. This "
+"is only mostly true. It actually means `unwrap` or `return Err(From::"
+"from(err))`. Since `From::from` is a conversion utility between different "
+"types, this means that if you `?` where the error is convertible to the "
+"return type, it will convert automatically."
+msgstr "`?` was previously explained as either `unwrap` ou `return Err(err)`. Este is only mostly true. It actually means `unwrap` ou `return Err(From::from(err))`. Since `From::from` is um conversion utility between diferente tipos, este means aquele if you `?` where o erro is convertible to o retorna tipo, it vai convert automatically."
+
+#: src/error/multiple_error_types/reenter_question_mark.md:22
+msgid ""
+"Here, we rewrite the previous example using `?`. As a result, the `map_err` "
+"will go away when `From::from` is implemented for our error type:"
+msgstr "Here, we rewrite o anterior example usando `?`. As um resultado, o `map_err` vai go away when `From::from` is implemented para our erro tipo:"
+
+#: src/error/multiple_error_types/reenter_question_mark.md:42
+msgid ""
+"// The same structure as before but rather than chain all `Results`\n"
+"// and `Options` along, we `?` to get the inner value out immediately.\n"
+msgstr ""
+"// O mesma estrutura as before but rather than chain all `Results`\n"
+"// e `Options` along, we `?` to get o inner valor out immediately.\n"
+
+#: src/error/multiple_error_types/reenter_question_mark.md:69
+msgid ""
+"This is actually fairly clean now. Compared with the original `panic`, it is "
+"very similar to replacing the `unwrap` calls with `?` except that the return "
+"types are `Result`. As a result, they must be destructured at the top level."
+msgstr "Este is actually fairly clean now. Compared com o original `panic`, it is very similar to replacing o `unwrap` calls com `?` except aquele o retorna tipos are `Result`. As um resultado, they deve be destructured at o top level."
+
+#: src/error/multiple_error_types/reenter_question_mark.md:76
+msgid ""
+"[`From::from`](https://doc.rust-lang.org/std/convert/trait.From.html) and [`?"
+"`](https://doc.rust-lang.org/reference/expressions/operator-expr.html#the-"
+"question-mark-operator)"
+msgstr "[`From::from`](https://doc.rust-lang.org/std/convert/trait.From.html) e [`?`](https://doc.rust-lang.org/reference/expressions/operator-expr.html#the-question-mark-operator)"
+
+#: src/error/multiple_error_types/wrap_error.md:3
+msgid "An alternative to boxing errors is to wrap them in your own error type."
+msgstr "An alternative to boxing errors is to wrap them in your own error type."
+
+#: src/error/multiple_error_types/wrap_error.md:16
+msgid ""
+"// We will defer to the parse error implementation for their error.\n"
+"    // Supplying extra info requires adding more data to the type.\n"
+msgstr ""
+"// We vai defer to o parse erro implementation para their erro.\n"
+"    // Supplying extra info requires adding more data to o tipo.\n"
+
+#: src/error/multiple_error_types/wrap_error.md:25
+msgid "\"please use a vector with at least one element\""
+msgstr "\"please use um vector com at least one element\""
+
+#: src/error/multiple_error_types/wrap_error.md:26
+msgid ""
+"// The wrapped error contains additional information and is available\n"
+"            // via the source() method.\n"
+msgstr ""
+"// O wrapped erro contains additional information e is available\n"
+"            // via o source() método.\n"
+
+#: src/error/multiple_error_types/wrap_error.md:29
+msgid "\"the provided string could not be parsed as int\""
+msgstr "\"the provided string could not be parsed as int\""
+
+#: src/error/multiple_error_types/wrap_error.md:38
+msgid ""
+"// The cause is the underlying implementation error type. Is implicitly\n"
+"            // cast to the trait object `&error::Error`. This works because "
+"the\n"
+"            // underlying type already implements the `Error` trait.\n"
+msgstr ""
+"// O cause is o underlying implementation erro tipo. Is implicitly\n"
+"            // cast to o trait object `&error::Error`. Este works porque o\n"
+"            // underlying tipo already implements o `Error` trait.\n"
+
+#: src/error/multiple_error_types/wrap_error.md:45
+msgid ""
+"// Implement the conversion from `ParseIntError` to `DoubleError`.\n"
+"// This will be automatically called by `?` if a `ParseIntError`\n"
+"// needs to be converted into a `DoubleError`.\n"
+msgstr ""
+"// Implement the conversion from `ParseIntError` to `DoubleError`.\n"
+"// This will be automatically called by `?` if a `ParseIntError`\n"
+"// needs to be converted into a `DoubleError`.\n"
+
+#: src/error/multiple_error_types/wrap_error.md:57
+msgid ""
+"// Here we implicitly use the `ParseIntError` implementation of `From` "
+"(which\n"
+"    // we defined above) in order to create a `DoubleError`.\n"
+msgstr ""
+"// Here we implicitly use the `ParseIntError` implementation of `From` (which\n"
+"    // we defined above) in order to create a `DoubleError`.\n"
+
+#: src/error/multiple_error_types/wrap_error.md:70
+msgid "\"  Caused by: {}\""
+msgstr "\"  Caused by: {}\""
+
+#: src/error/multiple_error_types/wrap_error.md:87
+msgid ""
+"This adds a bit more boilerplate for handling errors and might not be needed "
+"in all applications. There are some libraries that can take care of the "
+"boilerplate for you."
+msgstr "Este adds um bit more boilerplate para handling erros e might not be needed in all applications. There are some libraries aquele pode take care of o boilerplate para you."
+
+#: src/error/multiple_error_types/wrap_error.md:93
+msgid ""
+"[`From::from`](https://doc.rust-lang.org/std/convert/trait.From.html) and "
+"[`Enums`](../../custom_types/enum.md)"
+msgstr "[`From::from`](https://doc.rust-lang.org/std/convert/trait.From.html) e [`Enums`](../../custom_types/enum.md)"
+
+#: src/error/multiple_error_types/wrap_error.md:95
+msgid ""
+"[`Crates for handling errors`](https://crates.io/keywords/error-handling)"
+msgstr "[`Crates for handling errors`](https://crates.io/keywords/error-handling)"
+
+#: src/error/iter_result.md:3
+msgid "An `Iter::map` operation might fail, for example:"
+msgstr "Um `Iter::map` operation might fail, para example:"
+
+#: src/error/iter_result.md:12 src/error/iter_result.md:29
+#: src/error/iter_result.md:65
+msgid "\"Results: {:?}\""
+msgstr "\"Resultados: {:?}\""
+
+#: src/error/iter_result.md:16
+msgid "Let's step through strategies for handling this."
+msgstr "Let's step through strategies para handling este."
+
+#: src/error/iter_result.md:18
+msgid "Ignore the failed items with `filter_map()`"
+msgstr "Ignore o failed items com `filter_map()`"
+
+#: src/error/iter_result.md:20
+msgid ""
+"`filter_map` calls a function and filters out the results that are `None`."
+msgstr "`filter_map` calls um função e filters out o resultados aquele are `None`."
+
+#: src/error/iter_result.md:33
+msgid "Collect the failed items with `map_err()` and `filter_map()`"
+msgstr "Collect o failed items com `map_err()` e `filter_map()`"
+
+#: src/error/iter_result.md:35
+msgid ""
+"`map_err` calls a function with the error, so by adding that to the previous "
+"`filter_map` solution we can save them off to the side while iterating."
+msgstr "`map_err` calls um função com o erro, so by adding aquele to o anterior `filter_map` solution we pode save them off to o side while iterating."
+
+#: src/error/iter_result.md:40
+msgid "\"999\""
+msgstr "\"999\""
+
+#: src/error/iter_result.md:47 src/error/iter_result.md:80
+#: src/error/iter_result.md:97
+msgid "\"Numbers: {:?}\""
+msgstr "\"Números: {:?}\""
+
+#: src/error/iter_result.md:48 src/error/iter_result.md:81
+#: src/error/iter_result.md:98
+msgid "\"Errors: {:?}\""
+msgstr "\"Erros: {:?}\""
+
+#: src/error/iter_result.md:52
+msgid "Fail the entire operation with `collect()`"
+msgstr "Fail o entire operation com `collect()`"
+
+#: src/error/iter_result.md:54
+msgid ""
+"`Result` implements `FromIterator` so that a vector of results "
+"(`Vec<Result<T, E>>`) can be turned into a result with a vector "
+"(`Result<Vec<T>, E>`). Once an `Result::Err` is found, the iteration will "
+"terminate."
+msgstr "`Result` implements `FromIterator` so aquele um vector of resultados (`Vec<Result<T, E>>`) pode be turned em um resultado com um vector (`Result<Vec<T>, E>`). Once um `Result::Err` is found, o iteration vai terminate."
+
+#: src/error/iter_result.md:69
+msgid "This same technique can be used with `Option`."
+msgstr "Este mesmo technique pode be usado com `Option`."
+
+#: src/error/iter_result.md:71
+msgid "Collect all valid values and failures with `partition()`"
+msgstr "Collect all válido valores e failures com `partition()`"
+
+#: src/error/iter_result.md:85
+msgid ""
+"When you look at the results, you'll note that everything is still wrapped "
+"in `Result`.  A little more boilerplate is needed for this."
+msgstr "When you look at o resultados, you'll note aquele everything is still wrapped in `Result`.  UM little more boilerplate is needed para este."
+
+#: src/std.md:3
+msgid ""
+"The `std` library provides many custom types which expands drastically on "
+"the `primitives`. Some of these include:"
+msgstr "O `std` library provides many custom tipos which expands drastically on o `primitives`. Some of estes include:"
+
+#: src/std.md:6
+msgid "growable `String`s like: `\"hello world\"`"
+msgstr "growable `String`s like: `\"hello world\"`"
+
+#: src/std.md:7
+msgid "growable vectors: `[1, 2, 3]`"
+msgstr "growable vectors: `[1, 2, 3]`"
+
+#: src/std.md:8
+msgid "optional types: `Option<i32>`"
+msgstr "optional tipos: `Option<i32>`"
+
+#: src/std.md:9
+msgid "error handling types: `Result<i32, i32>`"
+msgstr "erro handling tipos: `Result<i32, i32>`"
+
+#: src/std.md:10
+msgid "heap allocated pointers: `Box<i32>`"
+msgstr "heap allocated pointers: `Box<i32>`"
+
+#: src/std.md:14 src/std_misc.md:14
+msgid ""
+"[primitives](primitives.md) and [the std library](https://doc.rust-lang.org/"
+"std/)"
+msgstr "[primitives](primitives.md) e [the std library](https://doc.rust-lang.org/std/)"
+
+#: src/std/box.md:3
+msgid ""
+"All values in Rust are stack allocated by default. Values can be _boxed_ "
+"(allocated on the heap) by creating a `Box<T>`. A box is a smart pointer to "
+"a heap allocated value of type `T`. When a box goes out of scope, its "
+"destructor is called, the inner object is destroyed, and the memory on the "
+"heap is freed."
+msgstr "All values in Rust are stack allocated by default. Values can be _boxed_ (allocated on the heap) by creating a `Box<T>`. A box is a smart pointer to a heap allocated value of type `T`. When a box goes out of scope, its destructor is called, the inner object is destroyed, and the memory on the heap is freed."
+
+#: src/std/box.md:8
+msgid ""
+"Boxed values can be dereferenced using the `*` operator; this removes one "
+"layer of indirection."
+msgstr "Boxed valores pode be dereferenced usando o `*` operator; este removes one layer of indirection."
+
+#: src/std/box.md:20
+msgid ""
+"// A Rectangle can be specified by where its top left and bottom right \n"
+"// corners are in space\n"
+msgstr ""
+"// A Rectangle can be specified by where its top left and bottom right \n"
+"// corners are in space\n"
+
+#: src/std/box.md:34
+msgid "// Allocate this point on the heap, and return a pointer to it\n"
+msgstr ""
+"// Allocate este point on o heap, e retorna um pointer to it\n"
+
+#: src/std/box.md:39
+msgid ""
+"// (all the type annotations are superfluous)\n"
+"    // Stack allocated variables\n"
+msgstr ""
+"// (all o tipo annotations are superfluous)\n"
+"    // Stack allocated variáveis\n"
+
+#: src/std/box.md:47
+msgid "// Heap allocated rectangle\n"
+msgstr ""
+"// Heap allocated rectangle\n"
+
+#: src/std/box.md:53
+msgid "// The output of functions can be boxed\n"
+msgstr ""
+"// O saída of funções pode be boxed\n"
+
+#: src/std/box.md:56
+msgid "// Double indirection\n"
+msgstr ""
+"// Double indirection\n"
+
+#: src/std/box.md:59
+msgid "\"Point occupies {} bytes on the stack\""
+msgstr "\"Point occupies {} bytes on o stack\""
+
+#: src/std/box.md:61
+msgid "\"Rectangle occupies {} bytes on the stack\""
+msgstr "\"Rectangle occupies {} bytes on o stack\""
+
+#: src/std/box.md:64
+msgid "// box size == pointer size\n"
+msgstr ""
+"// box size == pointer size\n"
+
+#: src/std/box.md:65
+msgid "\"Boxed point occupies {} bytes on the stack\""
+msgstr "\"Boxed point occupies {} bytes on o stack\""
+
+#: src/std/box.md:67
+msgid "\"Boxed rectangle occupies {} bytes on the stack\""
+msgstr "\"Boxed rectangle occupies {} bytes on o stack\""
+
+#: src/std/box.md:69
+msgid "\"Boxed box occupies {} bytes on the stack\""
+msgstr "\"Boxed box occupies {} bytes on o stack\""
+
+#: src/std/box.md:72
+msgid "// Copy the data contained in `boxed_point` into `unboxed_point`\n"
+msgstr ""
+"// Copy o data contained in `boxed_point` em `unboxed_point`\n"
+
+#: src/std/box.md:74
+msgid "\"Unboxed point occupies {} bytes on the stack\""
+msgstr "\"Unboxed point occupies {} bytes on o stack\""
+
+#: src/std/vec.md:3
+msgid ""
+"Vectors are re-sizable arrays. Like slices, their size is not known at "
+"compile time, but they can grow or shrink at any time. A vector is "
+"represented using 3 parameters:"
+msgstr "Vectors are re-sizable arrays. Like slices, their size is not known at compile time, but they can grow or shrink at any time. A vector is represented using 3 parameters:"
+
+#: src/std/vec.md:7
+msgid "pointer to the data"
+msgstr "pointer to o data"
+
+#: src/std/vec.md:8
+msgid "length"
+msgstr "length"
+
+#: src/std/vec.md:9
+msgid "capacity"
+msgstr "capacity"
+
+#: src/std/vec.md:11
+msgid ""
+"The capacity indicates how much memory is reserved for the vector. The "
+"vector can grow as long as the length is smaller than the capacity. When "
+"this threshold needs to be surpassed, the vector is reallocated with a "
+"larger capacity."
+msgstr "O capacity indicates how much memory is reserved para o vector. O vector pode grow as long as o length is smaller than o capacity. When este threshold needs to be surpassed, o vector is reallocated com um larger capacity."
+
+#: src/std/vec.md:17
+msgid "// Iterators can be collected into vectors\n"
+msgstr ""
+"// Iterators pode be collected em vectors\n"
+
+#: src/std/vec.md:19
+msgid "\"Collected (0..10) into: {:?}\""
+msgstr "\"Collected (0..10) em: {:?}\""
+
+#: src/std/vec.md:21
+msgid "// The `vec!` macro can be used to initialize a vector\n"
+msgstr ""
+"// O `vec!` macro pode be usado to initialize um vector\n"
+
+#: src/std/vec.md:23
+msgid "\"Initial vector: {:?}\""
+msgstr "\"Initial vector: {:?}\""
+
+#: src/std/vec.md:25
+msgid "// Insert new element at the end of the vector\n"
+msgstr ""
+"// Insert novo element at o end of o vector\n"
+
+#: src/std/vec.md:26
+msgid "\"Push 4 into the vector\""
+msgstr "\"Push 4 no vector\""
+
+#: src/std/vec.md:28
+msgid "\"Vector: {:?}\""
+msgstr "\"Vector: {:?}\""
+
+#: src/std/vec.md:30
+msgid "// Error! Immutable vectors can't grow\n"
+msgstr ""
+"// Erro! Imutável vectors pode't grow\n"
+
+#: src/std/vec.md:34
+msgid ""
+"// The `len` method yields the number of elements currently stored in a "
+"vector\n"
+msgstr ""
+"// O `len` método yields o número of elements currently stored in um vector\n"
+
+#: src/std/vec.md:35
+msgid "\"Vector length: {}\""
+msgstr "\"Vector length: {}\""
+
+#: src/std/vec.md:37
+msgid "// Indexing is done using the square brackets (indexing starts at 0)\n"
+msgstr ""
+"// Indexing is done usando o square brackets (indexing starts at 0)\n"
+
+#: src/std/vec.md:38
+msgid "\"Second element: {}\""
+msgstr "\"Segundo element: {}\""
+
+#: src/std/vec.md:40
+msgid "// `pop` removes the last element from the vector and returns it\n"
+msgstr ""
+"// `pop` removes o último element do vector e retorna it\n"
+
+#: src/std/vec.md:41
+msgid "\"Pop last element: {:?}\""
+msgstr "\"Pop último element: {:?}\""
+
+#: src/std/vec.md:43
+msgid "// Out of bounds indexing yields a panic\n"
+msgstr ""
+"// Out of bounds indexing yields um panic\n"
+
+#: src/std/vec.md:44
+msgid "\"Fourth element: {}\""
+msgstr "\"Fourth element: {}\""
+
+#: src/std/vec.md:47
+msgid "// `Vector`s can be easily iterated over\n"
+msgstr ""
+"// `Vector`s pode be easily iterated over\n"
+
+#: src/std/vec.md:48
+msgid "\"Contents of xs:\""
+msgstr "\"Contents of xs:\""
+
+#: src/std/vec.md:53
+msgid ""
+"// A `Vector` can also be iterated over while the iteration\n"
+"    // count is enumerated in a separate variable (`i`)\n"
+msgstr ""
+"// UM `Vector` pode also be iterated over while o iteration\n"
+"    // count is enumerated in um separate variável (`i`)\n"
+
+#: src/std/vec.md:56
+msgid "\"In position {} we have value {}\""
+msgstr "\"In position {} we have valor {}\""
+
+#: src/std/vec.md:59
+msgid ""
+"// Thanks to `iter_mut`, mutable `Vector`s can also be iterated\n"
+"    // over in a way that allows modifying each value\n"
+msgstr ""
+"// Thanks to `iter_mut`, mutável `Vector`s pode also be iterated\n"
+"    // over in um way aquele allows modifying each valor\n"
+
+#: src/std/vec.md:64
+msgid "\"Updated vector: {:?}\""
+msgstr "\"Updated vector: {:?}\""
+
+#: src/std/vec.md:68
+msgid ""
+"More `Vec` methods can be found under the [std::vec](https://doc.rust-lang."
+"org/std/vec/) module"
+msgstr "More `Vec` métodos pode be found under o [std::vec](https://doc.rust-lang.org/std/vec/) módulo"
+
+#: src/std/str.md:3
+msgid "The two most used string types in Rust are `String` and `&str`."
+msgstr "O two most usado string tipos in Rust are `String` e `&str`."
+
+#: src/std/str.md:5
+msgid ""
+"A `String` is stored as a vector of bytes (`Vec<u8>`), but guaranteed to "
+"always be a valid UTF-8 sequence. `String` is heap allocated, growable and "
+"not null terminated."
+msgstr "UM `String` is stored as um vector of bytes (`Vec<u8>`), but guaranteed to always be um válido UTF-8 sequence. `String` is heap allocated, growable e not null terminated."
+
+#: src/std/str.md:9
+msgid ""
+"`&str` is a slice (`&[u8]`) that always points to a valid UTF-8 sequence, "
+"and can be used to view into a `String`, just like `&[T]` is a view into "
+"`Vec<T>`."
+msgstr "`&str` is um slice (`&[u8]`) aquele always points to um válido UTF-8 sequence, e pode be usado to view em um `String`, just like `&[T]` is um view em `Vec<T>`."
+
+#: src/std/str.md:14
+msgid ""
+"// (all the type annotations are superfluous)\n"
+"    // A reference to a string allocated in read only memory\n"
+msgstr ""
+"// (all o tipo annotations are superfluous)\n"
+"    // UM reference to um string allocated in read only memory\n"
+
+#: src/std/str.md:16
+msgid "\"the quick brown fox jumps over the lazy dog\""
+msgstr "\"o quick brown fox jumps over o lazy dog\""
+
+#: src/std/str.md:17
+msgid "\"Pangram: {}\""
+msgstr "\"Pangram: {}\""
+
+#: src/std/str.md:19
+msgid "// Iterate over words in reverse, no new string is allocated\n"
+msgstr ""
+"// Iterate over words in reverse, no novo string is allocated\n"
+
+#: src/std/str.md:20
+msgid "\"Words in reverse\""
+msgstr "\"Words in reverse\""
+
+#: src/std/str.md:25
+msgid "// Copy chars into a vector, sort and remove duplicates\n"
+msgstr ""
+"// Copy chars em um vector, sort e remove duplicates\n"
+
+#: src/std/str.md:30
+msgid "// Create an empty and growable `String`\n"
+msgstr ""
+"// Cria um vazio e growable `String`\n"
+
+#: src/std/str.md:33
+msgid "// Insert a char at the end of string\n"
+msgstr ""
+"// Insert um char at o end of string\n"
+
+#: src/std/str.md:35
+msgid "// Insert a string at the end of string\n"
+msgstr ""
+"// Insert um string at o end of string\n"
+
+#: src/std/str.md:39
+msgid ""
+"// The trimmed string is a slice to the original string, hence no new\n"
+"    // allocation is performed\n"
+msgstr ""
+"// O trimmed string is um slice to o original string, hence no novo\n"
+"    // allocation is performed\n"
+
+#: src/std/str.md:43
+msgid "\"Used characters: {}\""
+msgstr "\"Usad characters: {}\""
+
+#: src/std/str.md:45
+msgid "// Heap allocate a string\n"
+msgstr ""
+"// Heap allocate um string\n"
+
+#: src/std/str.md:46
+msgid "\"I like dogs\""
+msgstr "\"I like dogs\""
+
+#: src/std/str.md:47
+msgid "// Allocate new memory and store the modified string there\n"
+msgstr ""
+"// Allocate novo memory e store o modified string there\n"
+
+#: src/std/str.md:48
+msgid "\"dog\""
+msgstr "\"dog\""
+
+#: src/std/str.md:48
+msgid "\"cat\""
+msgstr "\"cat\""
+
+#: src/std/str.md:50
+msgid "\"Alice says: {}\""
+msgstr "\"Alice says: {}\""
+
+#: src/std/str.md:51
+msgid "\"Bob says: {}\""
+msgstr "\"Bob says: {}\""
+
+#: src/std/str.md:55
+msgid ""
+"More `str`/`String` methods can be found under the [std::str](https://doc."
+"rust-lang.org/std/str/) and [std::string](https://doc.rust-lang.org/std/"
+"string/) modules"
+msgstr "More `str`/`String` métodos pode be found under o [std::str](https://doc.rust-lang.org/std/str/) e [std::string](https://doc.rust-lang.org/std/string/) módulos"
+
+#: src/std/str.md:60
+msgid "Literals and escapes"
+msgstr "Literals e escapes"
+
+#: src/std/str.md:62
+msgid ""
+"There are multiple ways to write string literals with special characters in "
+"them. All result in a similar `&str` so it's best to use the form that is "
+"the most convenient to write. Similarly there are multiple ways to write "
+"byte string literals, which all result in `&[u8; N]`."
+msgstr "There are multiple ways to write string literals com special characters in them. All resultado in um similar `&str` so it's best to use o form aquele is o most convenient to write. Similarly there are multiple ways to write byte string literals, which all resultado in `&[u8; N]`."
+
+#: src/std/str.md:67
+msgid ""
+"Generally special characters are escaped with a backslash character: `\\`. "
+"This way you can add any character to your string, even unprintable ones and "
+"ones that you don't know how to type. If you want a literal backslash, "
+"escape it with another one: `\\\\`"
+msgstr "Generally special characters are escaped com um backslash character: `\\`. Este way you pode add any character to your string, even unprintable ones e ones aquele you don't know how to tipo. If you want um literal backslash, escape it com another one: `\\\\`"
+
+#: src/std/str.md:72
+msgid ""
+"String or character literal delimiters occurring within a literal must be "
+"escaped: `\"\\\"\"`, `'\\''`."
+msgstr "String ou character literal delimiters occurring within um literal deve be escaped: `\"\\\"\"`, `'\\''`."
+
+#: src/std/str.md:76
+msgid "// You can use escapes to write bytes by their hexadecimal values...\n"
+msgstr ""
+"// You pode use escapes to write bytes by their hexadecimal valores...\n"
+
+#: src/std/str.md:77
+msgid "\"I'm writing \\x52\\x75\\x73\\x74!\""
+msgstr "\"I'm writing \\x52\\x75\\x73\\x74!\""
+
+#: src/std/str.md:78
+msgid "\"What are you doing\\x3F (\\\\x3F means ?) {}\""
+msgstr "\"What are you doing\\x3F (\\\\x3F means ?) {}\""
+
+#: src/std/str.md:80
+msgid "// ...or Unicode code points.\n"
+msgstr ""
+"// ...ou Unicode code points.\n"
+
+#: src/std/str.md:81
+msgid "\"\\u{211D}\""
+msgstr "\"\\u{211D}\""
+
+#: src/std/str.md:82
+msgid "\"\\\"DOUBLE-STRUCK CAPITAL R\\\"\""
+msgstr "\"\\\"DOUBLE-STRUCK CAPITAL R\\\"\""
+
+#: src/std/str.md:84
+msgid "\"Unicode character {} (U+211D) is called {}\""
+msgstr "\"Unicode character {} (U+211D) is chamado {}\""
+
+#: src/std/str.md:88
+msgid ""
+"\"String literals\n"
+"                        can span multiple lines.\n"
+"                        The linebreak and indentation here ->\\\n"
+"                        <- can be escaped too!\""
+msgstr ""
+"\"String literals\n"
+"                        pode span multiple lines.\n"
+"                        O linebreak e indentation here ->\\\n"
+"                        <- pode be escaped too!\""
+
+#: src/std/str.md:96
+msgid ""
+"Sometimes there are just too many characters that need to be escaped or it's "
+"just much more convenient to write a string out as-is. This is where raw "
+"string literals come into play."
+msgstr "Sometimes there are just too many characters that need to be escaped or it's just much more convenient to write a string out as-is. This is where raw string literals come into play."
+
+#: src/std/str.md:101
+msgid "r\"Escapes don't work here: \\x3F \\u{211D}\""
+msgstr "r\"Escapes don't work here: \\x3F \\u{211D}\""
+
+#: src/std/str.md:104
+msgid "// If you need quotes in a raw string, add a pair of #s\n"
+msgstr ""
+"// If you need quotes in um raw string, add um pair of #s\n"
+
+#: src/std/str.md:105
+msgid "r#\"And then I said: \"There is no escape!\"\"#"
+msgstr "r#\"E then I said: \"There is no escape!\"\"#"
+
+#: src/std/str.md:108
+msgid ""
+"// If you need \"# in your string, just use more #s in the delimiter.\n"
+"    // You can use up to 255 #s.\n"
+msgstr ""
+"// If you need \"# in your string, just use more #s in the delimiter.\n"
+"    // You can use up to 255 #s.\n"
+
+#: src/std/str.md:110
+msgid "r###\"A string with \"# in it. And even \"##!\"###"
+msgstr "r###\"UM string com \"# in it. E even \"##!\"###"
+
+#: src/std/str.md:115
+msgid ""
+"Want a string that's not UTF-8? (Remember, `str` and `String` must be valid "
+"UTF-8). Or maybe you want an array of bytes that's mostly text? Byte strings "
+"to the rescue!"
+msgstr "Want um string aquele's not UTF-8? (Remember, `str` e `String` deve be válido UTF-8). Ou maybe you want um array of bytes aquele's mostly text? Byte strings to o rescue!"
+
+#: src/std/str.md:122
+msgid "// Note that this is not actually a `&str`\n"
+msgstr ""
+"// Note aquele este is not actually um `&str`\n"
+
+#: src/std/str.md:123
+msgid "b\"this is a byte string\""
+msgstr "b\"este is um byte string\""
+
+#: src/std/str.md:125
+msgid ""
+"// Byte arrays don't have the `Display` trait, so printing them is a bit "
+"limited\n"
+msgstr ""
+"// Byte arrays don't have o `Display` trait, so printing them is um bit limited\n"
+
+#: src/std/str.md:126
+msgid "\"A byte string: {:?}\""
+msgstr "\"UM byte string: {:?}\""
+
+#: src/std/str.md:128
+msgid "// Byte strings can have byte escapes...\n"
+msgstr ""
+"// Byte strings pode have byte escapes...\n"
+
+#: src/std/str.md:129
+msgid "b\"\\x52\\x75\\x73\\x74 as bytes\""
+msgstr "b\"\\x52\\x75\\x73\\x74 as bytes\""
+
+#: src/std/str.md:130
+msgid ""
+"// ...but no unicode escapes\n"
+"    // let escaped = b\"\\u{211D} is not allowed\";\n"
+msgstr ""
+"// ...but no unicode escapes\n"
+"    // let escaped = b\"\\u{211D} is not allowed\";\n"
+
+#: src/std/str.md:132
+msgid "\"Some escaped bytes: {:?}\""
+msgstr "\"Some escaped bytes: {:?}\""
+
+#: src/std/str.md:135
+msgid "// Raw byte strings work just like raw strings\n"
+msgstr ""
+"// Raw byte strings work just like raw strings\n"
+
+#: src/std/str.md:136
+msgid "br\"\\u{211D} is not escaped here\""
+msgstr "br\"\\u{211D} is not escaped here\""
+
+#: src/std/str.md:139
+msgid "// Converting a byte array to `str` can fail\n"
+msgstr ""
+"// Converting um byte array to `str` pode fail\n"
+
+#: src/std/str.md:141
+msgid "\"And the same as text: '{}'\""
+msgstr "\"E o mesmo as text: '{}'\""
+
+#: src/std/str.md:144
+msgid ""
+"br#\"You can also use \"fancier\" formatting, \\\n"
+"                    like with normal raw strings\"#"
+msgstr ""
+"br#\"You pode also use \"fancier\" formatting, \\\n"
+"                    like com normal raw strings\"#"
+
+#: src/std/str.md:147
+msgid "// Byte strings don't have to be UTF-8\n"
+msgstr ""
+"// Byte strings don't have to be UTF-8\n"
+
+#: src/std/str.md:148
+msgid "b\"\\x82\\xe6\\x82\\xa8\\x82\\xb1\\x82\\xbb\""
+msgstr "b\"\\x82\\xe6\\x82\\xa8\\x82\\xb1\\x82\\xbb\""
+
+#: src/std/str.md:148
+msgid "// \"ようこそ\" in SHIFT-JIS\n"
+msgstr ""
+"// \"ようこそ\" in SHIFT-JIS\n"
+
+#: src/std/str.md:150
+msgid "// But then they can't always be converted to `str`\n"
+msgstr ""
+"// But then they pode't always be converted to `str`\n"
+
+#: src/std/str.md:152
+msgid "\"Conversion successful: '{}'\""
+msgstr "\"Conversion successful: '{}'\""
+
+#: src/std/str.md:153
+msgid "\"Conversion failed: {:?}\""
+msgstr "\"Conversion failed: {:?}\""
+
+#: src/std/str.md:158
+msgid ""
+"For conversions between character encodings check out the [encoding](https://"
+"crates.io/crates/encoding) crate."
+msgstr "Para conversions between character encodings check out o [encoding](https://crates.io/crates/encoding) crate."
+
+#: src/std/str.md:160
+msgid ""
+"A more detailed listing of the ways to write string literals and escape "
+"characters is given in the ['Tokens' chapter](https://doc.rust-lang.org/"
+"reference/tokens.html) of the Rust Reference."
+msgstr "UM more detailed listing of o ways to write string literals e escape characters is given in o ['Tokens' chapter](https://doc.rust-lang.org/reference/tokens.html) of o Rust Reference."
+
+#: src/std/option.md:3
+msgid ""
+"Sometimes it's desirable to catch the failure of some parts of a program "
+"instead of calling `panic!`; this can be accomplished using the `Option` "
+"enum."
+msgstr "Sometimes it's desirable to catch o failure of some parts of um program instead of calling `panic!`; este pode be accomplished usando o `Option` enum."
+
+#: src/std/option.md:6
+msgid "The `Option<T>` enum has two variants:"
+msgstr "O `Option<T>` enum has two variants:"
+
+#: src/std/option.md:8
+msgid "`None`, to indicate failure or lack of value, and"
+msgstr "`None`, to indicate failure ou lack of valor, e"
+
+#: src/std/option.md:9
+msgid "`Some(value)`, a tuple struct that wraps a `value` with type `T`."
+msgstr "`Some(value)`, um tuple struct aquele wraps um `value` com tipo `T`."
+
+#: src/std/option.md:12
+msgid "// An integer division that doesn't `panic!`\n"
+msgstr ""
+"// Um inteiro division aquele doesn't `panic!`\n"
+
+#: src/std/option.md:15
+msgid "// Failure is represented as the `None` variant\n"
+msgstr ""
+"// Failure is represented as o `None` variant\n"
+
+#: src/std/option.md:18
+msgid "// Result is wrapped in a `Some` variant\n"
+msgstr ""
+"// Result is wrapped in um `Some` variant\n"
+
+#: src/std/option.md:22
+msgid "// This function handles a division that may not succeed\n"
+msgstr ""
+"// Este função handles um division aquele may not succeed\n"
+
+#: src/std/option.md:25
+msgid "// `Option` values can be pattern matched, just like other enums\n"
+msgstr ""
+"// `Option` valores pode be pattern matched, just like other enums\n"
+
+#: src/std/option.md:27
+msgid "\"{} / {} failed!\""
+msgstr "\"{} / {} failed!\""
+
+#: src/std/option.md:29
+msgid "\"{} / {} = {}\""
+msgstr "\"{} / {} = {}\""
+
+#: src/std/option.md:38
+msgid "// Binding `None` to a variable needs to be type annotated\n"
+msgstr ""
+"// Binding `None` to uma variável needs to be tipo annotated\n"
+
+#: src/std/option.md:44
+msgid "// Unwrapping a `Some` variant will extract the value wrapped.\n"
+msgstr ""
+"// Unwrapping um `Some` variant vai extract o valor wrapped.\n"
+
+#: src/std/option.md:45 src/std/option.md:48
+msgid "\"{:?} unwraps to {:?}\""
+msgstr "\"{:?} unwraps to {:?}\""
+
+#: src/std/option.md:47
+msgid "// Unwrapping a `None` variant will `panic!`\n"
+msgstr ""
+"// Unwrapping um `None` variant vai `panic!`\n"
+
+#: src/std/result.md:3
+msgid ""
+"We've seen that the `Option` enum can be used as a return value from "
+"functions that may fail, where `None` can be returned to indicate failure. "
+"However, sometimes it is important to express _why_ an operation failed. To "
+"do this we have the `Result` enum."
+msgstr "We've seen aquele o `Option` enum pode be usado as um retorna valor de funções aquele may fail, where `None` pode be retornado to indicate failure. However, sometimes it is important to express _why_ um operation failed. To do este we have o `Result` enum."
+
+#: src/std/result.md:8
+msgid "The `Result<T, E>` enum has two variants:"
+msgstr "O `Result<T, E>` enum has two variants:"
+
+#: src/std/result.md:10
+msgid ""
+"`Ok(value)` which indicates that the operation succeeded, and wraps the "
+"`value` returned by the operation. (`value` has type `T`)"
+msgstr "`Ok(value)` which indicates aquele o operation succeeded, e wraps o `value` retornado by o operation. (`value` has tipo `T`)"
+
+#: src/std/result.md:12
+msgid ""
+"`Err(why)`, which indicates that the operation failed, and wraps `why`, "
+"which (hopefully) explains the cause of the failure. (`why` has type `E`)"
+msgstr "`Err(why)`, which indicates aquele o operation failed, e wraps `why`, which (hopefully) explains o cause of o failure. (`why` has tipo `E`)"
+
+#: src/std/result.md:17
+msgid "// Mathematical \"errors\" we want to catch\n"
+msgstr ""
+"// Mathematical \"erros\" we want to catch\n"
+
+#: src/std/result.md:29
+msgid ""
+"// This operation would `fail`, instead let's return the reason of\n"
+"            // the failure wrapped in `Err`\n"
+msgstr ""
+"// Este operation would `fail`, instead let's retorna o reason of\n"
+"            // o failure wrapped in `Err`\n"
+
+#: src/std/result.md:33
+msgid "// This operation is valid, return the result wrapped in `Ok`\n"
+msgstr ""
+"// Este operation is válido, retorna o resultado wrapped in `Ok`\n"
+
+#: src/std/result.md:54
+msgid "// `op(x, y)` === `sqrt(ln(x / y))`\n"
+msgstr ""
+"// `op(x, y)` === `sqrt(ln(x / y))`\n"
+
+#: src/std/result.md:57
+msgid "// This is a three level match pyramid!\n"
+msgstr ""
+"// Este is um three level match pyramid!\n"
+
+#: src/std/result.md:71
+msgid "// Will this fail?\n"
+msgstr ""
+"// Vai este fail?\n"
+
+#: src/std/result/question_mark.md:3
+msgid ""
+"Chaining results using match can get pretty untidy; luckily, the `?` "
+"operator can be used to make things pretty again. `?` is used at the end of "
+"an expression returning a `Result`, and is equivalent to a match expression, "
+"where the `Err(err)` branch expands to an early `return Err(From::"
+"from(err))`, and the `Ok(ok)` branch expands to an `ok` expression."
+msgstr "Chaining resultados usando match pode get pretty untidy; luckily, o `?` operator pode be usado to make things pretty again. `?` is usado at o end of um expression returning um `Result`, e is equivalent to um match expression, where o `Err(err)` branch expands to um early `return Err(From::from(err))`, e o `Ok(ok)` branch expands to um `ok` expression."
+
+#: src/std/result/question_mark.md:44
+msgid "// Intermediate function\n"
+msgstr ""
+"// Intermediate função\n"
+
+#: src/std/result/question_mark.md:46
+msgid "// if `div` \"fails\", then `DivisionByZero` will be `return`ed\n"
+msgstr ""
+"// if `div` \"fails\", then `DivisionByZero` vai be `return`ed\n"
+
+#: src/std/result/question_mark.md:49
+msgid "// if `ln` \"fails\", then `NonPositiveLogarithm` will be `return`ed\n"
+msgstr ""
+"// if `ln` \"fails\", then `NonPositiveLogarithm` vai be `return`ed\n"
+
+#: src/std/result/question_mark.md:59
+msgid "\"logarithm of non-positive number\""
+msgstr "\"logarithm of non-positive número\""
+
+#: src/std/result/question_mark.md:61 src/std/panic.md:15
+msgid "\"division by zero\""
+msgstr "\"division by zero\""
+
+#: src/std/result/question_mark.md:63
+msgid "\"square root of negative number\""
+msgstr "\"square root of negative número\""
+
+#: src/std/result/question_mark.md:75
+msgid ""
+"Be sure to check the [documentation](https://doc.rust-lang.org/std/result/"
+"index.html), as there are many methods to map/compose `Result`."
+msgstr "Be sure to check the [documentation](https://doc.rust-lang.org/std/result/index.html), as there are many methods to map/compose `Result`."
+
+#: src/std/panic.md:3
+msgid ""
+"The `panic!` macro can be used to generate a panic and start unwinding its "
+"stack. While unwinding, the runtime will take care of freeing all the "
+"resources _owned_ by the thread by calling the destructor of all its objects."
+msgstr "O `panic!` macro pode be usado to generate um panic e start unwinding its stack. While unwinding, o runtime vai take care of freeing all o resources _owned_ by o thread by calling o destructor of all its objects."
+
+#: src/std/panic.md:7
+msgid ""
+"Since we are dealing with programs with only one thread, `panic!` will cause "
+"the program to report the panic message and exit."
+msgstr "Since we are dealing com programs com only one thread, `panic!` vai cause o program to report o panic message e exit."
+
+#: src/std/panic.md:11
+msgid "// Re-implementation of integer division (/)\n"
+msgstr ""
+"// Re-implementation of inteiro division (/)\n"
+
+#: src/std/panic.md:14
+msgid "// Division by zero triggers a panic\n"
+msgstr ""
+"// Division by zero triggers um panic\n"
+
+#: src/std/panic.md:20
+msgid "// The `main` task\n"
+msgstr ""
+"// O `main` task\n"
+
+#: src/std/panic.md:23
+msgid "// Heap allocated integer\n"
+msgstr ""
+"// Heap allocated inteiro\n"
+
+#: src/std/panic.md:26
+msgid "// This operation will trigger a task failure\n"
+msgstr ""
+"// Este operation vai trigger um task failure\n"
+
+#: src/std/panic.md:29
+msgid "\"This point won't be reached!\""
+msgstr "\"Este point won't be reached!\""
+
+#: src/std/panic.md:31
+msgid "// `_x` should get destroyed at this point\n"
+msgstr ""
+"// `_x` deve get destroyed at este point\n"
+
+#: src/std/panic.md:35
+msgid "Let's check that `panic!` doesn't leak memory."
+msgstr "Let's check aquele `panic!` doesn't leak memory."
+
+#: src/std/hash.md:3
+msgid ""
+"Where vectors store values by an integer index, `HashMap`s store values by "
+"key. `HashMap` keys can be booleans, integers, strings, or any other type "
+"that implements the `Eq` and `Hash` traits. More on this in the next section."
+msgstr "Where vectors store valores by um inteiro index, `HashMap`s store valores by key. `HashMap` keys pode be booleans, inteiros, strings, ou any other tipo aquele implements o `Eq` e `Hash` traits. More on este in o próximo section."
+
+#: src/std/hash.md:8
+msgid ""
+"Like vectors, `HashMap`s are growable, but HashMaps can also shrink "
+"themselves when they have excess space. You can create a HashMap with a "
+"certain starting capacity using `HashMap::with_capacity(uint)`, or use "
+"`HashMap::new()` to get a HashMap with a default initial capacity "
+"(recommended)."
+msgstr "Like vectors, `HashMap`s are growable, but HashMaps pode also shrink themselves when they have excess space. You pode create um HashMap com um certain starting capacity usando `HashMap::with_capacity(uint)`, ou use `HashMap::new()` to get um HashMap com um default initial capacity (recommended)."
+
+#: src/std/hash.md:19 src/std/hash.md:30
+msgid "\"798-1364\""
+msgstr "\"798-1364\""
+
+#: src/std/hash.md:19
+msgid ""
+"\"We're sorry, the call cannot be completed as dialed. \n"
+"            Please hang up and try again.\""
+msgstr ""
+"\"We're sorry, o call não pode be completed as dialed. \n"
+"            Please hang up e try again.\""
+
+#: src/std/hash.md:21 src/std/hash.md:31
+msgid "\"645-7689\""
+msgstr "\"645-7689\""
+
+#: src/std/hash.md:21
+msgid ""
+"\"Hello, this is Mr. Awesome's Pizza. My name is Fred.\n"
+"            What can I get for you today?\""
+msgstr ""
+"\"Hello, este is Mr. Awesome's Pizza. My name is Fred.\n"
+"            What pode I get para you today?\""
+
+#: src/std/hash.md:23
+msgid "\"Hi! Who is this again?\""
+msgstr "\"Hi! Who is este again?\""
+
+#: src/std/hash.md:30 src/std/hash.md:36 src/std/hash.md:43
+msgid "\"Daniel\""
+msgstr "\"Daniel\""
+
+#: src/std/hash.md:31 src/std/hash.md:45 src/std/hash.md:50
+msgid "\"Ashley\""
+msgstr "\"Ashley\""
+
+#: src/std/hash.md:32
+msgid "\"Katie\""
+msgstr "\"Katie\""
+
+#: src/std/hash.md:32
+msgid "\"435-8291\""
+msgstr "\"435-8291\""
+
+#: src/std/hash.md:33
+msgid "\"Robert\""
+msgstr "\"Robert\""
+
+#: src/std/hash.md:33
+msgid "\"956-1745\""
+msgstr "\"956-1745\""
+
+#: src/std/hash.md:35
+msgid "// Takes a reference and returns Option<&V>\n"
+msgstr ""
+"// Takes um reference e retorna Option<&V>\n"
+
+#: src/std/hash.md:37
+msgid "\"Calling Daniel: {}\""
+msgstr "\"Chamaing Daniel: {}\""
+
+#: src/std/hash.md:38
+msgid "\"Don't have Daniel's number.\""
+msgstr "\"Don't have Daniel's número.\""
+
+#: src/std/hash.md:41
+msgid ""
+"// `HashMap::insert()` returns `None`\n"
+"    // if the inserted value is new, `Some(value)` otherwise\n"
+msgstr ""
+"// `HashMap::insert()` retorna `None`\n"
+"    // if o inserted valor is novo, `Some(value)` otherwise\n"
+
+#: src/std/hash.md:43
+msgid "\"164-6743\""
+msgstr "\"164-6743\""
+
+#: src/std/hash.md:46
+msgid "\"Calling Ashley: {}\""
+msgstr "\"Chamaing Ashley: {}\""
+
+#: src/std/hash.md:47
+msgid "\"Don't have Ashley's number.\""
+msgstr "\"Don't have Ashley's número.\""
+
+#: src/std/hash.md:52
+msgid ""
+"// `HashMap::iter()` returns an iterator that yields \n"
+"    // (&'a key, &'a value) pairs in arbitrary order.\n"
+msgstr ""
+"// `HashMap::iter()` retorna um iterator aquele yields \n"
+"    // (&'um key, &'um valor) pairs in arbitrary order.\n"
+
+#: src/std/hash.md:55
+msgid "\"Calling {}: {}\""
+msgstr "\"Chamaing {}: {}\""
+
+#: src/std/hash.md:60
+msgid ""
+"For more information on how hashing and hash maps (sometimes called hash "
+"tables) work, have a look at [Hash Table Wikipedia](https://en.wikipedia.org/"
+"wiki/Hash_table)"
+msgstr "Para more information on how hashing e hash maps (sometimes chamado hash tables) work, have um look at [Hash Table Wikipedia](https://en.wikipedia.org/wiki/Hash_table)"
+
+#: src/std/hash/alt_key_types.md:3
+msgid ""
+"Any type that implements the `Eq` and `Hash` traits can be a key in "
+"`HashMap`. This includes:"
+msgstr "Any tipo aquele implements o `Eq` e `Hash` traits pode be um key in `HashMap`. Este includes:"
+
+#: src/std/hash/alt_key_types.md:6
+msgid "`bool` (though not very useful since there are only two possible keys)"
+msgstr "`bool` (though not very useful since there are only two possible keys)"
+
+#: src/std/hash/alt_key_types.md:7
+msgid "`int`, `uint`, and all variations thereof"
+msgstr "`int`, `uint`, e all variations thereof"
+
+#: src/std/hash/alt_key_types.md:8
+msgid ""
+"`String` and `&str` (protip: you can have a `HashMap` keyed by `String` and "
+"call `.get()` with an `&str`)"
+msgstr "`String` e `&str` (protip: you pode have um `HashMap` keyed by `String` e call `.get()` com um `&str`)"
+
+#: src/std/hash/alt_key_types.md:11
+msgid ""
+"Note that `f32` and `f64` do _not_ implement `Hash`, likely because "
+"[floating-point precision errors](https://en.wikipedia.org/wiki/"
+"Floating_point#Accuracy_problems) would make using them as hashmap keys "
+"horribly error-prone."
+msgstr "Note aquele `f32` e `f64` do _not_ implement `Hash`, likely porque [floating-point precision errors](https://en.wikipedia.org/wiki/Floating_point#Accuracy_problems) would make usando them as hashmap keys horribly erro-prone."
+
+#: src/std/hash/alt_key_types.md:15
+msgid ""
+"All collection classes implement `Eq` and `Hash` if their contained type "
+"also respectively implements `Eq` and `Hash`. For example, `Vec<T>` will "
+"implement `Hash` if `T` implements `Hash`."
+msgstr "All collection classes implement `Eq` e `Hash` if their contained tipo also respectively implements `Eq` e `Hash`. Para example, `Vec<T>` vai implement `Hash` if `T` implements `Hash`."
+
+#: src/std/hash/alt_key_types.md:19
+msgid ""
+"You can easily implement `Eq` and `Hash` for a custom type with just one "
+"line: `#[derive(PartialEq, Eq, Hash)]`"
+msgstr "You pode easily implement `Eq` e `Hash` para um custom tipo com just one line: `#[derive(PartialEq, Eq, Hash)]`"
+
+#: src/std/hash/alt_key_types.md:22
+msgid ""
+"The compiler will do the rest. If you want more control over the details, "
+"you can implement `Eq` and/or `Hash` yourself. This guide will not cover the "
+"specifics of implementing `Hash`."
+msgstr "O compiler vai do o rest. If you want more control over o details, you pode implement `Eq` e/ou `Hash` yourself. Este guide vai not cover o specifics of implementing `Hash`."
+
+#: src/std/hash/alt_key_types.md:26
+msgid ""
+"To play around with using a `struct` in `HashMap`, let's try making a very "
+"simple user logon system:"
+msgstr "To play around com usando um `struct` in `HashMap`, let's try making um very simple user logon system:"
+
+#: src/std/hash/alt_key_types.md:31
+msgid "// Eq requires that you derive PartialEq on the type.\n"
+msgstr ""
+"// Eq requires aquele you derive PartialEq on o tipo.\n"
+
+#: src/std/hash/alt_key_types.md:48
+msgid "\"Username: {}\""
+msgstr "\"Usarname: {}\""
+
+#: src/std/hash/alt_key_types.md:49
+msgid "\"Password: {}\""
+msgstr "\"Password: {}\""
+
+#: src/std/hash/alt_key_types.md:50
+msgid "\"Attempting logon...\""
+msgstr "\"Attempting logon...\""
+
+#: src/std/hash/alt_key_types.md:59
+msgid "\"Successful logon!\""
+msgstr "\"Successful logon!\""
+
+#: src/std/hash/alt_key_types.md:60
+msgid "\"Name: {}\""
+msgstr "\"Name: {}\""
+
+#: src/std/hash/alt_key_types.md:61
+msgid "\"Email: {}\""
+msgstr "\"Email: {}\""
+
+#: src/std/hash/alt_key_types.md:63
+msgid "\"Login failed!\""
+msgstr "\"Login failed!\""
+
+#: src/std/hash/alt_key_types.md:71 src/std/hash/alt_key_types.md:82
+#: src/std/hash/alt_key_types.md:84
+msgid "\"j.everyman\""
+msgstr "\"j.everyman\""
+
+#: src/std/hash/alt_key_types.md:72 src/std/hash/alt_key_types.md:84
+msgid "\"password123\""
+msgstr "\"password123\""
+
+#: src/std/hash/alt_key_types.md:76
+msgid "\"John Everyman\""
+msgstr "\"John Everyman\""
+
+#: src/std/hash/alt_key_types.md:77
+msgid "\"j.everyman@email.com\""
+msgstr "\"j.everyman@email.com\""
+
+#: src/std/hash/alt_key_types.md:82
+msgid "\"psasword123\""
+msgstr "\"psasword123\""
+
+#: src/std/hash/hashset.md:3
+msgid ""
+"Consider a `HashSet` as a `HashMap` where we just care about the keys "
+"( `HashSet<T>` is, in actuality, just a wrapper around `HashMap<T, ()>`)."
+msgstr "Consider um `HashSet` as um `HashMap` where we just care about o keys ( `HashSet<T>` is, in actuality, just um wrapper around `HashMap<T, ()>`)."
+
+#: src/std/hash/hashset.md:6
+msgid ""
+"\"What's the point of that?\" you ask. \"I could just store the keys in a "
+"`Vec`.\""
+msgstr "\"What's o point of aquele?\" you ask. \"I could just store o keys in um `Vec`.\""
+
+#: src/std/hash/hashset.md:8
+msgid ""
+"A `HashSet`'s unique feature is that it is guaranteed to not have duplicate "
+"elements. That's the contract that any set collection fulfills. `HashSet` is "
+"just one implementation. (see also: [`BTreeSet`](https://doc.rust-lang.org/"
+"std/collections/struct.BTreeSet.html))"
+msgstr "UM `HashSet`'s unique feature is aquele it is guaranteed to not have duplicate elements. Aquele's o contract aquele any set collection fulfills. `HashSet` is just one implementation. (see also: [`BTreeSet`](https://doc.rust-lang.org/std/collections/struct.BTreeSet.html))"
+
+#: src/std/hash/hashset.md:13
+msgid ""
+"If you insert a value that is already present in the `HashSet`, (i.e. the "
+"new value is equal to the existing and they both have the same hash), then "
+"the new value will replace the old."
+msgstr "If you insert um valor aquele is already present in o `HashSet`, (i.e. o novo valor is equal to o existing e they both have o mesmo hash), then o novo valor vai replace o antigo."
+
+#: src/std/hash/hashset.md:17
+msgid ""
+"This is great for when you never want more than one of something, or when "
+"you want to know if you've already got something."
+msgstr "This is great for when you never want more than one of something, or when you want to know if you've already got something."
+
+#: src/std/hash/hashset.md:20
+msgid "But sets can do more than that."
+msgstr "But sets pode do more than aquele."
+
+#: src/std/hash/hashset.md:22
+msgid ""
+"Sets have 4 primary operations (all of the following calls return an "
+"iterator):"
+msgstr "Sets have 4 primary operations (all of o following calls retorna um iterator):"
+
+#: src/std/hash/hashset.md:24
+msgid "`union`: get all the unique elements in both sets."
+msgstr "`union`: get all o unique elements in both sets."
+
+#: src/std/hash/hashset.md:26
+msgid ""
+"`difference`: get all the elements that are in the first set but not the "
+"second."
+msgstr "`difference`: get all o elements aquele are in o primeiro set but not o segundo."
+
+#: src/std/hash/hashset.md:28
+msgid "`intersection`: get all the elements that are only in _both_ sets."
+msgstr "`intersection`: get all o elements aquele are only in _both_ sets."
+
+#: src/std/hash/hashset.md:30
+msgid ""
+"`symmetric_difference`: get all the elements that are in one set or the "
+"other, but _not_ both."
+msgstr "`symmetric_difference`: get all o elements aquele are in one set ou o other, but _not_ both."
+
+#: src/std/hash/hashset.md:33
+msgid "Try all of these in the following example:"
+msgstr "Tente all of estes in o following example:"
+
+#: src/std/hash/hashset.md:45
+msgid ""
+"// `HashSet::insert()` returns false if\n"
+"    // there was a value already present.\n"
+msgstr ""
+"// `HashSet::insert()` retorna false if\n"
+"    // there was um valor already present.\n"
+
+#: src/std/hash/hashset.md:47
+msgid "\"Value 4 is already in set B!\""
+msgstr "\"Valor 4 is already in set B!\""
+
+#: src/std/hash/hashset.md:52
+msgid ""
+"// If a collection's element type implements `Debug`,\n"
+"    // then the collection implements `Debug`.\n"
+"    // It usually prints its elements in the format `[elem1, elem2, ...]`\n"
+msgstr ""
+"// If um collection's element tipo implements `Debug`,\n"
+"    // then o collection implements `Debug`.\n"
+"    // It usually prints its elements in o format `[elem1, elem2, ...]`\n"
+
+#: src/std/hash/hashset.md:55
+msgid "\"A: {:?}\""
+msgstr "\"UM: {:?}\""
+
+#: src/std/hash/hashset.md:56
+msgid "\"B: {:?}\""
+msgstr "\"B: {:?}\""
+
+#: src/std/hash/hashset.md:58
+msgid "// Print [1, 2, 3, 4, 5] in arbitrary order\n"
+msgstr ""
+"// Imprime [1, 2, 3, 4, 5] in arbitrary order\n"
+
+#: src/std/hash/hashset.md:59
+msgid "\"Union: {:?}\""
+msgstr "\"Union: {:?}\""
+
+#: src/std/hash/hashset.md:61
+msgid "// This should print [1]\n"
+msgstr ""
+"// Este deve print [1]\n"
+
+#: src/std/hash/hashset.md:62
+msgid "\"Difference: {:?}\""
+msgstr "\"Difference: {:?}\""
+
+#: src/std/hash/hashset.md:64
+msgid "// Print [2, 3, 4] in arbitrary order.\n"
+msgstr ""
+"// Imprime [2, 3, 4] in arbitrary order.\n"
+
+#: src/std/hash/hashset.md:65
+msgid "\"Intersection: {:?}\""
+msgstr "\"Intersection: {:?}\""
+
+#: src/std/hash/hashset.md:67
+msgid "// Print [1, 5]\n"
+msgstr ""
+"// Imprime [1, 5]\n"
+
+#: src/std/hash/hashset.md:68
+msgid "\"Symmetric Difference: {:?}\""
+msgstr "\"Symmetric Difference: {:?}\""
+
+#: src/std/hash/hashset.md:73
+msgid ""
+"(Examples are adapted from the [documentation.](https://doc.rust-lang.org/"
+"std/collections/struct.HashSet.html#method.difference))"
+msgstr "(Exemplos are adapted do [documentation.](https://doc.rust-lang.org/std/collections/struct.HashSet.html#method.difference))"
+
+#: src/std/rc.md:3
+msgid ""
+"When multiple ownership is needed, `Rc`(Reference Counting) can be used. "
+"`Rc` keeps track of the number of the references which means the number of "
+"owners of the value wrapped inside an `Rc`."
+msgstr "When multiple ownership is needed, `Rc`(Reference Counting) pode be usado. `Rc` keeps track of o número of o references which means o número of owners of o valor wrapped dentro um `Rc`."
+
+#: src/std/rc.md:7
+msgid ""
+"Reference count of an `Rc` increases by 1 whenever an `Rc` is cloned, and "
+"decreases by 1 whenever one cloned `Rc` is dropped out of the scope. When an "
+"`Rc`'s reference count becomes zero (which means there are no remaining "
+"owners), both the `Rc` and the value are all dropped."
+msgstr "Reference count of um `Rc` increases by 1 whenever um `Rc` is cloned, e decreases by 1 whenever one cloned `Rc` is dropped out of o scope. When um `Rc`'s reference count becomes zero (which means there are no remaining owners), both o `Rc` e o valor are all dropped."
+
+#: src/std/rc.md:12
+msgid ""
+"Cloning an `Rc` never performs a deep copy. Cloning creates just another "
+"pointer to the wrapped value, and increments the count."
+msgstr "Cloning um `Rc` never performs um deep copy. Cloning creates just another pointer to o wrapped valor, e increments o count."
+
+#: src/std/rc.md:19
+msgid "\"Rc examples\""
+msgstr "\"Rc examples\""
+
+#: src/std/rc.md:21
+msgid "\"--- rc_a is created ---\""
+msgstr "\"--- rc_a is created ---\""
+
+#: src/std/rc.md:24 src/std/rc.md:31 src/std/rc.md:43
+msgid "\"Reference Count of rc_a: {}\""
+msgstr "\"Reference Count of rc_a: {}\""
+
+#: src/std/rc.md:27
+msgid "\"--- rc_a is cloned to rc_b ---\""
+msgstr "\"--- rc_a is cloned to rc_b ---\""
+
+#: src/std/rc.md:30
+msgid "\"Reference Count of rc_b: {}\""
+msgstr "\"Reference Count of rc_b: {}\""
+
+#: src/std/rc.md:33
+msgid "// Two `Rc`s are equal if their inner values are equal\n"
+msgstr ""
+"// Two `Rc`s are equal if their inner valores are equal\n"
+
+#: src/std/rc.md:34
+msgid "\"rc_a and rc_b are equal: {}\""
+msgstr "\"rc_a e rc_b are equal: {}\""
+
+#: src/std/rc.md:36
+msgid "// We can use methods of a value directly\n"
+msgstr ""
+"// We pode use métodos of um valor directly\n"
+
+#: src/std/rc.md:37
+msgid "\"Length of the value inside rc_a: {}\""
+msgstr "\"Length of o valor dentro rc_a: {}\""
+
+#: src/std/rc.md:38
+msgid "\"Value of rc_b: {}\""
+msgstr "\"Valor of rc_b: {}\""
+
+#: src/std/rc.md:40
+msgid "\"--- rc_b is dropped out of scope ---\""
+msgstr "\"--- rc_b is dropped out of scope ---\""
+
+#: src/std/rc.md:45
+msgid "\"--- rc_a is dropped out of scope ---\""
+msgstr "\"--- rc_a is dropped out of scope ---\""
+
+#: src/std/rc.md:48
+msgid ""
+"// Error! `rc_examples` already moved into `rc_a`\n"
+"    // And when `rc_a` is dropped, `rc_examples` is dropped together\n"
+"    // println!(\"rc_examples: {}\", rc_examples);\n"
+"    // TODO ^ Try uncommenting this line\n"
+msgstr ""
+"// Erro! `rc_examples` already moved em `rc_a`\n"
+"    // E when `rc_a` is dropped, `rc_examples` is dropped together\n"
+"    // println!(\"rc_examples: {}\", rc_examples);\n"
+"    // TODO ^ Tente uncommenting este line\n"
+
+#: src/std/rc.md:57
+msgid ""
+"[std::rc](https://doc.rust-lang.org/std/rc/index.html) and [std::sync::arc]"
+"(https://doc.rust-lang.org/std/sync/struct.Arc.html)."
+msgstr "[std::rc](https://doc.rust-lang.org/std/rc/index.html) e [std::sync::arc](https://doc.rust-lang.org/std/sync/struct.Arc.html)."
+
+#: src/std/arc.md:1
+msgid "Arc"
+msgstr "Arc"
+
+#: src/std/arc.md:3
+msgid ""
+"When shared ownership between threads is needed, `Arc`(Atomically Reference "
+"Counted) can be used. This struct, via the `Clone` implementation can create "
+"a reference pointer for the location of a value in the memory heap while "
+"increasing the reference counter. As it shares ownership between threads, "
+"when the last reference pointer to a value is out of scope, the variable is "
+"dropped."
+msgstr "When shared ownership between threads is needed, `Arc`(Atomically Reference Counted) pode be usado. Este struct, via o `Clone` implementation pode create um reference pointer para o location of um valor in o memory heap while increasing o reference counter. As it shares ownership between threads, when o último reference pointer to um valor is out of scope, o variável is dropped."
+
+#: src/std/arc.md:15
+msgid "// This variable declaration is where its value is specified.\n"
+msgstr ""
+"// Este variável declaration is where its valor is specified.\n"
+
+#: src/std/arc.md:16
+msgid "\"the same apple\""
+msgstr "\"o mesmo apple\""
+
+#: src/std/arc.md:19
+msgid ""
+"// Here there is no value specification as it is a pointer to a\n"
+"        // reference in the memory heap.\n"
+msgstr ""
+"// Here there is no value specification as it is a pointer to a\n"
+"        // reference in the memory heap.\n"
+
+#: src/std/arc.md:24
+msgid ""
+"// As Arc was used, threads can be spawned using the value allocated\n"
+"            // in the Arc variable pointer's location.\n"
+msgstr ""
+"// As Arc was usado, threads pode be spawned usando o valor allocated\n"
+"            // in o Arc variável pointer's location.\n"
+
+#: src/std/arc.md:30
+msgid "// Make sure all Arc instances are printed from spawned threads.\n"
+msgstr ""
+"// Make sure all Arc instances are printed de spawned threads.\n"
+
+#: src/std_misc.md:3
+msgid ""
+"Many other types are provided by the std library to support things such as:"
+msgstr "Many other tipos are provided by o std library to support things such as:"
+
+#: src/std_misc.md:10
+msgid "These expand beyond what the [primitives](primitives.md) provide."
+msgstr "Estes expand beyond what o [primitives](primitives.md) provide."
+
+#: src/std_misc/threads.md:3
+msgid ""
+"Rust provides a mechanism for spawning native OS threads via the `spawn` "
+"function, the argument of this function is a moving closure."
+msgstr "Rust provides um mechanism para spawning native OS threads via o `spawn` função, o argumento of este função is um moving closure."
+
+#: src/std_misc/threads.md:10 src/std_misc/threads/testcase_mapreduce.md:28
+msgid "// This is the `main` thread\n"
+msgstr ""
+"// Este is o `main` thread\n"
+
+#: src/std_misc/threads.md:13
+msgid "// Make a vector to hold the children which are spawned.\n"
+msgstr ""
+"// Make um vector to hold o children which are spawned.\n"
+
+#: src/std_misc/threads.md:17
+msgid "// Spin up another thread\n"
+msgstr ""
+"// Spin up another thread\n"
+
+#: src/std_misc/threads.md:19
+msgid "\"this is thread number {}\""
+msgstr "\"este is thread número {}\""
+
+#: src/std_misc/threads.md:24
+msgid "// Wait for the thread to finish. Returns a result.\n"
+msgstr ""
+"// Wait para o thread to finish. Retornas um resultado.\n"
+
+#: src/std_misc/threads.md:30
+msgid "These threads will be scheduled by the OS."
+msgstr "Estes threads vai be scheduled by o OS."
+
+#: src/std_misc/threads/testcase_mapreduce.md:3
+msgid ""
+"Rust makes it very easy to parallelize data processing, without many of the "
+"headaches traditionally associated with such an attempt."
+msgstr "Rust makes it very easy to parallelize data processing, sem many of o headaches traditionally associated com such um attempt."
+
+#: src/std_misc/threads/testcase_mapreduce.md:5
+msgid ""
+"The standard library provides great threading primitives out of the box. "
+"These, combined with Rust's concept of Ownership and aliasing rules, "
+"automatically prevent data races."
+msgstr "O standard library provides great threading primitives out of o box. Estes, combined com Rust's concept of Ownership e aliasing rules, automatically prevent data races."
+
+#: src/std_misc/threads/testcase_mapreduce.md:9
+msgid ""
+"The aliasing rules (one writable reference XOR many readable references) "
+"automatically prevent you from manipulating state that is visible to other "
+"threads. (Where synchronization is needed, there are synchronization "
+"primitives like `Mutex`es or `Channel`s.)"
+msgstr "O aliasing rules (one writable reference XOR many readable references) automatically prevent you de manipulating state aquele is visible to other threads. (Where synchronization is needed, there are synchronization primitives like `Mutex`es ou `Channel`s.)"
+
+#: src/std_misc/threads/testcase_mapreduce.md:14
+msgid ""
+"In this example, we will calculate the sum of all digits in a block of "
+"numbers. We will do this by parcelling out chunks of the block into "
+"different threads. Each thread will sum its tiny block of digits, and "
+"subsequently we will sum the intermediate sums produced by each thread."
+msgstr "In este example, we vai calculate o sum of all digits in um block of números. We vai do este by parcelling out chunks of o block em diferente threads. Each thread vai sum its tiny block of digits, e subsequently we vai sum o intermediate sums produced by each thread."
+
+#: src/std_misc/threads/testcase_mapreduce.md:19
+msgid ""
+"Note that, although we're passing references across thread boundaries, Rust "
+"understands that we're only passing read-only references, and that thus no "
+"unsafety or data races can occur. Also because the references we're passing "
+"have `'static` lifetimes, Rust understands that our data won't be destroyed "
+"while these threads are still running. (When you need to share non-`static` "
+"data between threads, you can use a smart pointer like `Arc` to keep the "
+"data alive and avoid non-`static` lifetimes.)"
+msgstr "Note aquele, although we're passing references across thread boundaries, Rust understands aquele we're only passing read-only references, e aquele thus no unsafety ou data races pode occur. Also porque o references we're passing have `'static` lifetimes, Rust understands aquele our data won't be destroyed while estes threads are still running. (When you need to share non-`static` data between threads, you pode use um smart pointer like `Arc` to keep o data alive e avoid non-`static` lifetimes.)"
+
+#: src/std_misc/threads/testcase_mapreduce.md:32
+msgid ""
+"// This is our data to process.\n"
+"    // We will calculate the sum of all digits via a threaded map-reduce "
+"algorithm.\n"
+"    // Each whitespace separated chunk will be handled in a different "
+"thread.\n"
+"    //\n"
+"    // TODO: see what happens to the output if you insert spaces!\n"
+msgstr ""
+"// Este is our data to process.\n"
+"    // We vai calculate o sum of all digits via um threaded map-reduce algorithm.\n"
+"    // Each whitespace separated chunk vai be handled in um diferente thread.\n"
+"    //\n"
+"    // TODO: see what happens to a saída if you insert spaces!\n"
+
+#: src/std_misc/threads/testcase_mapreduce.md:37
+msgid ""
+"\"86967897737416471853297327050364959\n"
+"11861322575564723963297542624962850\n"
+"70856234701860851907960690014725639\n"
+"38397966707106094172783238747669219\n"
+"52380795257888236525459303330302837\n"
+"58495327135744041048897885734297812\n"
+"69920216438980873548808413720956532\n"
+"16278424637452589860345374828574668\""
+msgstr ""
+"\"86967897737416471853297327050364959\n"
+"11861322575564723963297542624962850\n"
+"70856234701860851907960690014725639\n"
+"38397966707106094172783238747669219\n"
+"52380795257888236525459303330302837\n"
+"58495327135744041048897885734297812\n"
+"69920216438980873548808413720956532\n"
+"16278424637452589860345374828574668\""
+
+#: src/std_misc/threads/testcase_mapreduce.md:46
+msgid "// Make a vector to hold the child-threads which we will spawn.\n"
+msgstr ""
+"// Make um vector to hold o child-threads which we vai spawn.\n"
+
+#: src/std_misc/threads/testcase_mapreduce.md:49
+msgid ""
+"/*************************************************************************\n"
+"     * \"Map\" phase\n"
+"     *\n"
+"     * Divide our data into segments, and apply initial processing\n"
+"     ************************************************************************/"
+msgstr ""
+"/*************************************************************************\n"
+"     * \"Map\" phase\n"
+"     *\n"
+"     * Divide our data em segments, e apply initial processing\n"
+"     ************************************************************************/"
+
+#: src/std_misc/threads/testcase_mapreduce.md:55
+msgid ""
+"// split our data into segments for individual calculation\n"
+"    // each chunk will be a reference (&str) into the actual data\n"
+msgstr ""
+"// split our data em segments para individual calculation\n"
+"    // each chunk vai be um reference (&str) no actual data\n"
+
+#: src/std_misc/threads/testcase_mapreduce.md:59
+msgid ""
+"// Iterate over the data segments.\n"
+"    // .enumerate() adds the current loop index to whatever is iterated\n"
+"    // the resulting tuple \"(index, element)\" is then immediately\n"
+"    // \"destructured\" into two variables, \"i\" and \"data_segment\" with "
+"a\n"
+"    // \"destructuring assignment\"\n"
+msgstr ""
+"// Iterate over o data segments.\n"
+"    // .enumerate() adds o current loop index to whatever is iterated\n"
+"    // o resulting tuple \"(index, element)\" is then immediately\n"
+"    // \"destructured\" em two variáveis, \"i\" e \"data_segment\" com um\n"
+"    // \"destructuring assignment\"\n"
+
+#: src/std_misc/threads/testcase_mapreduce.md:65
+msgid "\"data segment {} is \\\"{}\\\"\""
+msgstr "\"data segment {} is \\\"{}\\\"\""
+
+#: src/std_misc/threads/testcase_mapreduce.md:67
+msgid ""
+"// Process each data segment in a separate thread\n"
+"        //\n"
+"        // spawn() returns a handle to the new thread,\n"
+"        // which we MUST keep to access the returned value\n"
+"        //\n"
+"        // 'move || -> u32' is syntax for a closure that:\n"
+"        // * takes no arguments ('||')\n"
+"        // * takes ownership of its captured variables ('move') and\n"
+"        // * returns an unsigned 32-bit integer ('-> u32')\n"
+"        //\n"
+"        // Rust is smart enough to infer the '-> u32' from\n"
+"        // the closure itself so we could have left that out.\n"
+"        //\n"
+"        // TODO: try removing the 'move' and see what happens\n"
+msgstr ""
+"// Process each data segment in um separate thread\n"
+"        //\n"
+"        // spawn() retorna um handle to o novo thread,\n"
+"        // which we DEVE keep to access o retornado valor\n"
+"        //\n"
+"        // 'move || -> u32' is syntax para um closure aquele:\n"
+"        // * takes no argumentos ('||')\n"
+"        // * takes ownership of its captured variáveis ('move') e\n"
+"        // * retorna um unsigned 32-bit inteiro ('-> u32')\n"
+"        //\n"
+"        // Rust is smart enough to infer o '-> u32' de\n"
+"        // o closure itself so we could have left aquele out.\n"
+"        //\n"
+"        // TODO: try removing o 'move' e see what happens\n"
+
+#: src/std_misc/threads/testcase_mapreduce.md:82
+msgid "// Calculate the intermediate sum of this segment:\n"
+msgstr ""
+"// Calculate o intermediate sum of este segment:\n"
+
+#: src/std_misc/threads/testcase_mapreduce.md:84
+msgid "// iterate over the characters of our segment..\n"
+msgstr ""
+"// iterate over o characters of our segment..\n"
+
+#: src/std_misc/threads/testcase_mapreduce.md:86
+msgid "// .. convert text-characters to their number value..\n"
+msgstr ""
+"// .. convert text-characters to their número valor..\n"
+
+#: src/std_misc/threads/testcase_mapreduce.md:87
+msgid "\"should be a digit\""
+msgstr "\"deve be um digit\""
+
+#: src/std_misc/threads/testcase_mapreduce.md:88
+msgid "// .. and sum the resulting iterator of numbers\n"
+msgstr ""
+"// .. e sum o resulting iterator of números\n"
+
+#: src/std_misc/threads/testcase_mapreduce.md:91
+msgid "// println! locks stdout, so no text-interleaving occurs\n"
+msgstr ""
+"// println! locks stdout, so no text-interleaving occurs\n"
+
+#: src/std_misc/threads/testcase_mapreduce.md:92
+msgid "\"processed segment {}, result={}\""
+msgstr "\"processed segment {}, resultado={}\""
+
+#: src/std_misc/threads/testcase_mapreduce.md:94
+msgid ""
+"// \"return\" not needed, because Rust is an \"expression language\", the\n"
+"            // last evaluated expression in each block is automatically its "
+"value.\n"
+msgstr ""
+"// \"retorna\" not needed, porque Rust is um \"expression language\", o\n"
+"            // último evaluated expression in each block is automatically its valor.\n"
+
+#: src/std_misc/threads/testcase_mapreduce.md:102
+msgid ""
+"/*************************************************************************\n"
+"     * \"Reduce\" phase\n"
+"     *\n"
+"     * Collect our intermediate results, and combine them into a final "
+"result\n"
+"     ************************************************************************/"
+msgstr ""
+"/*************************************************************************\n"
+"     * \"Reduce\" phase\n"
+"     *\n"
+"     * Collect our intermediate resultados, e combine them em um final resultado\n"
+"     ************************************************************************/"
+
+#: src/std_misc/threads/testcase_mapreduce.md:108
+msgid ""
+"// combine each thread's intermediate results into a single final sum.\n"
+"    //\n"
+"    // we use the \"turbofish\" ::<> to provide sum() with a type hint.\n"
+"    //\n"
+"    // TODO: try without the turbofish, by instead explicitly\n"
+"    // specifying the type of final_result\n"
+msgstr ""
+"// combine each thread's intermediate resultados em um single final sum.\n"
+"    //\n"
+"    // we use o \"turbofish\" ::<> to provide sum() com um tipo hint.\n"
+"    //\n"
+"    // TODO: try sno turbofish, by instead explicitly\n"
+"    // specifying o tipo of final_result\n"
+
+#: src/std_misc/threads/testcase_mapreduce.md:116
+msgid "\"Final sum result: {}\""
+msgstr "\"Final sum resultado: {}\""
+
+#: src/std_misc/threads/testcase_mapreduce.md:122
+msgid "Assignments"
+msgstr "Assignments"
+
+#: src/std_misc/threads/testcase_mapreduce.md:124
+msgid ""
+"It is not wise to let our number of threads depend on user inputted data. "
+"What if the user decides to insert a lot of spaces? Do we _really_ want to "
+"spawn 2,000 threads? Modify the program so that the data is always chunked "
+"into a limited number of chunks, defined by a static constant at the "
+"beginning of the program."
+msgstr "It is not wise to let our número of threads depend on user inputted data. What if o user decides to insert um lot of spaces? Do we _really_ want to spawn 2,000 threads? Modify o program so aquele o data is always chunked em um limited número of chunks, defined by um static constant at o beginning of o program."
+
+#: src/std_misc/threads/testcase_mapreduce.md:131
+msgid "[Threads](../threads.md)"
+msgstr "[Threads](../threads.md)"
+
+#: src/std_misc/threads/testcase_mapreduce.md:132
+msgid "[vectors](../../std/vec.md) and [iterators](../../trait/iter.md)"
+msgstr "[vectors](../../std/vec.md) e [iterators](../../trait/iter.md)"
+
+#: src/std_misc/threads/testcase_mapreduce.md:133
+msgid ""
+"[closures](../../fn/closures.md), [move](../../scope/move.md) semantics and "
+"[`move` closures](https://doc.rust-lang.org/book/ch13-01-closures."
+"html#closures-can-capture-their-environment)"
+msgstr "[closures](../../fn/closures.md), [move](../../scope/move.md) semantics e [`move` closures](https://doc.rust-lang.org/book/ch13-01-closures.html#closures-can-capture-their-environment)"
+
+#: src/std_misc/threads/testcase_mapreduce.md:134
+msgid ""
+"[destructuring](https://doc.rust-lang.org/book/ch18-03-pattern-syntax."
+"html#destructuring-to-break-apart-values) assignments"
+msgstr "[destructuring](https://doc.rust-lang.org/book/ch18-03-pattern-syntax.html#destructuring-to-break-apart-values) assignments"
+
+#: src/std_misc/threads/testcase_mapreduce.md:135
+msgid ""
+"[turbofish notation](https://doc.rust-lang.org/book/appendix-02-operators."
+"html?highlight=turbofish) to help type inference"
+msgstr "[turbofish notation](https://doc.rust-lang.org/book/appendix-02-operators.html?highlight=turbofish) to help tipo inference"
+
+#: src/std_misc/threads/testcase_mapreduce.md:136
+msgid "[unwrap vs. expect](../../error/option_unwrap.md)"
+msgstr "[unwrap vs. expect](../../error/option_unwrap.md)"
+
+#: src/std_misc/threads/testcase_mapreduce.md:137
+msgid "[enumerate](https://doc.rust-lang.org/book/loops.html#enumerate)"
+msgstr "[enumerate](https://doc.rust-lang.org/book/loops.html#enumerate)"
+
+#: src/std_misc/channels.md:3
+msgid ""
+"Rust provides asynchronous `channels` for communication between threads. "
+"Channels allow a unidirectional flow of information between two end-points: "
+"the `Sender` and the `Receiver`."
+msgstr "Rust provides asynchronous `channels` para communication between threads. Channels allow um unidirectional flow of information between two end-points: o `Sender` e o `Receiver`."
+
+#: src/std_misc/channels.md:15
+msgid ""
+"// Channels have two endpoints: the `Sender<T>` and the `Receiver<T>`,\n"
+"    // where `T` is the type of the message to be transferred\n"
+"    // (type annotation is superfluous)\n"
+msgstr ""
+"// Channels have two endpoints: o `Sender<T>` e o `Receiver<T>`,\n"
+"    // where `T` is o tipo of o message to be transferred\n"
+"    // (tipo anotação is superfluous)\n"
+
+#: src/std_misc/channels.md:22
+msgid "// The sender endpoint can be copied\n"
+msgstr ""
+"// O sender endpoint pode be copied\n"
+
+#: src/std_misc/channels.md:25
+msgid "// Each thread will send its id via the channel\n"
+msgstr ""
+"// Each thread vai send its id via o channel\n"
+
+#: src/std_misc/channels.md:27
+msgid ""
+"// The thread takes ownership over `thread_tx`\n"
+"            // Each thread queues a message in the channel\n"
+msgstr ""
+"// O thread takes ownership over `thread_tx`\n"
+"            // Each thread queues um message in o channel\n"
+
+#: src/std_misc/channels.md:31
+msgid ""
+"// Sending is a non-blocking operation, the thread will continue\n"
+"            // immediately after sending its message\n"
+msgstr ""
+"// Sending is um non-blocking operation, o thread vai continue\n"
+"            // immediately after sending its message\n"
+
+#: src/std_misc/channels.md:33
+msgid "\"thread {} finished\""
+msgstr "\"thread {} finished\""
+
+#: src/std_misc/channels.md:39
+msgid "// Here, all the messages are collected\n"
+msgstr ""
+"// Here, all o messages are collected\n"
+
+#: src/std_misc/channels.md:42
+msgid ""
+"// The `recv` method picks a message from the channel\n"
+"        // `recv` will block the current thread if there are no messages "
+"available\n"
+msgstr ""
+"// O `recv` método picks um message do channel\n"
+"        // `recv` vai block o current thread if there are no messages available\n"
+
+#: src/std_misc/channels.md:47
+msgid "// Wait for the threads to complete any remaining work\n"
+msgstr ""
+"// Wait para o threads to complete any remaining work\n"
+
+#: src/std_misc/channels.md:49
+msgid "\"oops! the child thread panicked\""
+msgstr "\"oops! o child thread panicked\""
+
+#: src/std_misc/channels.md:52
+msgid "// Show the order in which the messages were sent\n"
+msgstr ""
+"// Show o order in which o messages were sent\n"
+
+#: src/std_misc/path.md:3
+msgid ""
+"The `Path` struct represents file paths in the underlying filesystem. There "
+"are two flavors of `Path`: `posix::Path`, for UNIX-like systems, and "
+"`windows::Path`, for Windows. The prelude exports the appropriate platform-"
+"specific `Path` variant."
+msgstr "O `Path` struct represents arquivo paths in o underlying filesystem. There are two flavors of `Path`: `posix::Path`, para UNIX-like systems, e `windows::Path`, para Windows. O prelude exports o appropriate platform-specific `Path` variant."
+
+#: src/std_misc/path.md:8
+msgid ""
+"A `Path` can be created from an `OsStr`, and provides several methods to get "
+"information from the file/directory the path points to."
+msgstr "UM `Path` pode be created de um `OsStr`, e provides several métodos to get information do arquivo/directory o path points to."
+
+#: src/std_misc/path.md:11
+msgid ""
+"A `Path` is immutable. The owned version of `Path` is `PathBuf`. The "
+"relation between `Path` and `PathBuf` is similar to that of `str` and "
+"`String`: a `PathBuf` can be mutated in-place, and can be dereferenced to a "
+"`Path`."
+msgstr "UM `Path` is imutável. O owned version of `Path` is `PathBuf`. O relation between `Path` e `PathBuf` is similar to aquele of `str` e `String`: um `PathBuf` pode be mutated in-place, e pode be dereferenced to um `Path`."
+
+#: src/std_misc/path.md:15
+msgid ""
+"Note that a `Path` is _not_ internally represented as an UTF-8 string, but "
+"instead is stored as an `OsString`. Therefore, converting a `Path` to a "
+"`&str` is _not_ free and may fail (an `Option` is returned). However, a "
+"`Path` can be freely converted to an `OsString` or `&OsStr` using "
+"`into_os_string` and `as_os_str`, respectively."
+msgstr "Note aquele um `Path` is _not_ internally represented as um UTF-8 string, but instead is stored as um `OsString`. Therefore, converting um `Path` to um `&str` is _not_ free e may fail (um `Option` is retornado). However, um `Path` pode be freely converted to um `OsString` ou `&OsStr` usando `into_os_string` e `as_os_str`, respectively."
+
+#: src/std_misc/path.md:25
+msgid "// Create a `Path` from an `&'static str`\n"
+msgstr ""
+"// Cria um `Path` de um `&'static str`\n"
+
+#: src/std_misc/path.md:26
+msgid "\".\""
+msgstr "\".\""
+
+#: src/std_misc/path.md:28
+msgid "// The `display` method returns a `Display`able structure\n"
+msgstr ""
+"// O `display` método retorna um `Display`able estrutura\n"
+
+#: src/std_misc/path.md:31
+msgid ""
+"// `join` merges a path with a byte container using the OS specific\n"
+"    // separator, and returns a `PathBuf`\n"
+msgstr ""
+"// `join` merges um path com um byte container usando o OS specific\n"
+"    // separator, e retorna um `PathBuf`\n"
+
+#: src/std_misc/path.md:35
+msgid "// `push` extends the `PathBuf` with a `&Path`\n"
+msgstr ""
+"// `push` extends o `PathBuf` com um `&Path`\n"
+
+#: src/std_misc/path.md:37
+msgid "\"myfile.tar.gz\""
+msgstr "\"myfile.tar.gz\""
+
+#: src/std_misc/path.md:39
+msgid "// `set_file_name` updates the file name of the `PathBuf`\n"
+msgstr ""
+"// `set_file_name` updates o arquivo name of o `PathBuf`\n"
+
+#: src/std_misc/path.md:40
+msgid "\"package.tgz\""
+msgstr "\"package.tgz\""
+
+#: src/std_misc/path.md:42
+msgid "// Convert the `PathBuf` into a string slice\n"
+msgstr ""
+"// Convert o `PathBuf` em um string slice\n"
+
+#: src/std_misc/path.md:44
+msgid "\"new path is not a valid UTF-8 sequence\""
+msgstr "\"novo path is not um válido UTF-8 sequence\""
+
+#: src/std_misc/path.md:45
+msgid "\"new path is {}\""
+msgstr "\"novo path is {}\""
+
+#: src/std_misc/path.md:51
+msgid ""
+"Be sure to check at other `Path` methods (`posix::Path` or `windows::Path`) "
+"and the `Metadata` struct."
+msgstr "Be sure to check at other `Path` métodos (`posix::Path` ou `windows::Path`) e o `Metadata` struct."
+
+#: src/std_misc/path.md:56
+msgid ""
+"[OsStr](https://doc.rust-lang.org/std/ffi/struct.OsStr.html) and [Metadata]"
+"(https://doc.rust-lang.org/std/fs/struct.Metadata.html)."
+msgstr "[OsStr](https://doc.rust-lang.org/std/ffi/struct.OsStr.html) e [Metadata](https://doc.rust-lang.org/std/fs/struct.Metadata.html)."
+
+#: src/std_misc/file.md:3
+msgid ""
+"The `File` struct represents a file that has been opened (it wraps a file "
+"descriptor), and gives read and/or write access to the underlying file."
+msgstr "O `File` struct represents um arquivo aquele has been opened (it wraps um arquivo descriptor), e gives read e/ou write access to o underlying arquivo."
+
+#: src/std_misc/file.md:6
+msgid ""
+"Since many things can go wrong when doing file I/O, all the `File` methods "
+"return the `io::Result<T>` type, which is an alias for `Result<T, io::"
+"Error>`."
+msgstr "Since many things pode go wrong when doing arquivo I/O, all o `File` métodos retorna o `io::Result<T>` tipo, which is um alias para `Result<T, io::Error>`."
+
+#: src/std_misc/file.md:9
+msgid ""
+"This makes the failure of all I/O operations _explicit_. Thanks to this, the "
+"programmer can see all the failure paths, and is encouraged to handle them "
+"in a proactive manner."
+msgstr "Este makes o failure of all I/O operations _explicit_. Thanks to este, o programmer pode see all o failure paths, e is encouraged to handle them in um proactive manner."
+
+#: src/std_misc/file/open.md:3
+msgid "The `open` function can be used to open a file in read-only mode."
+msgstr "O `open` função pode be usado to open um arquivo in read-only mode."
+
+#: src/std_misc/file/open.md:5
+msgid ""
+"A `File` owns a resource, the file descriptor and takes care of closing the "
+"file when it is `drop`ed."
+msgstr "UM `File` owns um resource, o arquivo descriptor e takes care of closing o arquivo when it is `drop`ed."
+
+#: src/std_misc/file/open.md:14
+msgid "// Create a path to the desired file\n"
+msgstr ""
+"// Cria um path to o desired arquivo\n"
+
+#: src/std_misc/file/open.md:15
+msgid "\"hello.txt\""
+msgstr "\"hello.txt\""
+
+#: src/std_misc/file/open.md:18
+msgid "// Open the path in read-only mode, returns `io::Result<File>`\n"
+msgstr ""
+"// Abre o path in read-only mode, retorna `io::Result<File>`\n"
+
+#: src/std_misc/file/open.md:20
+msgid "\"couldn't open {}: {}\""
+msgstr "\"couldn't open {}: {}\""
+
+#: src/std_misc/file/open.md:24
+msgid "// Read the file contents into a string, returns `io::Result<usize>`\n"
+msgstr ""
+"// Lê o arquivo contents em um string, retorna `io::Result<usize>`\n"
+
+#: src/std_misc/file/open.md:27
+msgid "\"couldn't read {}: {}\""
+msgstr "\"couldn't read {}: {}\""
+
+#: src/std_misc/file/open.md:28
+msgid "\"{} contains:\\n{}\""
+msgstr "\"{} contains:\\n{}\""
+
+#: src/std_misc/file/open.md:31
+msgid "// `file` goes out of scope, and the \"hello.txt\" file gets closed\n"
+msgstr ""
+"// `file` goes out of scope, e o \"hello.txt\" arquivo gets closed\n"
+
+#: src/std_misc/file/open.md:35 src/std_misc/file/create.md:39
+#: src/std_misc/fs.md:109
+msgid "Here's the expected successful output:"
+msgstr "Here's o expected successful saída:"
+
+#: src/std_misc/file/open.md:37
+msgid ""
+"```shell\n"
+"$ echo \"Hello World!\" > hello.txt\n"
+"$ rustc open.rs && ./open\n"
+"hello.txt contains:\n"
+"Hello World!\n"
+"```"
+msgstr ""
+"```shell\n"
+"$ echo \"Hello World!\" > hello.txt\n"
+"$ rustc open.rs && ./open\n"
+"hello.txt contains:\n"
+"Hello World!\n"
+"```"
+
+#: src/std_misc/file/open.md:44
+msgid ""
+"(You are encouraged to test the previous example under different failure "
+"conditions: `hello.txt` doesn't exist, or `hello.txt` is not readable, etc.)"
+msgstr "(You are encouraged to test o anterior example under diferente failure conditions: `hello.txt` doesn't exist, ou `hello.txt` is not readable, etc.)"
+
+#: src/std_misc/file/create.md:3
+msgid ""
+"The `create` function opens a file in write-only mode. If the file already "
+"existed, the old content is destroyed. Otherwise, a new file is created."
+msgstr "O `create` função opens um arquivo in write-only mode. If o arquivo already existed, o antigo content is destroyed. Otherwise, um novo arquivo is created."
+
+#: src/std_misc/file/create.md:9
+msgid ""
+"\"Lorem ipsum dolor sit amet, consectetur adipisicing elit, sed do eiusmod\n"
+"tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim "
+"veniam,\n"
+"quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo\n"
+"consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse\n"
+"cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat "
+"non\n"
+"proident, sunt in culpa qui officia deserunt mollit anim id est laborum.\n"
+"\""
+msgstr ""
+"\"Lorem ipsum dolor sit amet, consectetur adipisicing elit, sed do eiusmod\n"
+"tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam,\n"
+"quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo\n"
+"consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse\n"
+"cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non\n"
+"proident, sunt in culpa qui officia deserunt mollit anim id est laborum.\n"
+"\""
+
+#: src/std_misc/file/create.md:22
+msgid "\"lorem_ipsum.txt\""
+msgstr "\"lorem_ipsum.txt\""
+
+#: src/std_misc/file/create.md:25
+msgid "// Open a file in write-only mode, returns `io::Result<File>`\n"
+msgstr ""
+"// Abre um arquivo in write-only mode, retorna `io::Result<File>`\n"
+
+#: src/std_misc/file/create.md:27
+msgid "\"couldn't create {}: {}\""
+msgstr "\"couldn't create {}: {}\""
+
+#: src/std_misc/file/create.md:31
+msgid "// Write the `LOREM_IPSUM` string to `file`, returns `io::Result<()>`\n"
+msgstr ""
+"// Escreve o `LOREM_IPSUM` string to `file`, retorna `io::Result<()>`\n"
+
+#: src/std_misc/file/create.md:33
+msgid "\"couldn't write to {}: {}\""
+msgstr "\"couldn't write to {}: {}\""
+
+#: src/std_misc/file/create.md:34
+msgid "\"successfully wrote to {}\""
+msgstr "\"successfully wrote to {}\""
+
+#: src/std_misc/file/create.md:54
+msgid ""
+"(As in the previous example, you are encouraged to test this example under "
+"failure conditions.)"
+msgstr "(As in o anterior example, you are encouraged to test este example under failure conditions.)"
+
+#: src/std_misc/file/create.md:57
+msgid ""
+"The [`OpenOptions`](https://doc.rust-lang.org/std/fs/struct.OpenOptions."
+"html) struct can be used to configure how a file is opened."
+msgstr "O [`OpenOptions`](https://doc.rust-lang.org/std/fs/struct.OpenOptions.html) struct pode be usado to configure how um arquivo is opened."
+
+#: src/std_misc/file/read_lines.md:3
+msgid "A naive approach"
+msgstr "UM naive approach"
+
+#: src/std_misc/file/read_lines.md:5
+msgid ""
+"This might be a reasonable first attempt for a beginner's first "
+"implementation for reading lines from a file."
+msgstr "Este might be um reasonable primeiro attempt para um beginner's primeiro implementation para reading lines de um arquivo."
+
+#: src/std_misc/file/read_lines.md:22
+msgid ""
+"Since the method `lines()` returns an iterator over the lines in the file, "
+"we can also perform a map inline and collect the results, yielding a more "
+"concise and fluent expression."
+msgstr "Since o método `lines()` retorna um iterator over o lines in o arquivo, we pode also perform um map inline e collect o resultados, yielding um more concise e fluent expression."
+
+#: src/std_misc/file/read_lines.md:31
+msgid "// panic on possible file-reading errors\n"
+msgstr ""
+"// panic on possible arquivo-reading erros\n"
+
+#: src/std_misc/file/read_lines.md:32
+msgid "// split the string into an iterator of string slices\n"
+msgstr ""
+"// split o string em um iterator of string slices\n"
+
+#: src/std_misc/file/read_lines.md:33
+msgid "// make each slice into a string\n"
+msgstr ""
+"// make each slice em um string\n"
+
+#: src/std_misc/file/read_lines.md:34
+msgid "// gather them together into a vector\n"
+msgstr ""
+"// gather them together em um vector\n"
+
+#: src/std_misc/file/read_lines.md:38
+msgid ""
+"Note that in both examples above, we must convert the `&str` reference "
+"returned from `lines()` to the owned type `String`, using `.to_string()` and "
+"`String::from` respectively."
+msgstr "Note aquele in both examples acima, we deve convert o `&str` reference retornado de `lines()` to o owned tipo `String`, usando `.to_string()` e `String::from` respectively."
+
+#: src/std_misc/file/read_lines.md:42
+msgid "A more efficient approach"
+msgstr "UM more efficient approach"
+
+#: src/std_misc/file/read_lines.md:44
+msgid ""
+"Here we pass ownership of the open `File` to a `BufReader` struct. "
+"`BufReader` uses an internal buffer to reduce intermediate allocations."
+msgstr "Here we pass ownership of o open `File` to um `BufReader` struct. `BufReader` uses um internal buffer to reduce intermediate allocations."
+
+#: src/std_misc/file/read_lines.md:47
+msgid ""
+"We also update `read_lines` to return an iterator instead of allocating new "
+"`String` objects in memory for each line."
+msgstr "We also update `read_lines` to retorna um iterator instead of allocating novo `String` objects in memory para each line."
+
+#: src/std_misc/file/read_lines.md:56
+msgid "// File hosts.txt must exist in the current path\n"
+msgstr ""
+"// Arquivo hosts.txt deve exist in o current path\n"
+
+#: src/std_misc/file/read_lines.md:57
+msgid "\"./hosts.txt\""
+msgstr "\"./hosts.txt\""
+
+#: src/std_misc/file/read_lines.md:58
+msgid "// Consumes the iterator, returns an (Optional) String\n"
+msgstr ""
+"// Consumes o iterator, retorna um (Optional) String\n"
+
+#: src/std_misc/file/read_lines.md:64
+msgid ""
+"// The output is wrapped in a Result to allow matching on errors.\n"
+"// Returns an Iterator to the Reader of the lines of the file.\n"
+msgstr ""
+"// O saída is wrapped in um Result to allow matching on erros.\n"
+"// Retornas um Iterator to o Lêer of o lines of o arquivo.\n"
+
+#: src/std_misc/file/read_lines.md:74
+msgid "Running this program simply prints the lines individually."
+msgstr "Running este program simply prints o lines individually."
+
+#: src/std_misc/file/read_lines.md:76
+msgid ""
+"```shell\n"
+"$ echo -e \"127.0.0.1\\n192.168.0.1\\n\" > hosts.txt\n"
+"$ rustc read_lines.rs && ./read_lines\n"
+"127.0.0.1\n"
+"192.168.0.1\n"
+"```"
+msgstr ""
+"```shell\n"
+"$ echo -e \"127.0.0.1\\n192.168.0.1\\n\" > hosts.txt\n"
+"$ rustc read_lines.rs && ./read_lines\n"
+"127.0.0.1\n"
+"192.168.0.1\n"
+"```"
+
+#: src/std_misc/file/read_lines.md:83
+msgid ""
+"(Note that since `File::open` expects a generic `AsRef<Path>` as argument, "
+"we define our generic `read_lines()` method with the same generic "
+"constraint, using the `where` keyword.)"
+msgstr "(Note aquele since `File::open` expects um generic `AsRef<Path>` as argumento, we define our generic `read_lines()` método com o mesmo generic constraint, usando o `where` keyword.)"
+
+#: src/std_misc/file/read_lines.md:86
+msgid ""
+"This process is more efficient than creating a `String` in memory with all "
+"of the file's contents. This can especially cause performance issues when "
+"working with larger files."
+msgstr "Este process is more efficient than creating um `String` in memory com all of o arquivo's contents. Este pode especially cause performance issues when working com larger arquivos."
+
+#: src/std_misc/process.md:3
+msgid ""
+"The `process::Output` struct represents the output of a finished child "
+"process, and the `process::Command` struct is a process builder."
+msgstr "O `process::Output` struct represents a saída of um finished child process, e o `process::Command` struct is um process builder."
+
+#: src/std_misc/process.md:10
+msgid "\"rustc\""
+msgstr "\"rustc\""
+
+#: src/std_misc/process.md:11
+msgid "\"--version\""
+msgstr "\"--version\""
+
+#: src/std_misc/process.md:13
+msgid "\"failed to execute process: {}\""
+msgstr "\"failed to execute process: {}\""
+
+#: src/std_misc/process.md:19
+msgid "\"rustc succeeded and stdout was:\\n{}\""
+msgstr "\"rustc succeeded e stdout was:\\n{}\""
+
+#: src/std_misc/process.md:23
+msgid "\"rustc failed and stderr was:\\n{}\""
+msgstr "\"rustc failed e stderr was:\\n{}\""
+
+#: src/std_misc/process.md:28
+msgid ""
+"(You are encouraged to try the previous example with an incorrect flag "
+"passed to `rustc`)"
+msgstr "(You are encouraged to try o anterior example com um incorrect flag passed to `rustc`)"
+
+#: src/std_misc/process/pipe.md:3
+msgid ""
+"The `std::process::Child` struct represents a child process, and exposes the "
+"`stdin`, `stdout` and `stderr` handles for interaction with the underlying "
+"process via pipes."
+msgstr "O `std::process::Child` struct represents um child process, e exposes o `stdin`, `stdout` e `stderr` handles para interaction com o underlying process via pipes."
+
+#: src/std_misc/process/pipe.md:11
+msgid "\"the quick brown fox jumps over the lazy dog\\n\""
+msgstr "\"o quick brown fox jumps over o lazy dog\\n\""
+
+#: src/std_misc/process/pipe.md:15
+msgid "// Spawn the `wc` command\n"
+msgstr ""
+"// Spawn o `wc` command\n"
+
+#: src/std_misc/process/pipe.md:16 src/std_misc/fs.md:12 src/std_misc/fs.md:73
+#: src/std_misc/ffi.md:11
+msgid "\"windows\""
+msgstr "\"windows\""
+
+#: src/std_misc/process/pipe.md:17
+msgid "\"powershell\""
+msgstr "\"powershell\""
+
+#: src/std_misc/process/pipe.md:18
+msgid "\"-Command\""
+msgstr "\"-Command\""
+
+#: src/std_misc/process/pipe.md:18
+msgid "\"$input | Measure-Object -Line -Word -Character\""
+msgstr "\"$entrada | Measure-Object -Line -Word -Character\""
+
+#: src/std_misc/process/pipe.md:21
+msgid "\"wc\""
+msgstr "\"wc\""
+
+#: src/std_misc/process/pipe.md:27
+msgid "\"couldn't spawn wc: {}\""
+msgstr "\"couldn't spawn wc: {}\""
+
+#: src/std_misc/process/pipe.md:31
+msgid ""
+"// Write a string to the `stdin` of `wc`.\n"
+"    //\n"
+"    // `stdin` has type `Option<ChildStdin>`, but since we know this "
+"instance\n"
+"    // must have one, we can directly `unwrap` it.\n"
+msgstr ""
+"// Escreve um string to o `stdin` of `wc`.\n"
+"    //\n"
+"    // `stdin` has tipo `Option<ChildStdin>`, but since we know este instance\n"
+"    // deve have one, we pode directly `unwrap` it.\n"
+
+#: src/std_misc/process/pipe.md:36
+msgid "\"couldn't write to wc stdin: {}\""
+msgstr "\"couldn't write to wc stdin: {}\""
+
+#: src/std_misc/process/pipe.md:37
+msgid "\"sent pangram to wc\""
+msgstr "\"sent pangram to wc\""
+
+#: src/std_misc/process/pipe.md:40
+msgid ""
+"// Because `stdin` does not live after the above calls, it is `drop`ed,\n"
+"    // and the pipe is closed.\n"
+"    //\n"
+"    // This is very important, otherwise `wc` wouldn't start processing the\n"
+"    // input we just sent.\n"
+msgstr ""
+"// Porque `stdin` does not live after o acima calls, it is `drop`ed,\n"
+"    // e o pipe is closed.\n"
+"    //\n"
+"    // Este is very important, otherwise `wc` wouldn't start processing o\n"
+"    // entrada we just sent.\n"
+
+#: src/std_misc/process/pipe.md:46
+msgid ""
+"// The `stdout` field also has type `Option<ChildStdout>` so must be "
+"unwrapped.\n"
+msgstr ""
+"// O `stdout` campo also has tipo `Option<ChildStdout>` so deve be unwrapped.\n"
+
+#: src/std_misc/process/pipe.md:49
+msgid "\"couldn't read wc stdout: {}\""
+msgstr "\"couldn't read wc stdout: {}\""
+
+#: src/std_misc/process/pipe.md:50
+msgid "\"wc responded with:\\n{}\""
+msgstr "\"wc responded com:\\n{}\""
+
+#: src/std_misc/process/wait.md:3
+msgid ""
+"If you'd like to wait for a `process::Child` to finish, you must call "
+"`Child::wait`, which will return a `process::ExitStatus`."
+msgstr "If you'd like to wait para um `process::Child` to finish, you deve call `Child::wait`, which vai retorna um `process::ExitStatus`."
+
+#: src/std_misc/process/wait.md:10
+msgid "\"sleep\""
+msgstr "\"sleep\""
+
+#: src/std_misc/process/wait.md:13
+msgid "\"reached end of main\""
+msgstr "\"reached end of main\""
+
+#: src/std_misc/process/wait.md:18
+msgid ""
+"# `wait` keeps running for 5 seconds until the `sleep 5` command finishes\n"
+msgstr ""
+"# `wait` keeps running para 5 seconds until o `sleep 5` command finishes\n"
+
+#: src/std_misc/fs.md:3
+msgid ""
+"The `std::fs` module contains several functions that deal with the "
+"filesystem."
+msgstr "O `std::fs` módulo contains several funções aquele deal com o filesystem."
+
+#: src/std_misc/fs.md:10 src/std_misc/fs.md:68 src/std_misc/ffi.md:20
+msgid "\"unix\""
+msgstr "\"unix\""
+
+#: src/std_misc/fs.md:15
+msgid "// A simple implementation of `% cat path`\n"
+msgstr ""
+"// UM simple implementation of `% cat path`\n"
+
+#: src/std_misc/fs.md:25
+msgid "// A simple implementation of `% echo s > path`\n"
+msgstr ""
+"// UM simple implementation of `% echo s > path`\n"
+
+#: src/std_misc/fs.md:32
+msgid "// A simple implementation of `% touch path` (ignores existing files)\n"
+msgstr ""
+"// UM simple implementation of `% touch path` (ignores existing arquivos)\n"
+
+#: src/std_misc/fs.md:42
+msgid "\"`mkdir a`\""
+msgstr "\"`mkdir a`\""
+
+#: src/std_misc/fs.md:43
+msgid "// Create a directory, returns `io::Result<()>`\n"
+msgstr ""
+"// Cria um directory, retorna `io::Result<()>`\n"
+
+#: src/std_misc/fs.md:45 src/std_misc/fs.md:52 src/std_misc/fs.md:58
+#: src/std_misc/fs.md:63 src/std_misc/fs.md:70 src/std_misc/fs.md:75
+#: src/std_misc/fs.md:81 src/std_misc/fs.md:88 src/std_misc/fs.md:97
+#: src/std_misc/fs.md:103
+msgid "\"! {:?}\""
+msgstr "\"! {:?}\""
+
+#: src/std_misc/fs.md:49
+msgid "\"`echo hello > a/b.txt`\""
+msgstr "\"`echo hello > a/b.txt`\""
+
+#: src/std_misc/fs.md:50
+msgid ""
+"// The previous match can be simplified using the `unwrap_or_else` method\n"
+msgstr ""
+"// O anterior match pode be simplified usando o `unwrap_or_else` método\n"
+
+#: src/std_misc/fs.md:51
+msgid "\"a/b.txt\""
+msgstr "\"um/b.txt\""
+
+#: src/std_misc/fs.md:55
+msgid "\"`mkdir -p a/c/d`\""
+msgstr "\"`mkdir -p a/c/d`\""
+
+#: src/std_misc/fs.md:56
+msgid "// Recursively create a directory, returns `io::Result<()>`\n"
+msgstr ""
+"// Recursively create um directory, retorna `io::Result<()>`\n"
+
+#: src/std_misc/fs.md:57 src/std_misc/fs.md:102
+msgid "\"a/c/d\""
+msgstr "\"um/c/d\""
+
+#: src/std_misc/fs.md:61
+msgid "\"`touch a/c/e.txt`\""
+msgstr "\"`touch a/c/e.txt`\""
+
+#: src/std_misc/fs.md:62 src/std_misc/fs.md:96
+msgid "\"a/c/e.txt\""
+msgstr "\"um/c/e.txt\""
+
+#: src/std_misc/fs.md:66
+msgid "\"`ln -s ../b.txt a/c/b.txt`\""
+msgstr "\"`ln -s ../b.txt a/c/b.txt`\""
+
+#: src/std_misc/fs.md:67
+msgid "// Create a symbolic link, returns `io::Result<()>`\n"
+msgstr ""
+"// Cria um symbolic link, retorna `io::Result<()>`\n"
+
+#: src/std_misc/fs.md:69 src/std_misc/fs.md:74
+msgid "\"../b.txt\""
+msgstr "\"../b.txt\""
+
+#: src/std_misc/fs.md:69 src/std_misc/fs.md:74 src/std_misc/fs.md:80
+msgid "\"a/c/b.txt\""
+msgstr "\"um/c/b.txt\""
+
+#: src/std_misc/fs.md:79
+msgid "\"`cat a/c/b.txt`\""
+msgstr "\"`cat a/c/b.txt`\""
+
+#: src/std_misc/fs.md:85
+msgid "\"`ls a`\""
+msgstr "\"`ls a`\""
+
+#: src/std_misc/fs.md:86
+msgid "// Read the contents of a directory, returns `io::Result<Vec<Path>>`\n"
+msgstr ""
+"// Lê o contents of um directory, retorna `io::Result<Vec<Path>>`\n"
+
+#: src/std_misc/fs.md:94
+msgid "\"`rm a/c/e.txt`\""
+msgstr "\"`rm a/c/e.txt`\""
+
+#: src/std_misc/fs.md:95
+msgid "// Remove a file, returns `io::Result<()>`\n"
+msgstr ""
+"// Remove um arquivo, retorna `io::Result<()>`\n"
+
+#: src/std_misc/fs.md:100
+msgid "\"`rmdir a/c/d`\""
+msgstr "\"`rmdir a/c/d`\""
+
+#: src/std_misc/fs.md:101
+msgid "// Remove an empty directory, returns `io::Result<()>`\n"
+msgstr ""
+"// Remove um vazio directory, retorna `io::Result<()>`\n"
+
+#: src/std_misc/fs.md:111
+msgid ""
+"```shell\n"
+"$ rustc fs.rs && ./fs\n"
+"`mkdir a`\n"
+"`echo hello > a/b.txt`\n"
+"`mkdir -p a/c/d`\n"
+"`touch a/c/e.txt`\n"
+"`ln -s ../b.txt a/c/b.txt`\n"
+"`cat a/c/b.txt`\n"
+"> hello\n"
+"`ls a`\n"
+"> \"a/b.txt\"\n"
+"> \"a/c\"\n"
+"`rm a/c/e.txt`\n"
+"`rmdir a/c/d`\n"
+"```"
+msgstr ""
+"```shell\n"
+"$ rustc fs.rs && ./fs\n"
+"`mkdir um`\n"
+"`echo hello > um/b.txt`\n"
+"`mkdir -p um/c/d`\n"
+"`touch um/c/e.txt`\n"
+"`ln -s ../b.txt um/c/b.txt`\n"
+"`cat um/c/b.txt`\n"
+"> hello\n"
+"`ls um`\n"
+"> \"a/b.txt\"\n"
+"> \"a/c\"\n"
+"`rm um/c/e.txt`\n"
+"`rmdir um/c/d`\n"
+"```"
+
+#: src/std_misc/fs.md:127
+msgid "And the final state of the `a` directory is:"
+msgstr "E o final state of o `a` directory is:"
+
+#: src/std_misc/fs.md:139
+msgid "An alternative way to define the function `cat` is with `?` notation:"
+msgstr "Um alternative way to define a função `cat` is com `?` notation:"
+
+#: src/std_misc/fs.md:152
+msgid "[`cfg!`](../attribute/cfg.md)"
+msgstr "[`cfg!`](../attribute/cfg.md)"
+
+#: src/std_misc/arg.md:3
+msgid "Standard Library"
+msgstr "Standard Library"
+
+#: src/std_misc/arg.md:5
+msgid ""
+"The command line arguments can be accessed using `std::env::args`, which "
+"returns an iterator that yields a `String` for each argument:"
+msgstr "O command line argumentos pode be accessed usando `std::env::args`, which retorna um iterator aquele yields um `String` para each argumento:"
+
+#: src/std_misc/arg.md:14
+msgid "// The first argument is the path that was used to call the program.\n"
+msgstr ""
+"// O primeiro argumento is o path aquele was usado to call o program.\n"
+
+#: src/std_misc/arg.md:15
+msgid "\"My path is {}.\""
+msgstr "\"My path is {}.\""
+
+#: src/std_misc/arg.md:17
+msgid ""
+"// The rest of the arguments are the passed command line parameters.\n"
+"    // Call the program like this:\n"
+"    //   $ ./args arg1 arg2\n"
+msgstr ""
+"// O rest of o argumentos are o passed command line parâmetros.\n"
+"    // Chama o program like este:\n"
+"    //   $ ./args arg1 arg2\n"
+
+#: src/std_misc/arg.md:20
+msgid "\"I got {:?} arguments: {:?}.\""
+msgstr "\"I got {:?} argumentos: {:?}.\""
+
+#: src/std_misc/arg.md:24
+msgid ""
+"```shell\n"
+"$ ./args 1 2 3\n"
+"My path is ./args.\n"
+"I got 3 arguments: [\"1\", \"2\", \"3\"].\n"
+"```"
+msgstr ""
+"```shell\n"
+"$ ./args 1 2 3\n"
+"My path is ./args.\n"
+"I got 3 arguments: [\"1\", \"2\", \"3\"].\n"
+"```"
+
+#: src/std_misc/arg.md:32
+msgid ""
+"Alternatively, there are numerous crates that can provide extra "
+"functionality when creating command-line applications. One of the more "
+"popular command line argument crates being [`clap`](https://rust-cli.github."
+"io/book/tutorial/cli-args.html#parsing-cli-arguments-with-clap)."
+msgstr "Alternatively, there are numerous crates aquele pode provide extra functionality when creating command-line applications. One of o more popular command line argumento crates being [`clap`](https://rust-cli.github.io/book/tutorial/cli-args.html#parsing-cli-arguments-with-clap)."
+
+#: src/std_misc/arg/matching.md:3
+msgid "Matching can be used to parse simple arguments:"
+msgstr "Matching pode be usado to parse simple argumentos:"
+
+#: src/std_misc/arg/matching.md:17
+msgid ""
+"\"usage:\n"
+"match_args <string>\n"
+"    Check whether given string is the answer.\n"
+"match_args {{increase|decrease}} <integer>\n"
+"    Increase or decrease given integer by one.\""
+msgstr ""
+"\"usage:\n"
+"match_args <string>\n"
+"    Check whether given string is o answer.\n"
+"match_args {{increase|decrease}} <inteiro>\n"
+"    Increase ou decrease given inteiro by one.\""
+
+#: src/std_misc/arg/matching.md:28
+msgid "// no arguments passed\n"
+msgstr ""
+"// no argumentos passed\n"
+
+#: src/std_misc/arg/matching.md:30
+msgid "\"My name is 'match_args'. Try passing some arguments!\""
+msgstr "\"My name is 'match_args'. Tente passing some argumentos!\""
+
+#: src/std_misc/arg/matching.md:32
+msgid "// one argument passed\n"
+msgstr ""
+"// one argumento passed\n"
+
+#: src/std_misc/arg/matching.md:35
+msgid "\"This is the answer!\""
+msgstr "\"Este is o answer!\""
+
+#: src/std_misc/arg/matching.md:36
+msgid "\"This is not the answer.\""
+msgstr "\"Este is not o answer.\""
+
+#: src/std_misc/arg/matching.md:39
+msgid "// one command and one argument passed\n"
+msgstr ""
+"// one command e one argumento passed\n"
+
+#: src/std_misc/arg/matching.md:43
+msgid "// parse the number\n"
+msgstr ""
+"// parse o número\n"
+
+#: src/std_misc/arg/matching.md:49
+msgid "\"error: second argument not an integer\""
+msgstr "\"erro: segundo argumento not um inteiro\""
+
+#: src/std_misc/arg/matching.md:54
+msgid "// parse the command\n"
+msgstr ""
+"// parse o command\n"
+
+#: src/std_misc/arg/matching.md:56
+msgid "\"increase\""
+msgstr "\"increase\""
+
+#: src/std_misc/arg/matching.md:57
+msgid "\"decrease\""
+msgstr "\"decrease\""
+
+#: src/std_misc/arg/matching.md:59
+msgid "\"error: invalid command\""
+msgstr "\"erro: inválido command\""
+
+#: src/std_misc/arg/matching.md:64
+msgid "// all the other cases\n"
+msgstr ""
+"// all o other cases\n"
+
+#: src/std_misc/arg/matching.md:66
+msgid "// show a help message\n"
+msgstr ""
+"// show um help message\n"
+
+#: src/std_misc/arg/matching.md:73
+msgid ""
+"If you named your program `match_args.rs` and compile it like this `rustc "
+"match_args.rs`, you can execute it as follows:"
+msgstr "If you named your program `match_args.rs` e compile it like este `rustc match_args.rs`, you pode execute it as follows:"
+
+#: src/std_misc/ffi.md:3
+msgid ""
+"Rust provides a Foreign Function Interface (FFI) to C libraries. Foreign "
+"functions must be declared inside an `extern` block annotated with a "
+"`#[link]` attribute containing the name of the foreign library."
+msgstr "Rust provides um Foreign Função Interface (FFI) to C libraries. Foreign funções deve be declared dentro um `extern` block annotated com um `#[link]` attribute containing o name of o foreign library."
+
+#: src/std_misc/ffi.md:9
+msgid "// this extern block links to the libm library\n"
+msgstr ""
+"// este extern block links to o libm library\n"
+
+#: src/std_misc/ffi.md:12
+msgid "\"msvcrt\""
+msgstr "\"msvcrt\""
+
+#: src/std_misc/ffi.md:14 src/std_misc/ffi.md:23
+msgid ""
+"// this is a foreign function\n"
+"    // that computes the square root of a single precision complex number\n"
+msgstr ""
+"// este is um foreign função\n"
+"    // aquele computes o square root of um single precision complex número\n"
+
+#: src/std_misc/ffi.md:21
+msgid "\"m\""
+msgstr "\"m\""
+
+#: src/std_misc/ffi.md:29
+msgid ""
+"// Since calling foreign functions is considered unsafe,\n"
+"// it's common to write safe wrappers around them.\n"
+msgstr ""
+"// Since calling foreign funções is considered unsafe,\n"
+"// it's common to write seguro wrappers around them.\n"
+
+#: src/std_misc/ffi.md:37
+msgid "// z = -1 + 0i\n"
+msgstr ""
+"// z = -1 + 0i\n"
+
+#: src/std_misc/ffi.md:40
+msgid "// calling a foreign function is an unsafe operation\n"
+msgstr ""
+"// calling um foreign função is um unsafe operation\n"
+
+#: src/std_misc/ffi.md:43
+msgid "\"the square root of {:?} is {:?}\""
+msgstr "\"o square root of {:?} is {:?}\""
+
+#: src/std_misc/ffi.md:45
+msgid "// calling safe API wrapped around unsafe operation\n"
+msgstr ""
+"// calling seguro API wrapped around unsafe operation\n"
+
+#: src/std_misc/ffi.md:46
+msgid "\"cos({:?}) = {:?}\""
+msgstr "\"cos({:?}) = {:?}\""
+
+#: src/std_misc/ffi.md:48
+msgid "// Minimal implementation of single precision complex numbers\n"
+msgstr ""
+"// Minimal implementation of single precision complex números\n"
+
+#: src/std_misc/ffi.md:60
+msgid "\"{}-{}i\""
+msgstr "\"{}-{}i\""
+
+#: src/std_misc/ffi.md:62
+msgid "\"{}+{}i\""
+msgstr "\"{}+{}i\""
+
+#: src/testing.md:3
+msgid ""
+"Rust is a programming language that cares a lot about correctness and it "
+"includes support for writing software tests within the language itself."
+msgstr "Rust is um programming language aquele cares um lot about correctness e it includes support para writing software tests within o language itself."
+
+#: src/testing.md:6
+msgid "Testing comes in three styles:"
+msgstr "Testing comes in three styles:"
+
+#: src/testing.md:8
+msgid "[Unit](testing/unit_testing.md) testing."
+msgstr "[Unit](testing/unit_testing.md) testing."
+
+#: src/testing.md:9
+msgid "[Doc](testing/doc_testing.md) testing."
+msgstr "[Doc](testing/doc_testing.md) testing."
+
+#: src/testing.md:10
+msgid "[Integration](testing/integration_testing.md) testing."
+msgstr "[Integration](testing/integration_testing.md) testing."
+
+#: src/testing.md:12
+msgid "Also Rust has support for specifying additional dependencies for tests:"
+msgstr "Also Rust has support para specifying additional dependencies para tests:"
+
+#: src/testing.md:14
+msgid "[Dev-dependencies](testing/dev_dependencies.md)"
+msgstr "[Dev-dependencies](testing/dev_dependencies.md)"
+
+#: src/testing.md:18
+msgid ""
+"[The Book](https://doc.rust-lang.org/book/ch11-00-testing.html) chapter on "
+"testing"
+msgstr "[The Book](https://doc.rust-lang.org/book/ch11-00-testing.html) chapter on testing"
+
+#: src/testing.md:19
+msgid ""
+"[API Guidelines](https://rust-lang-nursery.github.io/api-guidelines/"
+"documentation.html) on doc-testing"
+msgstr "[API Guidelines](https://rust-lang-nursery.github.io/api-guidelines/documentation.html) on doc-testing"
+
+#: src/testing/unit_testing.md:3
+msgid ""
+"Tests are Rust functions that verify that the non-test code is functioning "
+"in the expected manner. The bodies of test functions typically perform some "
+"setup, run the code we want to test, then assert whether the results are "
+"what we expect."
+msgstr "Tests are Rust funções aquele verify aquele o non-test code is functioning in o expected manner. O bodies of test funções typically perform some setup, run o code we want to test, then assert whether o resultados are what we expect."
+
+#: src/testing/unit_testing.md:8
+msgid ""
+"Most unit tests go into a `tests` [mod](../mod.md) with the `#[cfg(test)]` "
+"[attribute](../attribute.md). Test functions are marked with the `#[test]` "
+"attribute."
+msgstr "Most unit tests go em um `tests` [mod](../mod.md) com o `#[cfg(test)]` [attribute](../attribute.md). Test funções are marked com o `#[test]` attribute."
+
+#: src/testing/unit_testing.md:11
+msgid ""
+"Tests fail when something in the test function [panics](../std/panic.md). "
+"There are some helper [macros](../macros.md):"
+msgstr "Tests fail when something in o test função [panics](../std/panic.md). There are some helper [macros](../macros.md):"
+
+#: src/testing/unit_testing.md:14
+msgid "`assert!(expression)` - panics if expression evaluates to `false`."
+msgstr "`assert!(expression)` - panics if expression evaluates to `false`."
+
+#: src/testing/unit_testing.md:15
+msgid ""
+"`assert_eq!(left, right)` and `assert_ne!(left, right)` - testing left and "
+"right expressions for equality and inequality respectively."
+msgstr "`assert_eq!(left, right)` e `assert_ne!(left, right)` - testing left e right expressions para equality e inequality respectively."
+
+#: src/testing/unit_testing.md:22
+msgid ""
+"// This is a really bad adding function, its purpose is to fail in this\n"
+"// example.\n"
+msgstr ""
+"// Este is um really bad adding função, its purpose is to fail in este\n"
+"// example.\n"
+
+#: src/testing/unit_testing.md:32
+msgid ""
+"// Note this useful idiom: importing names from outer (for mod tests) "
+"scope.\n"
+msgstr ""
+"// Note este useful idiom: importing names de outer (para mod tests) scope.\n"
+
+#: src/testing/unit_testing.md:42
+msgid ""
+"// This assert would fire and test will fail.\n"
+"        // Please note, that private functions can be tested too!\n"
+msgstr ""
+"// Este assert would fire e test vai fail.\n"
+"        // Please note, aquele privado funções pode be tested too!\n"
+
+#: src/testing/unit_testing.md:49
+msgid "Tests can be run with `cargo test`."
+msgstr "Tests pode be run com `cargo test`."
+
+#: src/testing/unit_testing.md:73
+msgid "Tests and `?`"
+msgstr "Tests e `?`"
+
+#: src/testing/unit_testing.md:75
+msgid ""
+"None of the previous unit test examples had a return type. But in Rust 2018, "
+"your unit tests can return `Result<()>`, which lets you use `?` in them! "
+"This can make them much more concise."
+msgstr "None of o anterior unit test examples had um retorna tipo. But in Rust 2018, your unit tests pode retorna `Result<()>`, which lets you use `?` in them! Este pode make them much more concise."
+
+#: src/testing/unit_testing.md:84
+msgid "\"negative floats don't have square roots\""
+msgstr "\"negative floats don't have square roots\""
+
+#: src/testing/unit_testing.md:101
+msgid ""
+"See [\"The Edition Guide\"](https://doc.rust-lang.org/edition-guide/"
+"rust-2018/error-handling-and-panics/question-mark-in-main-and-tests.html) "
+"for more details."
+msgstr "See [\"The Edition Guide\"](https://doc.rust-lang.org/edition-guide/rust-2018/error-handling-and-panics/question-mark-in-main-and-tests.html) para more details."
+
+#: src/testing/unit_testing.md:103
+msgid "Testing panics"
+msgstr "Testing panics"
+
+#: src/testing/unit_testing.md:105
+msgid ""
+"To check functions that should panic under certain circumstances, use "
+"attribute `#[should_panic]`. This attribute accepts optional parameter "
+"`expected = ` with the text of the panic message. If your function can panic "
+"in multiple ways, it helps make sure your test is testing the correct panic."
+msgstr "To check funções aquele deve panic under certain circumstances, use attribute `#[should_panic]`. Este attribute accepts optional parâmetro `expected = ` com o text of o panic message. If your função pode panic in multiple ways, it helps make sure your test is testing o correct panic."
+
+#: src/testing/unit_testing.md:113 src/testing/doc_testing.md:45
+msgid "\"Divide-by-zero error\""
+msgstr "\"Divide-by-zero erro\""
+
+#: src/testing/unit_testing.md:115 src/testing/unit_testing.md:136
+msgid "\"Divide result is zero\""
+msgstr "\"Divide resultado is zero\""
+
+#: src/testing/unit_testing.md:143
+msgid "Running these tests gives us:"
+msgstr "Running estes tests gives us:"
+
+#: src/testing/unit_testing.md:162
+msgid "Running specific tests"
+msgstr "Running specific tests"
+
+#: src/testing/unit_testing.md:164
+msgid ""
+"To run specific tests one may specify the test name to `cargo test` command."
+msgstr "To run specific tests one may specify o test name to `cargo test` command."
+
+#: src/testing/unit_testing.md:180
+msgid ""
+"To run multiple tests one may specify part of a test name that matches all "
+"the tests that should be run."
+msgstr "To run multiple tests one may specify part of um test name aquele matches all o tests aquele deve be run."
+
+#: src/testing/unit_testing.md:198
+msgid "Ignoring tests"
+msgstr "Ignoring tests"
+
+#: src/testing/unit_testing.md:200
+msgid ""
+"Tests can be marked with the `#[ignore]` attribute to exclude some tests. Or "
+"to run them with command `cargo test -- --ignored`"
+msgstr "Tests pode be marked com o `#[ignore]` attribute to exclude some tests. Ou to run them com command `cargo test -- --ignored`"
+
+#: src/testing/doc_testing.md:3
+msgid ""
+"The primary way of documenting a Rust project is through annotating the "
+"source code. Documentation comments are written in [CommonMark Markdown "
+"specification](https://commonmark.org/) and support code blocks in them. "
+"Rust takes care about correctness, so these code blocks are compiled and "
+"used as documentation tests."
+msgstr "O primary way of documenting um Rust project is through annotating o source code. Documentation comments are written in [CommonMark Markdown specification](https://commonmark.org/) e support code blocks in them. Rust takes care about correctness, so estes code blocks are compiled e usado as documentation tests."
+
+#: src/testing/doc_testing.md:10
+msgid ""
+"/// First line is a short summary describing function.\n"
+"///\n"
+"/// The next lines present detailed documentation. Code blocks start with\n"
+"/// triple backquotes and have implicit `fn main()` inside\n"
+"/// and `extern crate <cratename>`. Assume we're testing a `playground` library\n"
+"/// crate or using the Playground's Test action:\n"
+"///\n"
+"/// ```\n"
+"/// let result = playground::add(2, 3);\n"
+"/// assert_eq!(result, 5);\n"
+"/// ```\n"
+msgstr ""
+"/// Primeiro line is um short summary describing função.\n"
+"///\n"
+"/// O próximo lines present detailed documentation. Code blocks start com\n"
+"/// triple backquotes e have implícita `fn main()` dentro\n"
+"/// e `extern crate <cratename>`. Assume we're testing um `playground` library\n"
+"/// crate ou usando o Playground's Test action:\n"
+"///\n"
+"/// ```\n"
+"/// let result = playground::add(2, 3);\n"
+"/// assert_eq!(result, 5);\n"
+"/// ```\n"
+
+#: src/testing/doc_testing.md:23
+msgid ""
+"/// Usually doc comments may include sections \"Examples\", \"Panics\" and "
+"\"Failures\".\n"
+"///\n"
+"/// The next function divides two numbers.\n"
+"///\n"
+"/// # Examples\n"
+"///\n"
+"/// ```\n"
+"/// let result = playground::div(10, 2);\n"
+"/// assert_eq!(result, 5);\n"
+"/// ```\n"
+"///\n"
+"/// # Panics\n"
+"///\n"
+"/// The function panics if the second argument is zero.\n"
+"///\n"
+"/// ```rust,should_panic\n"
+"/// // panics on division by zero\n"
+"/// playground::div(10, 0);\n"
+"/// ```\n"
+msgstr ""
+"/// Usually doc comments may include sections \"Exemplos\", \"Panics\" e \"Failures\".\n"
+"///\n"
+"/// O próxima função divides two números.\n"
+"///\n"
+"/// # Exemplos\n"
+"///\n"
+"/// ```\n"
+"/// let result = playground::div(10, 2);\n"
+"/// assert_eq!(result, 5);\n"
+"/// ```\n"
+"///\n"
+"/// # Panics\n"
+"///\n"
+"/// O função panics if o segundo argumento is zero.\n"
+"///\n"
+"/// ```rust,should_panic\n"
+"/// // panics on division by zero\n"
+"/// playground::div(10, 0);\n"
+"/// ```\n"
+
+#: src/testing/doc_testing.md:52
+msgid ""
+"Code blocks in documentation are automatically tested when running the "
+"regular `cargo test` command:"
+msgstr "Code blocks in documentation are automatically tested when running o regular `cargo test` command:"
+
+#: src/testing/doc_testing.md:71
+msgid "Motivation behind documentation tests"
+msgstr "Motivation behind documentation tests"
+
+#: src/testing/doc_testing.md:73
+msgid ""
+"The main purpose of documentation tests is to serve as examples that "
+"exercise the functionality, which is one of the most important [guidelines]"
+"(https://rust-lang-nursery.github.io/api-guidelines/documentation."
+"html#examples-use--not-try-not-unwrap-c-question-mark). It allows using "
+"examples from docs as complete code snippets. But using `?` makes "
+"compilation fail since `main` returns `unit`. The ability to hide some "
+"source lines from documentation comes to the rescue: one may write `fn "
+"try_main() -> Result<(), ErrorType>`, hide it and `unwrap` it in hidden "
+"`main`. Sounds complicated? Here's an example:"
+msgstr "O main purpose of documentation tests is to serve as examples aquele exercise o functionality, which is one of o most important [guidelines](https://rust-lang-nursery.github.io/api-guidelines/documentation.html#examples-use--not-try-not-unwrap-c-question-mark). It allows usando examples de docs as complete code snippets. But usando `?` makes compilation fail since `main` retorna `unit`. O ability to hide some source lines de documentation comes to o rescue: one may write `fn try_main() -> Result<(), ErrorType>`, hide it e `unwrap` it in hidden `main`. Sounds complicated? Here's um example:"
+
+#: src/testing/doc_testing.md:82
+msgid ""
+"/// Using hidden `try_main` in doc tests.\n"
+"///\n"
+"/// ```\n"
+"/// # // hidden lines start with `#` symbol, but they're still compilable!\n"
+"/// # fn try_main() -> Result<(), String> { // line that wraps the body "
+"shown in doc\n"
+"/// let res = playground::try_div(10, 2)?;\n"
+"/// # Ok(()) // returning from try_main\n"
+"/// # }\n"
+"/// # fn main() { // starting main that'll unwrap()\n"
+"/// #    try_main().unwrap(); // calling try_main and unwrapping\n"
+"/// #                         // so that test will panic in case of error\n"
+"/// # }\n"
+"/// ```\n"
+msgstr ""
+"/// Usando hidden `try_main` in doc tests.\n"
+"///\n"
+"/// ```\n"
+"/// # // hidden lines start with `#` symbol, but they're still compilable!\n"
+"/// # fn try_main() -> Result<(), String> { // line that wraps the body shown in doc\n"
+"/// let res = playground::try_div(10, 2)?;\n"
+"/// # Ok(()) // returning from try_main\n"
+"/// # }\n"
+"/// # fn main() { // starting main that'll unwrap()\n"
+"/// #    try_main().unwrap(); // calling try_main and unwrapping\n"
+"/// #                         // so that test will panic in case of error\n"
+"/// # }\n"
+"/// ```\n"
+
+#: src/testing/doc_testing.md:97
+msgid "\"Divide-by-zero\""
+msgstr "\"Divide-by-zero\""
+
+#: src/testing/doc_testing.md:106
+msgid ""
+"[RFC505](https://github.com/rust-lang/rfcs/blob/master/text/0505-api-comment-"
+"conventions.md) on documentation style"
+msgstr "[RFC505](https://github.com/rust-lang/rfcs/blob/master/text/0505-api-comment-conventions.md) on documentation style"
+
+#: src/testing/doc_testing.md:107
+msgid ""
+"[API Guidelines](https://rust-lang-nursery.github.io/api-guidelines/"
+"documentation.html) on documentation guidelines"
+msgstr "[API Guidelines](https://rust-lang-nursery.github.io/api-guidelines/documentation.html) on documentation guidelines"
+
+#: src/testing/integration_testing.md:3
+msgid ""
+"[Unit tests](unit_testing.md) are testing one module in isolation at a time: "
+"they're small and can test private code. Integration tests are external to "
+"your crate and use only its public interface in the same way any other code "
+"would. Their purpose is to test that many parts of your library work "
+"correctly together."
+msgstr "[Unit tests](unit_testing.md) are testing one módulo in isolation at um time: they're small e pode test privado code. Integration tests are external to your crate e use only its público interface in o mesmo way any other code would. Their purpose is to test aquele many parts of your library work correctly together."
+
+#: src/testing/integration_testing.md:8
+msgid "Cargo looks for integration tests in `tests` directory next to `src`."
+msgstr "Cargo looks para integration tests in `tests` directory próximo to `src`."
+
+#: src/testing/integration_testing.md:10 src/testing/dev_dependencies.md:17
+msgid "File `src/lib.rs`:"
+msgstr "Arquivo `src/lib.rs`:"
+
+#: src/testing/integration_testing.md:13
+msgid "// Define this in a crate called `adder`.\n"
+msgstr ""
+"// Define este in um crate chamado `adder`.\n"
+
+#: src/testing/integration_testing.md:19
+msgid "File with test: `tests/integration_test.rs`:"
+msgstr "Arquivo com test: `tests/integration_test.rs`:"
+
+#: src/testing/integration_testing.md:28
+msgid "Running tests with `cargo test` command:"
+msgstr "Running tests com `cargo test` command:"
+
+#: src/testing/integration_testing.md:50
+msgid ""
+"Each Rust source file in the `tests` directory is compiled as a separate "
+"crate. In order to share some code between integration tests we can make a "
+"module with public functions, importing and using it within tests."
+msgstr "Each Rust source arquivo in o `tests` directory is compiled as um separate crate. In order to share some code between integration tests we pode make um módulo com público funções, importing e usando it within tests."
+
+#: src/testing/integration_testing.md:54
+msgid "File `tests/common/mod.rs`:"
+msgstr "Arquivo `tests/common/mod.rs`:"
+
+#: src/testing/integration_testing.md:58
+msgid ""
+"// some setup code, like creating required files/directories, starting\n"
+"    // servers, etc.\n"
+msgstr ""
+"// some setup code, like creating required arquivos/directories, starting\n"
+"    // servers, etc.\n"
+
+#: src/testing/integration_testing.md:63
+msgid "File with test: `tests/integration_test.rs`"
+msgstr "Arquivo com test: `tests/integration_test.rs`"
+
+#: src/testing/integration_testing.md:66
+msgid "// importing common module.\n"
+msgstr ""
+"// importing common módulo.\n"
+
+#: src/testing/integration_testing.md:71
+msgid "// using common code.\n"
+msgstr ""
+"// usando common code.\n"
+
+#: src/testing/integration_testing.md:77
+msgid ""
+"Creating the module as `tests/common.rs` also works, but is not recommended "
+"because the test runner will treat the file as a test crate and try to run "
+"tests inside it."
+msgstr "Creating o módulo as `tests/common.rs` also works, but is not recommended porque o test runner vai treat o arquivo as um test crate e try to run tests dentro it."
+
+#: src/testing/dev_dependencies.md:1
+msgid "Development dependencies"
+msgstr "Development dependencies"
+
+#: src/testing/dev_dependencies.md:3
+msgid ""
+"Sometimes there is a need to have dependencies for tests (or examples, or "
+"benchmarks) only. Such dependencies are added to `Cargo.toml` in the `[dev-"
+"dependencies]` section. These dependencies are not propagated to other "
+"packages which depend on this package."
+msgstr "Sometimes there is um need to have dependencies para tests (ou examples, ou benchmarks) only. Such dependencies are added to `Cargo.toml` in o `[dev-dependencies]` section. Estes dependencies are not propagated to other packages which depend on este package."
+
+#: src/testing/dev_dependencies.md:8
+msgid ""
+"One such example is [`pretty_assertions`](https://docs.rs/"
+"pretty_assertions/1.0.0/pretty_assertions/index.html), which extends "
+"standard `assert_eq!` and `assert_ne!` macros, to provide colorful diff.  \n"
+"File `Cargo.toml`:"
+msgstr ""
+"One such example is [`pretty_assertions`](https://docs.rs/pretty_assertions/1.0.0/pretty_assertions/index.html), which extends standard `assert_eq!` e `assert_ne!` macros, to provide colorful diff.  \n"
+"Arquivo `Cargo.toml`:"
+
+#: src/testing/dev_dependencies.md:11
+msgid ""
+"```toml\n"
+"# standard crate data is left out\n"
+"[dev-dependencies]\n"
+"pretty_assertions = \"1\"\n"
+"```"
+msgstr ""
+"```toml\n"
+"# standard crate data is left out\n"
+"[dev-dependencies]\n"
+"pretty_assertions = \"1\"\n"
+"```"
+
+#: src/testing/dev_dependencies.md:27
+msgid "// crate for test-only use. Cannot be used in non-test code.\n"
+msgstr ""
+"// crate para test-only use. Não pode be usado in non-test code.\n"
+
+#: src/testing/dev_dependencies.md:38
+msgid ""
+"[Cargo](http://doc.crates.io/specifying-dependencies.html) docs on "
+"specifying dependencies."
+msgstr "[Cargo](http://doc.crates.io/specifying-dependencies.html) docs on specifying dependencies."
+
+#: src/unsafe.md:3
+msgid ""
+"As an introduction to this section, to borrow from [the official docs]"
+"(https://doc.rust-lang.org/book/ch19-01-unsafe-rust.html), \"one should try "
+"to minimize the amount of unsafe code in a code base.\" With that in mind, "
+"let's get started! Unsafe annotations in Rust are used to bypass protections "
+"put in place by the compiler; specifically, there are four primary things "
+"that unsafe is used for:"
+msgstr "As um introduction to este section, to emprestar de [the official docs](https://doc.rust-lang.org/book/ch19-01-unsafe-rust.html), \"one deve try to minimize o amount of unsafe code in um code base.\" Com aquele in mind, let's get started! Unsafe annotations in Rust are usado to bypass protections put in place by o compiler; specifically, there are four primary things aquele unsafe is usado para:"
+
+#: src/unsafe.md:9
+msgid "dereferencing raw pointers"
+msgstr "dereferencing raw pointers"
+
+#: src/unsafe.md:10
+msgid ""
+"calling functions or methods which are `unsafe` (including calling a "
+"function over FFI, see [a previous chapter](std_misc/ffi.md) of the book)"
+msgstr "calling funções ou métodos which are `unsafe` (including calling um função over FFI, see [a previous chapter](std_misc/ffi.md) of o book)"
+
+#: src/unsafe.md:12
+msgid "accessing or modifying static mutable variables"
+msgstr "accessing ou modifying static mutável variáveis"
+
+#: src/unsafe.md:13
+msgid "implementing unsafe traits"
+msgstr "implementing unsafe traits"
+
+#: src/unsafe.md:15
+msgid "Raw Pointers"
+msgstr "Raw Pointers"
+
+#: src/unsafe.md:17
+msgid ""
+"Raw pointers `*` and references `&T` function similarly, but references are "
+"always safe because they are guaranteed to point to valid data due to the "
+"borrow checker. Dereferencing a raw pointer can only be done through an "
+"unsafe block."
+msgstr "Raw pointers `*` e references `&T` função similarly, but references are always seguro porque they are guaranteed to point to válido data due to o emprestar checker. Dereferencing um raw pointer pode only be done through um unsafe block."
+
+#: src/unsafe.md:32
+msgid "Calling Unsafe Functions"
+msgstr "Chamaing Unsafe Funções"
+
+#: src/unsafe.md:34
+msgid ""
+"Some functions can be declared as `unsafe`, meaning it is the programmer's "
+"responsibility to ensure correctness instead of the compiler's. One example "
+"of this is [`std::slice::from_raw_parts`](https://doc.rust-lang.org/std/"
+"slice/fn.from_raw_parts.html) which will create a slice given a pointer to "
+"the first element and a length."
+msgstr "Some funções pode be declared as `unsafe`, meaning it is o programmer's responsibility to ensure correctness instead of o compiler's. One example of este is [`std::slice::from_raw_parts`](https://doc.rust-lang.org/std/slice/fn.from_raw_parts.html) which vai create um slice given um pointer to o primeiro element e um length."
+
+#: src/unsafe.md:56
+msgid ""
+"For `slice::from_raw_parts`, one of the assumptions which _must_ be upheld "
+"is that the pointer passed in points to valid memory and that the memory "
+"pointed to is of the correct type. If these invariants aren't upheld then "
+"the program's behaviour is undefined and there is no knowing what will "
+"happen."
+msgstr "Para `slice::from_raw_parts`, one of o assumptions which _must_ be upheld is aquele o pointer passed in points to válido memory e aquele o memory pointed to is of o correct tipo. If estes invariants aren't upheld then o program's behaviour is undefined e there is no knowing what vai happen."
+
+#: src/unsafe/asm.md:3
+msgid ""
+"Rust provides support for inline assembly via the `asm!` macro. It can be "
+"used to embed handwritten assembly in the assembly output generated by the "
+"compiler. Generally this should not be necessary, but might be where the "
+"required performance or timing cannot be otherwise achieved. Accessing low "
+"level hardware primitives, e.g. in kernel code, may also demand this "
+"functionality."
+msgstr "Rust provides support para inline assembly via o `asm!` macro. It pode be usado to embed handwritten assembly in o assembly saída generated by o compiler. Generally este deve not be necessary, but might be where o required performance ou timing não pode be otherwise achieved. Accessing low level hardware primitives, e.g. in kernel code, may also demand este functionality."
+
+#: src/unsafe/asm.md:8
+msgid ""
+"**Note**: the examples here are given in x86/x86-64 assembly, but other "
+"architectures are also supported."
+msgstr "**Note**: o examples here are given in x86/x86-64 assembly, but other architectures are also supported."
+
+#: src/unsafe/asm.md:10
+msgid "Inline assembly is currently supported on the following architectures:"
+msgstr "Inline assembly is currently supported on o following architectures:"
+
+#: src/unsafe/asm.md:12
+msgid "x86 and x86-64"
+msgstr "x86 e x86-64"
+
+#: src/unsafe/asm.md:13
+msgid "ARM"
+msgstr "ARM"
+
+#: src/unsafe/asm.md:14
+msgid "AArch64"
+msgstr "AArch64"
+
+#: src/unsafe/asm.md:15
+msgid "RISC-V"
+msgstr "RISC-V"
+
+#: src/unsafe/asm.md:17
+msgid "Basic usage"
+msgstr "Basic usage"
+
+#: src/unsafe/asm.md:19
+msgid "Let us start with the simplest possible example:"
+msgstr "Let us start com o simplest possible example:"
+
+#: src/unsafe/asm.md:22 src/unsafe/asm.md:42 src/unsafe/asm.md:69
+#: src/unsafe/asm.md:107 src/unsafe/asm.md:124 src/unsafe/asm.md:149
+#: src/unsafe/asm.md:183 src/unsafe/asm.md:204 src/unsafe/asm.md:221
+#: src/unsafe/asm.md:260 src/unsafe/asm.md:296 src/unsafe/asm.md:312
+#: src/unsafe/asm.md:338 src/unsafe/asm.md:376 src/unsafe/asm.md:403
+#: src/unsafe/asm.md:427 src/unsafe/asm.md:465
+msgid "\"x86_64\""
+msgstr "\"x86_64\""
+
+#: src/unsafe/asm.md:26
+msgid "\"nop\""
+msgstr "\"nop\""
+
+#: src/unsafe/asm.md:31
+msgid ""
+"This will insert a NOP (no operation) instruction into the assembly "
+"generated by the compiler. Note that all `asm!` invocations have to be "
+"inside an `unsafe` block, as they could insert arbitrary instructions and "
+"break various invariants. The instructions to be inserted are listed in the "
+"first argument of the `asm!` macro as a string literal."
+msgstr "Este vai insert um NOP (no operation) instruction no assembly generated by o compiler. Note aquele all `asm!` invocations have to be dentro um `unsafe` block, as they could insert arbitrary instructions e break various invariants. O instructions to be inserted are listed in o primeiro argumento of o `asm!` macro as um string literal."
+
+#: src/unsafe/asm.md:36
+msgid "Inputs and outputs"
+msgstr "Inputs e outputs"
+
+#: src/unsafe/asm.md:38
+msgid ""
+"Now inserting an instruction that does nothing is rather boring. Let us do "
+"something that actually acts on data:"
+msgstr "Now inserting um instruction aquele does nothing is rather boring. Let us do something aquele actually acts on data:"
+
+#: src/unsafe/asm.md:47
+msgid "\"mov {}, 5\""
+msgstr "\"mov {}, 5\""
+
+#: src/unsafe/asm.md:53
+msgid ""
+"This will write the value `5` into the `u64` variable `x`. You can see that "
+"the string literal we use to specify instructions is actually a template "
+"string. It is governed by the same rules as Rust [format strings](https://"
+"doc.rust-lang.org/std/fmt/#syntax). The arguments that are inserted into the "
+"template however look a bit different than you may be familiar with. First "
+"we need to specify if the variable is an input or an output of the inline "
+"assembly. In this case it is an output. We declared this by writing `out`. "
+"We also need to specify in what kind of register the assembly expects the "
+"variable. In this case we put it in an arbitrary general purpose register by "
+"specifying `reg`. The compiler will choose an appropriate register to insert "
+"into the template and will read the variable from there after the inline "
+"assembly finishes executing."
+msgstr "Este vai write o valor `5` no `u64` variável `x`. You pode see aquele o string literal we use to specify instructions is actually um template string. It is governed by o mesmo rules as Rust [format strings](https://doc.rust-lang.org/std/fmt/#syntax). O argumentos aquele are inserted no template however look um bit diferente than you may be familiar com. Primeiro we need to specify if o variável is um entrada ou um saída of o inline assembly. In este case it is um saída. We declared este by writing `out`. We also need to specify in what kind of register o assembly expects o variável. In este case we put it in um arbitrary general purpose register by specifying `reg`. O compiler vai choose um appropriate register to insert no template e vai read o variável de there after o inline assembly finishes executing."
+
+#: src/unsafe/asm.md:66
+msgid "Let us see another example that also uses an input:"
+msgstr "Let us see another example aquele also uses um entrada:"
+
+#: src/unsafe/asm.md:76
+msgid "\"mov {0}, {1}\""
+msgstr "\"mov {0}, {1}\""
+
+#: src/unsafe/asm.md:77 src/unsafe/asm.md:112 src/unsafe/asm.md:130
+msgid "\"add {0}, 5\""
+msgstr "\"add {0}, 5\""
+
+#: src/unsafe/asm.md:86
+msgid ""
+"This will add `5` to the input in variable `i` and write the result to "
+"variable `o`. The particular way this assembly does this is first copying "
+"the value from `i` to the output, and then adding `5` to it."
+msgstr "Este vai add `5` to a entrada in variável `i` e write o resultado to variável `o`. O particular way este assembly does este is primeiro copying o valor de `i` to a saída, e then adding `5` to it."
+
+#: src/unsafe/asm.md:90
+msgid "The example shows a few things:"
+msgstr "O example shows um few things:"
+
+#: src/unsafe/asm.md:92
+msgid ""
+"First, we can see that `asm!` allows multiple template string arguments; "
+"each one is treated as a separate line of assembly code, as if they were all "
+"joined together with newlines between them. This makes it easy to format "
+"assembly code."
+msgstr "Primeiro, we pode see aquele `asm!` allows multiple template string argumentos; each one is treated as um separate line of assembly code, as if they were all joined together com newlines between them. Este makes it easy to format assembly code."
+
+#: src/unsafe/asm.md:97
+msgid ""
+"Second, we can see that inputs are declared by writing `in` instead of `out`."
+msgstr "Segundo, we pode see aquele inputs are declared by writing `in` instead of `out`."
+
+#: src/unsafe/asm.md:99
+msgid ""
+"Third, we can see that we can specify an argument number, or name as in any "
+"format string. For inline assembly templates this is particularly useful as "
+"arguments are often used more than once. For more complex inline assembly "
+"using this facility is generally recommended, as it improves readability, "
+"and allows reordering instructions without changing the argument order."
+msgstr "Third, we pode see aquele we pode specify um argumento número, ou name as in any format string. Para inline assembly templates este is particularly useful as argumentos are often usado more than once. Para more complex inline assembly usando este facility is generally recommended, as it improves readability, e allows reordering instructions sem changing o argumento order."
+
+#: src/unsafe/asm.md:104
+msgid "We can further refine the above example to avoid the `mov` instruction:"
+msgstr "We pode further refine o acima example to avoid o `mov` instruction:"
+
+#: src/unsafe/asm.md:118
+msgid ""
+"We can see that `inout` is used to specify an argument that is both input "
+"and output. This is different from specifying an input and output separately "
+"in that it is guaranteed to assign both to the same register."
+msgstr "We pode see aquele `inout` is usado to specify um argumento aquele is both entrada e saída. Este is diferente de specifying um entrada e saída separately in aquele it is guaranteed to assign both to o mesmo register."
+
+#: src/unsafe/asm.md:121
+msgid ""
+"It is also possible to specify different variables for the input and output "
+"parts of an `inout` operand:"
+msgstr "It is also possible to specify diferente variáveis para a entrada e saída parts of um `inout` operand:"
+
+#: src/unsafe/asm.md:136
+msgid "Late output operands"
+msgstr "Late saída operands"
+
+#: src/unsafe/asm.md:138
+msgid ""
+"The Rust compiler is conservative with its allocation of operands. It is "
+"assumed that an `out` can be written at any time, and can therefore not "
+"share its location with any other argument. However, to guarantee optimal "
+"performance it is important to use as few registers as possible, so they "
+"won't have to be saved and reloaded around the inline assembly block. To "
+"achieve this Rust provides a `lateout` specifier. This can be used on any "
+"output that is written only after all inputs have been consumed. There is "
+"also an `inlateout` variant of this specifier."
+msgstr "O Rust compiler is conservative com its allocation of operands. It is assumed aquele um `out` pode be written at any time, e pode therefore not share its location com any other argumento. However, to guarantee optimal performance it is important to use as few registers as possible, so they won't have to be saved e reloaded around o inline assembly block. To achieve este Rust provides um `lateout` specifier. Este pode be usado on any saída aquele is written only after all inputs have been consumed. There is also um `inlateout` variant of este specifier."
+
+#: src/unsafe/asm.md:146
+msgid ""
+"Here is an example where `inlateout` _cannot_ be used in `release` mode or "
+"other optimized cases:"
+msgstr "Here is an example where `inlateout` _cannot_ be used in `release` mode or other optimized cases:"
+
+#: src/unsafe/asm.md:157 src/unsafe/asm.md:189 src/unsafe/asm.md:472
+msgid "\"add {0}, {1}\""
+msgstr "\"add {0}, {1}\""
+
+#: src/unsafe/asm.md:158
+msgid "\"add {0}, {2}\""
+msgstr "\"add {0}, {2}\""
+
+#: src/unsafe/asm.md:168
+msgid ""
+"In unoptimized cases (e.g. `Debug` mode), replacing `inout(reg) a` with "
+"`inlateout(reg) a` in the above example can continue to give the expected "
+"result. However, with `release` mode or other optimized cases, using "
+"`inlateout(reg) a` can instead lead to the final value `a = 16`, causing the "
+"assertion to fail."
+msgstr "In unoptimized cases (e.g. `Debug` mode), replacing `inout(reg) a` com `inlateout(reg) a` in o acima example pode continue to give o expected resultado. However, com `release` mode ou other optimized cases, usando `inlateout(reg) a` pode instead lead to o final valor `a = 16`, causing o assertion to fail."
+
+#: src/unsafe/asm.md:173
+msgid ""
+"This is because in optimized cases, the compiler is free to allocate the "
+"same register for inputs `b` and `c` since it knows that they have the same "
+"value. Furthermore, when `inlateout` is used, `a` and `c` could be allocated "
+"to the same register, in which case the first `add` instruction would "
+"overwrite the initial load from variable `c`. This is in contrast to how "
+"using `inout(reg) a` ensures a separate register is allocated for `a`."
+msgstr "Este is porque in optimized cases, o compiler is free to allocate o mesmo register para inputs `b` e `c` since it knows aquele they have o mesmo valor. Furthermore, when `inlateout` is usado, `a` e `c` could be allocated to o mesmo register, in which case o primeiro `add` instruction would overwrite o initial load de variável `c`. Este is in contrast to how usando `inout(reg) a` ensures um separate register is allocated para `a`."
+
+#: src/unsafe/asm.md:179
+msgid ""
+"However, the following example can use `inlateout` since the output is only "
+"modified after all input registers have been read:"
+msgstr "However, o following example pode use `inlateout` since a saída is only modified after all entrada registers have been read:"
+
+#: src/unsafe/asm.md:195
+msgid ""
+"As you can see, this assembly fragment will still work correctly if `a` and "
+"`b` are assigned to the same register."
+msgstr "As you pode see, este assembly fragment vai still work correctly if `a` e `b` are assigned to o mesmo register."
+
+#: src/unsafe/asm.md:197
+msgid "Explicit register operands"
+msgstr "Explícita register operands"
+
+#: src/unsafe/asm.md:199
+msgid ""
+"Some instructions require that the operands be in a specific register. "
+"Therefore, Rust inline assembly provides some more specific constraint "
+"specifiers. While `reg` is generally available on any architecture, explicit "
+"registers are highly architecture specific. E.g. for x86 the general purpose "
+"registers `eax`, `ebx`, `ecx`, `edx`, `ebp`, `esi`, and `edi` among others "
+"can be addressed by their name."
+msgstr "Some instructions require aquele o operands be in um specific register. Therefore, Rust inline assembly provides some more specific constraint specifiers. While `reg` is generally available on any architecture, explícita registers are highly architecture specific. E.g. para x86 o general purpose registers `eax`, `ebx`, `ecx`, `edx`, `ebp`, `esi`, e `edi` among others pode be addressed by their name."
+
+#: src/unsafe/asm.md:209
+msgid "\"out 0x64, eax\""
+msgstr "\"out 0x64, eax\""
+
+#: src/unsafe/asm.md:209 src/unsafe/asm.md:285
+msgid "\"eax\""
+msgstr "\"eax\""
+
+#: src/unsafe/asm.md:214
+msgid ""
+"In this example we call the `out` instruction to output the content of the "
+"`cmd` variable to port `0x64`. Since the `out` instruction only accepts "
+"`eax` (and its sub registers) as operand we had to use the `eax` constraint "
+"specifier."
+msgstr "In este example we call o `out` instruction ta saída o content of o `cmd` variável to port `0x64`. Since o `out` instruction only accepts `eax` (e its sub registers) as operand we had to use o `eax` constraint specifier."
+
+#: src/unsafe/asm.md:216
+msgid ""
+"**Note**: unlike other operand types, explicit register operands cannot be "
+"used in the template string: you can't use `{}` and should write the "
+"register name directly instead. Also, they must appear at the end of the "
+"operand list after all other operand types."
+msgstr "**Note**: unlike other operand tipos, explícita register operands não pode be usado in o template string: you pode't use `{}` e deve write o register name directly instead. Also, they deve appear at o end of o operand list after all other operand tipos."
+
+#: src/unsafe/asm.md:218
+msgid "Consider this example which uses the x86 `mul` instruction:"
+msgstr "Consider este example which uses o x86 `mul` instruction:"
+
+#: src/unsafe/asm.md:230
+msgid ""
+"// The x86 mul instruction takes rax as an implicit input and writes\n"
+"            // the 128-bit result of the multiplication to rax:rdx.\n"
+"            \"mul {}\""
+msgstr ""
+"// O x86 mul instruction takes rax as um implícita entrada e writes\n"
+"            // o 128-bit resultado of o multiplication to rax:rdx.\n"
+"            \"mul {}\""
+
+#: src/unsafe/asm.md:234 src/unsafe/asm.md:356
+msgid "\"rax\""
+msgstr "\"rax\""
+
+#: src/unsafe/asm.md:235
+msgid "\"rdx\""
+msgstr "\"rdx\""
+
+#: src/unsafe/asm.md:244
+msgid ""
+"This uses the `mul` instruction to multiply two 64-bit inputs with a 128-bit "
+"result. The only explicit operand is a register, that we fill from the "
+"variable `a`. The second operand is implicit, and must be the `rax` "
+"register, which we fill from the variable `b`. The lower 64 bits of the "
+"result are stored in `rax` from which we fill the variable `lo`. The higher "
+"64 bits are stored in `rdx` from which we fill the variable `hi`."
+msgstr "Este uses o `mul` instruction to multiply two 64-bit inputs com um 128-bit resultado. O only explícita operand is um register, aquele we fill do variável `a`. O segundo operand is implícita, e deve be o `rax` register, which we fill do variável `b`. O lower 64 bits of o resultado are stored in `rax` de which we fill o variável `lo`. O higher 64 bits are stored in `rdx` de which we fill o variável `hi`."
+
+#: src/unsafe/asm.md:250
+msgid "Clobbered registers"
+msgstr "Clobbered registers"
+
+#: src/unsafe/asm.md:252
+msgid ""
+"In many cases inline assembly will modify state that is not needed as an "
+"output. Usually this is either because we have to use a scratch register in "
+"the assembly or because instructions modify state that we don't need to "
+"further examine. This state is generally referred to as being \"clobbered\". "
+"We need to tell the compiler about this since it may need to save and "
+"restore this state around the inline assembly block."
+msgstr "In many cases inline assembly vai modify state aquele is not needed as um saída. Usually este is either porque we have to use um scratch register in o assembly ou porque instructions modify state aquele we don't need to further examine. Este state is generally referred to as being \"clobbered\". We need to tell o compiler about este since it may need to save e restore este state around o inline assembly block."
+
+#: src/unsafe/asm.md:262
+msgid "// three entries of four bytes each\n"
+msgstr ""
+"// three entries of four bytes each\n"
+
+#: src/unsafe/asm.md:264
+msgid ""
+"// String is stored as ascii in ebx, edx, ecx in order\n"
+"    // Because ebx is reserved, the asm needs to preserve the value of it.\n"
+"    // So we push and pop it around the main asm.\n"
+"    // 64 bit mode on 64 bit processors does not allow pushing/popping of\n"
+"    // 32 bit registers (like ebx), so we have to use the extended rbx "
+"register instead.\n"
+msgstr ""
+"// String is stored as ascii in ebx, edx, ecx in order\n"
+"    // Porque ebx is reserved, o asm needs to preserve o valor of it.\n"
+"    // So we push e pop it around o main asm.\n"
+"    // 64 bit mode on 64 bit processors does not allow pushing/popping of\n"
+"    // 32 bit registers (like ebx), so we have to use o extended rbx register instead.\n"
+
+#: src/unsafe/asm.md:272
+msgid "\"push rbx\""
+msgstr "\"push rbx\""
+
+#: src/unsafe/asm.md:273
+msgid "\"cpuid\""
+msgstr "\"cpuid\""
+
+#: src/unsafe/asm.md:274
+msgid "\"mov [rdi], ebx\""
+msgstr "\"mov [rdi], ebx\""
+
+#: src/unsafe/asm.md:275
+msgid "\"mov [rdi + 4], edx\""
+msgstr "\"mov [rdi + 4], edx\""
+
+#: src/unsafe/asm.md:276
+msgid "\"mov [rdi + 8], ecx\""
+msgstr "\"mov [rdi + 8], ecx\""
+
+#: src/unsafe/asm.md:277
+msgid "\"pop rbx\""
+msgstr "\"pop rbx\""
+
+#: src/unsafe/asm.md:278
+msgid ""
+"// We use a pointer to an array for storing the values to simplify\n"
+"            // the Rust code at the cost of a couple more asm instructions\n"
+"            // This is more explicit with how the asm works however, as "
+"opposed\n"
+"            // to explicit register outputs such as `out(\"ecx\") val`\n"
+"            // The *pointer itself* is only an input even though it's "
+"written behind\n"
+msgstr ""
+"// We use um pointer to um array para storing o valores to simplify\n"
+"            // o Rust code at o cost of um couple more asm instructions\n"
+"            // Este is more explícita com how o asm works however, as opposed\n"
+"            // to explícita register outputs such as `out(\"ecx\") val`\n"
+"            // O *pointer itself* is only um entrada even though it's written behind\n"
+
+#: src/unsafe/asm.md:283 src/unsafe/asm.md:354
+msgid "\"rdi\""
+msgstr "\"rdi\""
+
+#: src/unsafe/asm.md:284
+msgid "// select cpuid 0, also specify eax as clobbered\n"
+msgstr ""
+"// select cpuid 0, also specify eax as clobbered\n"
+
+#: src/unsafe/asm.md:286
+msgid "// cpuid clobbers these registers too\n"
+msgstr ""
+"// cpuid clobbers estes registers too\n"
+
+#: src/unsafe/asm.md:287
+msgid "\"ecx\""
+msgstr "\"ecx\""
+
+#: src/unsafe/asm.md:288
+msgid "\"edx\""
+msgstr "\"edx\""
+
+#: src/unsafe/asm.md:293
+msgid "\"CPU Manufacturer ID: {}\""
+msgstr "\"CPU Manufacturer ID: {}\""
+
+#: src/unsafe/asm.md:300
+msgid ""
+"In the example above we use the `cpuid` instruction to read the CPU "
+"manufacturer ID. This instruction writes to `eax` with the maximum supported "
+"`cpuid` argument and `ebx`, `edx`, and `ecx` with the CPU manufacturer ID as "
+"ASCII bytes in that order."
+msgstr "In o example acima we use o `cpuid` instruction to read o CPU manufacturer ID. Este instruction writes to `eax` com o maximum supported `cpuid` argumento e `ebx`, `edx`, e `ecx` com o CPU manufacturer ID as ASCII bytes in aquele order."
+
+#: src/unsafe/asm.md:303
+msgid ""
+"Even though `eax` is never read we still need to tell the compiler that the "
+"register has been modified so that the compiler can save any values that "
+"were in these registers before the asm. This is done by declaring it as an "
+"output but with `_` instead of a variable name, which indicates that the "
+"output value is to be discarded."
+msgstr "Even though `eax` is never read we still need to tell o compiler aquele o register has been modified so aquele o compiler pode save any valores aquele were in estes registers before o asm. Este is done by declaring it as um saída but com `_` instead of uma variável name, which indicates aquele a saída valor is to be discarded."
+
+#: src/unsafe/asm.md:305
+msgid ""
+"This code also works around the limitation that `ebx` is a reserved register "
+"by LLVM. That means that LLVM assumes that it has full control over the "
+"register and it must be restored to its original state before exiting the "
+"asm block, so it cannot be used as an input or output **except** if the "
+"compiler uses it to fulfill a general register class (e.g. `in(reg)`). This "
+"makes `reg` operands dangerous when using reserved registers as we could "
+"unknowingly corrupt our input or output because they share the same register."
+msgstr "Este code also works around o limitation aquele `ebx` is um reserved register by LLVM. Aquele means aquele LLVM assumes aquele it has full control over o register e it deve be restored to its original state before exiting o asm block, so it não pode be usado as um entrada ou saída **except** if o compiler uses it to fulfill um general register class (e.g. `in(reg)`). Este makes `reg` operands dangerous when usando reserved registers as we could unknowingly corrupt our entrada ou saída porque they share o mesmo register."
+
+#: src/unsafe/asm.md:307
+msgid ""
+"To work around this we use `rdi` to store the pointer to the output array, "
+"save `ebx` via `push`, read from `ebx` inside the asm block into the array "
+"and then restore `ebx` to its original state via `pop`. The `push` and `pop` "
+"use the full 64-bit `rbx` version of the register to ensure that the entire "
+"register is saved. On 32 bit targets the code would instead use `ebx` in the "
+"`push`/`pop`."
+msgstr "To work around este we use `rdi` to store o pointer to a saída array, save `ebx` via `push`, read de `ebx` dentro o asm block no array e then restore `ebx` to its original state via `pop`. O `push` e `pop` use o full 64-bit `rbx` version of o register to ensure aquele o entire register is saved. On 32 bit targets o code would instead use `ebx` in o `push`/`pop`."
+
+#: src/unsafe/asm.md:309
+msgid ""
+"This can also be used with a general register class to obtain a scratch "
+"register for use inside the asm code:"
+msgstr "Este pode also be usado com um general register class to obtain um scratch register para use dentro o asm code:"
+
+#: src/unsafe/asm.md:314
+msgid "// Multiply x by 6 using shifts and adds\n"
+msgstr ""
+"// Multiply x by 6 usando shifts e adds\n"
+
+#: src/unsafe/asm.md:319
+msgid "\"mov {tmp}, {x}\""
+msgstr "\"mov {tmp}, {x}\""
+
+#: src/unsafe/asm.md:320
+msgid "\"shl {tmp}, 1\""
+msgstr "\"shl {tmp}, 1\""
+
+#: src/unsafe/asm.md:321
+msgid "\"shl {x}, 2\""
+msgstr "\"shl {x}, 2\""
+
+#: src/unsafe/asm.md:322
+msgid "\"add {x}, {tmp}\""
+msgstr "\"add {x}, {tmp}\""
+
+#: src/unsafe/asm.md:331
+msgid "Symbol operands and ABI clobbers"
+msgstr "Symbol operands e ABI clobbers"
+
+#: src/unsafe/asm.md:333
+msgid ""
+"By default, `asm!` assumes that any register not specified as an output will "
+"have its contents preserved by the assembly code. The [`clobber_abi`]"
+"(https://doc.rust-lang.org/stable/reference/inline-assembly.html#abi-"
+"clobbers) argument to `asm!` tells the compiler to automatically insert the "
+"necessary clobber operands according to the given calling convention ABI: "
+"any register which is not fully preserved in that ABI will be treated as "
+"clobbered.  Multiple `clobber_abi` arguments may be provided and all "
+"clobbers from all specified ABIs will be inserted."
+msgstr "By default, `asm!` assumes aquele any register not specified as um saída vai have its contents preserved by o assembly code. O [`clobber_abi`](https://doc.rust-lang.org/stable/reference/inline-assembly.html#abi-clobbers) argumento to `asm!` tells o compiler to automatically insert o necessary clobber operands according to o given calling convention ABI: any register which is not fully preserved in aquele ABI vai be treated as clobbered.  Multiple `clobber_abi` argumentos may be provided e all clobbers de all specified ABIs vai be inserted."
+
+#: src/unsafe/asm.md:341 src/unsafe/asm.md:359
+msgid "\"C\""
+msgstr "\"C\""
+
+#: src/unsafe/asm.md:342
+msgid "\"arg = {}\""
+msgstr "\"arg = {}\""
+
+#: src/unsafe/asm.md:350
+msgid "\"call {}\""
+msgstr "\"call {}\""
+
+#: src/unsafe/asm.md:351
+msgid "// Function pointer to call\n"
+msgstr ""
+"// Função pointer to call\n"
+
+#: src/unsafe/asm.md:353
+msgid "// 1st argument in rdi\n"
+msgstr ""
+"// 1st argumento in rdi\n"
+
+#: src/unsafe/asm.md:355
+msgid "// Return value in rax\n"
+msgstr ""
+"// Retorna valor in rax\n"
+
+#: src/unsafe/asm.md:357
+msgid ""
+"// Mark all registers which are not preserved by the \"C\" calling\n"
+"            // convention as clobbered.\n"
+msgstr ""
+"// Mark all registers which are not preserved by o \"C\" calling\n"
+"            // convention as clobbered.\n"
+
+#: src/unsafe/asm.md:367
+msgid "Register template modifiers"
+msgstr "Register template modifiers"
+
+#: src/unsafe/asm.md:369
+msgid ""
+"In some cases, fine control is needed over the way a register name is "
+"formatted when inserted into the template string. This is needed when an "
+"architecture's assembly language has several names for the same register, "
+"each typically being a \"view\" over a subset of the register (e.g. the low "
+"32 bits of a 64-bit register)."
+msgstr "In some cases, fine control is needed over o way um register name is formatted when inserted no template string. Este is needed when um architecture's assembly language has several names para o mesmo register, each typically being um \"view\" over um subset of o register (e.g. o low 32 bits of um 64-bit register)."
+
+#: src/unsafe/asm.md:371
+msgid ""
+"By default the compiler will always choose the name that refers to the full "
+"register size (e.g. `rax` on x86-64, `eax` on x86, etc)."
+msgstr "By default o compiler vai always choose o name aquele refers to o full register size (e.g. `rax` on x86-64, `eax` on x86, etc)."
+
+#: src/unsafe/asm.md:373
+msgid ""
+"This default can be overridden by using modifiers on the template string "
+"operands, just like you would with format strings:"
+msgstr "This default can be overridden by using modifiers on the template string operands, just like you would with format strings:"
+
+#: src/unsafe/asm.md:382
+msgid "\"mov {0:h}, {0:l}\""
+msgstr "\"mov {0:h}, {0:l}\""
+
+#: src/unsafe/asm.md:389
+msgid ""
+"In this example, we use the `reg_abcd` register class to restrict the "
+"register allocator to the 4 legacy x86 registers (`ax`, `bx`, `cx`, `dx`) of "
+"which the first two bytes can be addressed independently."
+msgstr "In este example, we use o `reg_abcd` register class to restrict o register allocator to o 4 legacy x86 registers (`ax`, `bx`, `cx`, `dx`) of which o primeiro two bytes pode be addressed independently."
+
+#: src/unsafe/asm.md:391
+msgid ""
+"Let us assume that the register allocator has chosen to allocate `x` in the "
+"`ax` register. The `h` modifier will emit the register name for the high "
+"byte of that register and the `l` modifier will emit the register name for "
+"the low byte. The asm code will therefore be expanded as `mov ah, al` which "
+"copies the low byte of the value into the high byte."
+msgstr "Let us assume aquele o register allocator has chosen to allocate `x` in o `ax` register. O `h` modifier vai emit o register name para o high byte of aquele register e o `l` modifier vai emit o register name para o low byte. O asm code vai therefore be expanded as `mov ah, al` which copies o low byte of o valor no high byte."
+
+#: src/unsafe/asm.md:394
+msgid ""
+"If you use a smaller data type (e.g. `u16`) with an operand and forget to "
+"use template modifiers, the compiler will emit a warning and suggest the "
+"correct modifier to use."
+msgstr "If you use um smaller data tipo (e.g. `u16`) com um operand e forget to use template modifiers, o compiler vai emit um warning e suggest o correct modifier to use."
+
+#: src/unsafe/asm.md:396
+msgid "Memory address operands"
+msgstr "Memory address operands"
+
+#: src/unsafe/asm.md:398
+msgid ""
+"Sometimes assembly instructions require operands passed via memory addresses/"
+"memory locations. You have to manually use the memory address syntax "
+"specified by the target architecture. For example, on x86/x86_64 using Intel "
+"assembly syntax, you should wrap inputs/outputs in `[]` to indicate they are "
+"memory operands:"
+msgstr "Sometimes assembly instructions require operands passed via memory addresses/memory locations. You have to manually use o memory address syntax specified by o target architecture. Para example, on x86/x86_64 usando Intel assembly syntax, you deve wrap inputs/outputs in `[]` to indicate they are memory operands:"
+
+#: src/unsafe/asm.md:408
+msgid "\"fldcw [{}]\""
+msgstr "\"fldcw [{}]\""
+
+#: src/unsafe/asm.md:414
+msgid "Labels"
+msgstr "Labels"
+
+#: src/unsafe/asm.md:416
+msgid ""
+"Any reuse of a named label, local or otherwise, can result in an assembler "
+"or linker error or may cause other strange behavior. Reuse of a named label "
+"can happen in a variety of ways including:"
+msgstr "Any reuse of um named label, local ou otherwise, pode resultado in um assembler ou linker erro ou may cause other strange behavior. Reuse of um named label pode happen in um variety of ways including:"
+
+#: src/unsafe/asm.md:418
+msgid ""
+"explicitly: using a label more than once in one `asm!` block, or multiple "
+"times across blocks."
+msgstr "explicitly: usando um label more than once in one `asm!` block, ou multiple times across blocks."
+
+#: src/unsafe/asm.md:419
+msgid ""
+"implicitly via inlining: the compiler is allowed to instantiate multiple "
+"copies of an `asm!` block, for example when the function containing it is "
+"inlined in multiple places."
+msgstr "implicitly via inlining: o compiler is allowed to instantiate multiple copies of um `asm!` block, para example when a função containing it is inlined in multiple places."
+
+#: src/unsafe/asm.md:420
+msgid ""
+"implicitly via LTO: LTO can cause code from _other crates_ to be placed in "
+"the same codegen unit, and so could bring in arbitrary labels."
+msgstr "implicitly via LTO: LTO pode cause code de _other crates_ to be placed in o mesmo codegen unit, e so could bring in arbitrary labels."
+
+#: src/unsafe/asm.md:422
+msgid ""
+"As a consequence, you should only use GNU assembler **numeric** [local "
+"labels](https://sourceware.org/binutils/docs/as/Symbol-Names.html#Local-"
+"Labels) inside inline assembly code. Defining symbols in assembly code may "
+"lead to assembler and/or linker errors due to duplicate symbol definitions."
+msgstr "As um consequence, you deve only use GNU assembler **numeric** [local labels](https://sourceware.org/binutils/docs/as/Symbol-Names.html#Local-Labels) dentro inline assembly code. Defining symbols in assembly code may lead to assembler e/ou linker erros due to duplicate symbol definitions."
+
+#: src/unsafe/asm.md:424
+msgid ""
+"Moreover, on x86 when using the default Intel syntax, due to [an LLVM bug]"
+"(https://bugs.llvm.org/show_bug.cgi?id=36144), you shouldn't use labels "
+"exclusively made of `0` and `1` digits, e.g. `0`, `11` or `101010`, as they "
+"may end up being interpreted as binary values. Using `options(att_syntax)` "
+"will avoid any ambiguity, but that affects the syntax of the _entire_ `asm!` "
+"block. (See [Options](#options), below, for more on `options`.)"
+msgstr "Moreover, on x86 when usando o default Intel syntax, due to [an LLVM bug](https://bugs.llvm.org/show_bug.cgi?id=36144), you shouldn't use labels exclusively made of `0` e `1` digits, e.g. `0`, `11` ou `101010`, as they may end up being interpreted as binary valores. Usando `options(att_syntax)` vai avoid any ambiguity, but aquele affects o syntax of o _entire_ `asm!` block. (See [Options](#options), abaixo, para more on `options`.)"
+
+#: src/unsafe/asm.md:433
+msgid "\"mov {0}, 10\""
+msgstr "\"mov {0}, 10\""
+
+#: src/unsafe/asm.md:434 src/unsafe/asm.md:439
+msgid "\"2:\""
+msgstr "\"2:\""
+
+#: src/unsafe/asm.md:435
+msgid "\"sub {0}, 1\""
+msgstr "\"sub {0}, 1\""
+
+#: src/unsafe/asm.md:436
+msgid "\"cmp {0}, 3\""
+msgstr "\"cmp {0}, 3\""
+
+#: src/unsafe/asm.md:437
+msgid "\"jle 2f\""
+msgstr "\"jle 2f\""
+
+#: src/unsafe/asm.md:438
+msgid "\"jmp 2b\""
+msgstr "\"jmp 2b\""
+
+#: src/unsafe/asm.md:440
+msgid "\"add {0}, 2\""
+msgstr "\"add {0}, 2\""
+
+#: src/unsafe/asm.md:448
+msgid ""
+"This will decrement the `{0}` register value from 10 to 3, then add 2 and "
+"store it in `a`."
+msgstr "Este vai decrement o `{0}` register valor de 10 to 3, then add 2 e store it in `a`."
+
+#: src/unsafe/asm.md:450
+msgid "This example shows a few things:"
+msgstr "Este example shows um few things:"
+
+#: src/unsafe/asm.md:452
+msgid ""
+"First, that the same number can be used as a label multiple times in the "
+"same inline block."
+msgstr "Primeiro, aquele o mesmo número pode be usado as um label multiple times in o mesmo inline block."
+
+#: src/unsafe/asm.md:453
+msgid ""
+"Second, that when a numeric label is used as a reference (as an instruction "
+"operand, for example), the suffixes “b” (“backward”) or ”f” (“forward”) "
+"should be added to the numeric label. It will then refer to the nearest "
+"label defined by this number in this direction."
+msgstr "Segundo, aquele when um numeric label is usado as um reference (as um instruction operand, para example), o suffixes “b” (“backward”) ou ”f” (“forward”) deve be added to o numeric label. It vai then refer to o nearest label defined by este número in este direction."
+
+#: src/unsafe/asm.md:458
+msgid "Options"
+msgstr "Options"
+
+#: src/unsafe/asm.md:460
+msgid ""
+"By default, an inline assembly block is treated the same way as an external "
+"FFI function call with a custom calling convention: it may read/write "
+"memory, have observable side effects, etc. However, in many cases it is "
+"desirable to give the compiler more information about what the assembly code "
+"is actually doing so that it can optimize better."
+msgstr "By default, um inline assembly block is treated o mesmo way as um external FFI função call com um custom calling convention: it may read/write memory, have observable side effects, etc. However, in many cases it is desirable to give o compiler more information about what o assembly code is actually doing so aquele it pode optimize better."
+
+#: src/unsafe/asm.md:462
+msgid "Let's take our previous example of an `add` instruction:"
+msgstr "Let's take our anterior example of um `add` instruction:"
+
+#: src/unsafe/asm.md:481
+msgid ""
+"Options can be provided as an optional final argument to the `asm!` macro. "
+"We specified three options here:"
+msgstr "Options pode be provided as um optional final argumento to o `asm!` macro. We specified three options here:"
+
+#: src/unsafe/asm.md:483
+msgid ""
+"`pure` means that the asm code has no observable side effects and that its "
+"output depends only on its inputs. This allows the compiler optimizer to "
+"call the inline asm fewer times or even eliminate it entirely."
+msgstr "`pure` means aquele o asm code has no observable side effects e aquele its saída depends only on its inputs. Este allows o compiler optimizer to call o inline asm fewer times ou even eliminate it entirely."
+
+#: src/unsafe/asm.md:484
+msgid ""
+"`nomem` means that the asm code does not read or write to memory. By default "
+"the compiler will assume that inline assembly can read or write any memory "
+"address that is accessible to it (e.g. through a pointer passed as an "
+"operand, or a global)."
+msgstr "`nomem` means aquele o asm code does not read ou write to memory. By default o compiler vai assume aquele inline assembly pode read ou write any memory address aquele is accessible to it (e.g. through um pointer passed as um operand, ou um global)."
+
+#: src/unsafe/asm.md:485
+msgid ""
+"`nostack` means that the asm code does not push any data onto the stack. "
+"This allows the compiler to use optimizations such as the stack red zone on "
+"x86-64 to avoid stack pointer adjustments."
+msgstr "`nostack` means that the asm code does not push any data onto the stack. This allows the compiler to use optimizations such as the stack red zone on x86-64 to avoid stack pointer adjustments."
+
+#: src/unsafe/asm.md:487
+msgid ""
+"These allow the compiler to better optimize code using `asm!`, for example "
+"by eliminating pure `asm!` blocks whose outputs are not needed."
+msgstr "Estes allow o compiler to better optimize code usando `asm!`, para example by eliminating pure `asm!` blocks whose outputs are not needed."
+
+#: src/unsafe/asm.md:489
+msgid ""
+"See the [reference](https://doc.rust-lang.org/stable/reference/inline-"
+"assembly.html) for the full list of available options and their effects."
+msgstr "See o [reference](https://doc.rust-lang.org/stable/reference/inline-assembly.html) para o full list of available options e their effects."
+
+#: src/compatibility.md:3
+msgid ""
+"The Rust language is evolving rapidly, and because of this certain "
+"compatibility issues can arise, despite efforts to ensure forwards-"
+"compatibility wherever possible."
+msgstr "O Rust language is evolving rapidly, e porque of este certain compatibility issues pode arise, despite efforts to ensure forwards-compatibility wherever possible."
+
+#: src/compatibility.md:7
+msgid "[Raw identifiers](compatibility/raw_identifiers.md)"
+msgstr "[Raw identifiers](compatibility/raw_identifiers.md)"
+
+#: src/compatibility/raw_identifiers.md:3
+msgid ""
+"Rust, like many programming languages, has the concept of \"keywords\". "
+"These identifiers mean something to the language, and so you cannot use them "
+"in places like variable names, function names, and other places. Raw "
+"identifiers let you use keywords where they would not normally be allowed. "
+"This is particularly useful when Rust introduces new keywords, and a library "
+"using an older edition of Rust has a variable or function with the same name "
+"as a keyword introduced in a newer edition."
+msgstr "Rust, like many programming languages, has o concept of \"keywords\". Estes identifiers mean something to o language, e so you não pode use them in places like variável names, função names, e other places. Raw identifiers let you use keywords where they would not normally be allowed. Este is particularly useful when Rust introduces novo keywords, e um library usando um older edition of Rust has uma variável ou função com o mesmo name as um keyword introduced in um newer edition."
+
+#: src/compatibility/raw_identifiers.md:11
+msgid ""
+"For example, consider a crate `foo` compiled with the 2015 edition of Rust "
+"that exports a function named `try`. This keyword is reserved for a new "
+"feature in the 2018 edition, so without raw identifiers, we would have no "
+"way to name the function."
+msgstr "Para example, consider um crate `foo` compiled com o 2015 edition of Rust aquele exports um função named `try`. Este keyword is reserved para um novo feature in o 2018 edition, so sem raw identifiers, we would have no way to name a função."
+
+#: src/compatibility/raw_identifiers.md:24
+msgid "You'll get this error:"
+msgstr "You'll get este erro:"
+
+#: src/compatibility/raw_identifiers.md:34
+msgid "You can write this with a raw identifier:"
+msgstr "You pode write este com um raw identifier:"
+
+#: src/meta.md:3
+msgid ""
+"Some topics aren't exactly relevant to how you program runs but provide you "
+"tooling or infrastructure support which just makes things better for "
+"everyone. These topics include:"
+msgstr "Some topics aren't exactly relevant to how you program runs but provide you tooling ou infrastructure support which just makes things better para everyone. Estes topics include:"
+
+#: src/meta.md:7
+msgid ""
+"[Documentation](meta/doc.md): Generate library documentation for users via "
+"the included `rustdoc`."
+msgstr "[Documentation](meta/doc.md): Generate library documentation para users via o included `rustdoc`."
+
+#: src/meta.md:9
+msgid ""
+"[Playground](meta/playground.md): Integrate the Rust Playground in your "
+"documentation."
+msgstr "[Playground](meta/playground.md): Integrate o Rust Playground in your documentation."
+
+#: src/meta/doc.md:3
+msgid ""
+"Use `cargo doc` to build documentation in `target/doc`, `cargo doc --open` "
+"will automatically open it in your web browser."
+msgstr "Usa `cargo doc` to build documentation in `target/doc`, `cargo doc --open` vai automatically open it in your web browser."
+
+#: src/meta/doc.md:6
+msgid ""
+"Use `cargo test` to run all tests (including documentation tests), and "
+"`cargo test --doc` to only run documentation tests."
+msgstr "Usa `cargo test` to run all tests (including documentation tests), e `cargo test --doc` to only run documentation tests."
+
+#: src/meta/doc.md:9
+msgid ""
+"These commands will appropriately invoke `rustdoc` (and `rustc`) as required."
+msgstr "Estes commands vai appropriately invoke `rustdoc` (e `rustc`) as required."
+
+#: src/meta/doc.md:11
+msgid "Doc comments"
+msgstr "Doc comments"
+
+#: src/meta/doc.md:13
+msgid ""
+"Doc comments are very useful for big projects that require documentation. "
+"When running `rustdoc`, these are the comments that get compiled into "
+"documentation. They are denoted by a `///`, and support [Markdown](https://"
+"en.wikipedia.org/wiki/Markdown)."
+msgstr "Doc comments are very useful para big projects aquele require documentation. When running `rustdoc`, estes are o comments aquele get compiled em documentation. They are denoted by um `///`, e support [Markdown](https://en.wikipedia.org/wiki/Markdown)."
+
+#: src/meta/doc.md:18
+msgid "\"doc\""
+msgstr "\"doc\""
+
+#: src/meta/doc.md:19
+msgid "/// A human being is represented here\n"
+msgstr ""
+"/// UM human being is represented here\n"
+
+#: src/meta/doc.md:22
+msgid "/// A person must have a name, no matter how much Juliet may hate it\n"
+msgstr ""
+"/// UM person deve have um name, no matter how much Juliet may hate it\n"
+
+#: src/meta/doc.md:27
+msgid ""
+"/// Creates a person with the given name.\n"
+"    ///\n"
+"    /// # Examples\n"
+"    ///\n"
+"    /// ```\n"
+"    /// // You can have rust code between fences inside the comments\n"
+"    /// // If you pass --test to `rustdoc`, it will even test it for you!\n"
+"    /// use doc::Person;\n"
+"    /// let person = Person::new(\"name\");\n"
+"    /// ```\n"
+msgstr ""
+"/// Crias um person com o given name.\n"
+"    ///\n"
+"    /// # Exemplos\n"
+"    ///\n"
+"    /// ```\n"
+"    /// // You can have rust code between fences inside the comments\n"
+"    /// // If you pass --test to `rustdoc`, it will even test it for you!\n"
+"    /// use doc::Person;\n"
+"    /// let person = Person::new(\"name\");\n"
+"    /// ```\n"
+
+#: src/meta/doc.md:43
+msgid ""
+"/// Gives a friendly hello!\n"
+"    ///\n"
+"    /// Says \"Hello, [name](Person::name)\" to the `Person` it is called "
+"on.\n"
+msgstr ""
+"/// Gives um friendly hello!\n"
+"    ///\n"
+"    /// Says \"Hello, [name](Person::name)\" to o `Person` it is chamado on.\n"
+
+#: src/meta/doc.md:47
+msgid "\"Hello, {}!\""
+msgstr "\"Hello, {}!\""
+
+#: src/meta/doc.md:52
+msgid "\"John\""
+msgstr "\"John\""
+
+#: src/meta/doc.md:58
+msgid ""
+"To run the tests, first build the code as a library, then tell `rustdoc` "
+"where to find the library so it can link it into each doctest program:"
+msgstr "To run o tests, primeiro build o code as um library, then tell `rustdoc` where to find o library so it pode link it em each doctest program:"
+
+#: src/meta/doc.md:61
+msgid ""
+"```shell\n"
+"$ rustc doc.rs --crate-type lib\n"
+"$ rustdoc --test --extern doc=\"libdoc.rlib\" doc.rs\n"
+"```"
+msgstr ""
+"```shell\n"
+"$ rustc doc.rs --crate-type lib\n"
+"$ rustdoc --test --extern doc=\"libdoc.rlib\" doc.rs\n"
+"```"
+
+#: src/meta/doc.md:66
+msgid "Doc attributes"
+msgstr "Doc attributes"
+
+#: src/meta/doc.md:68
+msgid ""
+"Below are a few examples of the most common `#[doc]` attributes used with "
+"`rustdoc`."
+msgstr "Abaixo are um few examples of o most common `#[doc]` attributes usado com `rustdoc`."
+
+#: src/meta/doc.md:71
+msgid "`inline`"
+msgstr "`inline`"
+
+#: src/meta/doc.md:73
+msgid "Used to inline docs, instead of linking out to separate page."
+msgstr "Usad to inline docs, instead of linking out to separate page."
+
+#: src/meta/doc.md:78
+msgid "/// bar docs\n"
+msgstr ""
+"/// bar docs\n"
+
+#: src/meta/doc.md:81
+msgid "/// the docs for Bar\n"
+msgstr ""
+"/// o docs para Bar\n"
+
+#: src/meta/doc.md:86
+msgid "`no_inline`"
+msgstr "`no_inline`"
+
+#: src/meta/doc.md:88
+msgid "Used to prevent linking out to separate page or anywhere."
+msgstr "Usad to prevent linking out to separate page ou anywhere."
+
+#: src/meta/doc.md:91
+msgid "// Example from libcore/prelude\n"
+msgstr ""
+"// Exemplos de libcore/prelude\n"
+
+#: src/meta/doc.md:96
+msgid "`hidden`"
+msgstr "`hidden`"
+
+#: src/meta/doc.md:98
+msgid "Using this tells `rustdoc` not to include this in documentation:"
+msgstr "Usando este tells `rustdoc` not to include este in documentation:"
+
+#: src/meta/doc.md:101
+msgid "// Example from the futures-rs library\n"
+msgstr ""
+"// Exemplos do futures-rs library\n"
+
+#: src/meta/doc.md:106
+msgid ""
+"For documentation, `rustdoc` is widely used by the community. It's what is "
+"used to generate the [std library docs](https://doc.rust-lang.org/std/)."
+msgstr "Para documentation, `rustdoc` is widely usado by o community. It's what is usado to generate o [std library docs](https://doc.rust-lang.org/std/)."
+
+#: src/meta/doc.md:111
+msgid ""
+"[The Rust Book: Making Useful Documentation Comments](https://doc.rust-lang."
+"org/book/ch14-02-publishing-to-crates-io.html#making-useful-documentation-"
+"comments)"
+msgstr "[The Rust Book: Making Useful Documentation Comments](https://doc.rust-lang.org/book/ch14-02-publishing-to-crates-io.html#making-useful-documentation-comments)"
+
+#: src/meta/doc.md:112
+msgid "[The rustdoc Book](https://doc.rust-lang.org/rustdoc/index.html)"
+msgstr "[The rustdoc Book](https://doc.rust-lang.org/rustdoc/index.html)"
+
+#: src/meta/doc.md:113
+msgid ""
+"[The Reference: Doc comments](https://doc.rust-lang.org/stable/reference/"
+"comments.html#doc-comments)"
+msgstr "[The Reference: Doc comments](https://doc.rust-lang.org/stable/reference/comments.html#doc-comments)"
+
+#: src/meta/doc.md:114
+msgid ""
+"[RFC 1574: API Documentation Conventions](https://rust-lang.github.io/"
+"rfcs/1574-more-api-documentation-conventions.html#appendix-a-full-"
+"conventions-text)"
+msgstr "[RFC 1574: API Documentation Conventions](https://rust-lang.github.io/rfcs/1574-more-api-documentation-conventions.html#appendix-a-full-conventions-text)"
+
+#: src/meta/doc.md:115
+msgid ""
+"[RFC 1946: Relative links to other items from doc comments (intra-rustdoc "
+"links)](https://rust-lang.github.io/rfcs/1946-intra-rustdoc-links.html)"
+msgstr "[RFC 1946: Relative links to other items from doc comments (intra-rustdoc links)](https://rust-lang.github.io/rfcs/1946-intra-rustdoc-links.html)"
+
+#: src/meta/doc.md:116
+msgid ""
+"[Is there any documentation style guide for comments? (reddit)](https://www."
+"reddit.com/r/rust/comments/ahb50s/"
+"is_there_any_documentation_style_guide_for/)"
+msgstr "[Is there any documentation style guide for comments? (reddit)](https://www.reddit.com/r/rust/comments/ahb50s/is_there_any_documentation_style_guide_for/)"
+
+#: src/meta/playground.md:3
+msgid ""
+"The [Rust Playground](https://play.rust-lang.org/) is a way to experiment "
+"with Rust code through a web interface."
+msgstr "O [Rust Playground](https://play.rust-lang.org/) is um way to experiment com Rust code through um web interface."
+
+#: src/meta/playground.md:6
+msgid "Using it with `mdbook`"
+msgstr "Usando it com `mdbook`"
+
+#: src/meta/playground.md:8
+msgid ""
+"In [`mdbook`](https://github.com/rust-lang/mdBook), you can make code "
+"examples playable and editable."
+msgstr "In [`mdbook`](https://github.com/rust-lang/mdBook), you pode make code examples playable e editable."
+
+#: src/meta/playground.md:16
+msgid ""
+"This allows the reader to both run your code sample, but also modify and "
+"tweak it. The key here is the adding of the word `editable` to your "
+"codefence block separated by a comma."
+msgstr "Este allows o reader to both run your code sample, but also modify e tweak it. O key here is o adding of o word `editable` to your codefence block separated by um comma."
+
+#: src/meta/playground.md:26
+msgid ""
+"Additionally, you can add `ignore` if you want `mdbook` to skip your code "
+"when it builds and tests."
+msgstr "Adicionaitionally, you pode add `ignore` if you want `mdbook` to skip your code when it builds e tests."
+
+#: src/meta/playground.md:35
+msgid "Using it with docs"
+msgstr "Usando it com docs"
+
+#: src/meta/playground.md:37
+msgid ""
+"You may have noticed in some of the [official Rust docs](https://doc.rust-"
+"lang.org/core/) a button that says \"Run\", which opens the code sample up "
+"in a new tab in Rust Playground. This feature is enabled if you use the "
+"`#[doc]` attribute called [`html_playground_url`](https://doc.rust-lang.org/"
+"rustdoc/write-documentation/the-doc-attribute.html#html_playground_url)."
+msgstr "You may have noticed in some of o [official Rust docs](https://doc.rust-lang.org/core/) um button aquele says \"Run\", which opens o code sample up in um novo tab in Rust Playground. Este feature is enabled if you use o `#[doc]` attribute chamado [`html_playground_url`](https://doc.rust-lang.org/rustdoc/write-documentation/the-doc-attribute.html#html_playground_url)."
+
+#: src/meta/playground.md:42
+msgid ""
+"````text\n"
+"#![doc(html_playground_url = \"https://play.rust-lang.org/\")]\n"
+"//! ```\n"
+"//! println!(\"Hello World\");\n"
+"//! ```\n"
+"````"
+msgstr ""
+"````text\n"
+"#![doc(html_playground_url = \"https://play.rust-lang.org/\")]\n"
+"//! ```\n"
+"//! println!(\"Hello World\");\n"
+"//! ```\n"
+"````"
+
+#: src/meta/playground.md:51
+msgid "[The Rust Playground](https://play.rust-lang.org/)"
+msgstr "[The Rust Playground](https://play.rust-lang.org/)"
+
+#: src/meta/playground.md:52
+msgid ""
+"[The Rust Playground On Github](https://github.com/integer32llc/rust-"
+"playground/)"
+msgstr "[The Rust Playground On Github](https://github.com/integer32llc/rust-playground/)"
+
+#: src/meta/playground.md:53
+msgid ""
+"[The rustdoc Book](https://doc.rust-lang.org/rustdoc/what-is-rustdoc.html)"
+msgstr "[The rustdoc Book](https://doc.rust-lang.org/rustdoc/what-is-rustdoc.html)"


### PR DESCRIPTION
This pull request adds a new translation guide for Brazilian Portuguese contributors, providing clear instructions on how to translate Rust by Example using the `mdbook-i18n-helpers` workflow. The guide covers tool installation, translation file management, and how to add new language entries in related configuration files.

**New translation workflow documentation:**

* Added a comprehensive `TRANSLATING_PT.md` file outlining the translation process for Rust by Example, including tool requirements, step-by-step commands for creating and updating translations, and instructions for tracking translation progress.
* Provided guidance on editing translation resources and compiling the translated book using the appropriate environment variables and commands.

**Integration with project configuration:**

* Included detailed instructions for adding new language entries to `.github/workflows/rbe.yml`, `theme/head.hbs`, and `src/bootstrap/src/core/build_steps/doc.rs` to ensure proper integration of new translations into the build and deployment process.