### PR TITLE
Add a page on the Default trait

### DIFF
--- a/src/SUMMARY.md
+++ b/src/SUMMARY.md
@@ -136,6 +136,7 @@
 
 - [Traits](trait.md)
     - [Derive](trait/derive.md)
+    - [Default](trait/default.md)
     - [Returning Traits with `dyn`](trait/dyn.md)
     - [Operator Overloading](trait/ops.md)
     - [Drop](trait/drop.md)

--- a/src/trait/default.md
+++ b/src/trait/default.md
@@ -1,0 +1,66 @@
+# Default
+
+The [`Default`][default] trait provides a useful default value for a type. Many
+types in the standard library implement it, and it can be derived for your own
+types with `#[derive(Default)]`, which gives every field its own default.
+
+```rust,editable
+#[derive(Default, Debug)]
+struct MyConfig {
+    name: String,
+    count: u32,
+    verbose: bool,
+}
+
+fn main() {
+    // `Default::default()` builds a value with every field defaulted.
+    let config = MyConfig::default();
+    println!("{config:?}");
+
+    // The struct update syntax takes the remaining fields from
+    // `Default::default()`, so you only set the ones you care about.
+    let custom = MyConfig {
+        name: "app".to_string(),
+        ..Default::default()
+    };
+    println!("{custom:?}");
+}
+```
+
+You can also implement `Default` by hand when the default you want is not just
+the field-by-field default:
+
+```rust,editable
+struct Port(u16);
+
+impl Default for Port {
+    fn default() -> Self {
+        Port(8080)
+    }
+}
+
+fn main() {
+    let Port(port) = Port::default();
+    println!("default port: {port}");
+}
+```
+
+### When to use it
+
+`Default` is a good fit when a type has an obvious "empty" or "zero" value. It
+also works with APIs that rely on it, such as the struct update syntax above or
+[`Option::unwrap_or_default`][unwrap-or-default].
+
+Prefer a regular constructor (for example an associated `new` function) when a
+type has no meaningful default, or when building a value needs arguments or can
+fail. Implementing `Default` in those cases forces an arbitrary value, which can
+hide bugs.
+
+### See also
+
+[`derive`][derive] and [`Option`][option].
+
+[default]: https://doc.rust-lang.org/std/default/trait.Default.html
+[derive]: derive.md
+[option]: https://doc.rust-lang.org/std/option/enum.Option.html
+[unwrap-or-default]: https://doc.rust-lang.org/std/option/enum.Option.html#method.unwrap_or_default


### PR DESCRIPTION
`Default` was only mentioned in passing (e.g. in the Derive page), so this adds a dedicated page for it under *Traits*.

The page covers:

- deriving `Default` with `#[derive(Default)]`
- implementing it by hand for a custom default value
- the struct update syntax (`..Default::default()`)
- a short note on when to use `Default` and when a constructor is a better fit

Both examples are `rust,editable` and self-contained. Also adds the page to `SUMMARY.md`.

Closes #1256
