### PR TITLE
Update println formatting for tuple struct examples

### DIFF
--- a/src/custom_types/structs.md
+++ b/src/custom_types/structs.md
@@ -77,12 +77,12 @@ fn main() {
     let pair = Pair(1, 0.1);
 
     // Access the fields of a tuple struct
-    println!("pair contains {:?} and {:?}", pair.0, pair.1);
+    println!("pair contains {} and {}", pair.0, pair.1);
 
     // Destructure a tuple struct
     let Pair(integer, decimal) = pair;
 
-    println!("pair contains {:?} and {:?}", integer, decimal);
+    println!("pair contains {} and {}", integer, decimal);
 }
 ```
 


### PR DESCRIPTION
Remove unnecessary debug trait formatter to avoid confusion by learners